### PR TITLE
Allow for base dir specification of where shmem and persistence is saved

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ rust-version = "1.91.0"
 version = "0.1.0"
 
 [workspace.dependencies]
-flux = { path = "crates/flux", version = "0.0.35" }
-flux-communication = { path = "crates/flux-communication", version = "0.0.25" }
+flux = { path = "crates/flux", version = "0.0.36" }
+flux-communication = { path = "crates/flux-communication", version = "0.0.26" }
 flux-timing = { path = "crates/flux-timing", version = "0.0.14" }
 flux-utils = { path = "crates/flux-utils", version = "0.0.22" }
 flux-network = { path = "crates/flux-network", version = "0.0.7" }

--- a/crates/flux-communication/Cargo.toml
+++ b/crates/flux-communication/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flux-communication"
-version = "0.0.25"
+version = "0.0.26"
 edition.workspace = true
 rust-version.workspace = true
 license = "Apache-2.0 AND MIT"

--- a/crates/flux-communication/src/lib.rs
+++ b/crates/flux-communication/src/lib.rs
@@ -9,7 +9,10 @@ use std::path::Path;
 
 pub use array::SeqlockArray;
 pub use error::{EmptyError, QueueError, ReadError};
-use flux_utils::{directories::{local_share_dir, shmem_dir_queues, shmem_dir_queues_with_base}, short_typename};
+use flux_utils::{
+    directories::{local_share_dir, shmem_dir_queues, shmem_dir_queues_with_base},
+    short_typename,
+};
 pub use seqlock::Seqlock;
 pub use shmem_data::ShmemData;
 pub use timer::{Timer, TimingMessage};

--- a/crates/flux-communication/src/lib.rs
+++ b/crates/flux-communication/src/lib.rs
@@ -5,26 +5,37 @@ mod seqlock;
 mod shmem_data;
 pub mod timer;
 
+use std::path::Path;
+
 pub use array::SeqlockArray;
 pub use error::{EmptyError, QueueError, ReadError};
-use flux_utils::{directories::shmem_dir_queues, short_typename};
+use flux_utils::{directories::{local_share_dir, shmem_dir_queues, shmem_dir_queues_with_base}, short_typename};
 pub use seqlock::Seqlock;
 pub use shmem_data::ShmemData;
 pub use timer::{Timer, TimingMessage};
 
-pub fn shmem_dir_queues_string<S: AsRef<str>>(app_name: S) -> String {
+pub fn shmem_dir_queues_string<S: AsRef<Path>>(app_name: S) -> String {
     let queues_dir = shmem_dir_queues(app_name);
     queues_dir.to_string_lossy().to_string()
 }
 
-pub fn shmem_queue<S: AsRef<str>, T: Copy>(
+pub fn shmem_queue<S: AsRef<Path>, T: Copy>(
+    app_name: S,
+    len: usize,
+    typ: queue::QueueType,
+) -> queue::Queue<T> {
+    shmem_queue_with_base_dir(local_share_dir(), app_name, len, typ)
+}
+
+pub fn shmem_queue_with_base_dir<D: AsRef<Path>, S: AsRef<Path>, T: Copy>(
+    base_dir: D,
     app_name: S,
     len: usize,
     typ: queue::QueueType,
 ) -> queue::Queue<T> {
     let queue_name = short_typename::<T>();
     queue::Queue::create_or_open_shared(
-        shmem_dir_queues(app_name).join(queue_name.as_str()),
+        shmem_dir_queues_with_base(base_dir, app_name).join(queue_name.as_str()),
         len,
         typ,
     )

--- a/crates/flux-communication/src/shmem_data.rs
+++ b/crates/flux-communication/src/shmem_data.rs
@@ -1,10 +1,8 @@
 use std::{
-    borrow::Borrow,
-    ops::{Deref, DerefMut},
-    ptr::NonNull,
+    borrow::Borrow, ops::{Deref, DerefMut}, path::Path, ptr::NonNull
 };
 
-use flux_utils::{directories::shmem_dir_data, short_typename};
+use flux_utils::{directories::{local_share_dir, shmem_dir_data_with_base}, short_typename};
 use shared_memory::{Shmem, ShmemError};
 
 #[repr(C)]
@@ -23,8 +21,12 @@ impl<T> ShmemData<T> {
         app_name: &str,
         init_f: impl FnOnce() -> T,
     ) -> Result<ShmemData<T>, ShmemError> {
+        Self::open_or_init_with_base_dir(local_share_dir(), app_name, init_f)
+    }
+
+    pub fn open_or_init_with_base_dir<D: AsRef<Path>, A: AsRef<Path>>(dir: D, app_name: A, init_f: impl FnOnce()->T)-> Result<ShmemData<T>, ShmemError> {
         use shared_memory::{ShmemConf, ShmemError};
-        let shmem_file = shmem_dir_data(app_name).join(short_typename::<T>().as_str());
+        let shmem_file = shmem_dir_data_with_base(&dir, &app_name).join(short_typename::<T>().as_str());
         std::fs::create_dir_all(
             shmem_file
                 .parent()
@@ -42,9 +44,15 @@ impl<T> ShmemData<T> {
                 Ok(Self { inner })
             }
             Err(ShmemError::LinkExists) => {
-                let shmem = ShmemConf::new().flink(&shmem_file).open().unwrap_or_else(|_| {
-                    panic!("couldn't open shmem file {}", shmem_file.display())
-                });
+
+                let Ok(shmem) = ShmemConf::new().flink(&shmem_file).open() else {
+                    if shmem_file.exists() {
+                       tracing::warn!("couldn't open shmem file {}, recreating and retrying", shmem_file.display());
+                       std::fs::remove_file(shmem_file).expect("couldn't remove shmem file for TileInfo");
+                       return Self::open_or_init_with_base_dir(dir, app_name, init_f);
+                    }
+                    panic!("couldn't open shmem file {}", shmem_file.display());
+                };
 
                 let inner = Self::shmem_ptr(shmem);
 
@@ -52,6 +60,7 @@ impl<T> ShmemData<T> {
             }
             Err(e) => Err(e),
         }
+        
     }
 
     fn shmem_ptr(shmem: Shmem) -> NonNull<T> {

--- a/crates/flux-communication/src/timer.rs
+++ b/crates/flux-communication/src/timer.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt::Display, sync::Mutex};
+use std::{collections::HashMap, fmt::Display, path::Path, sync::Mutex};
 
 use flux_timing::{Duration, Instant, InternalMessage, Nanos};
 use once_cell::sync::Lazy;
@@ -60,7 +60,7 @@ pub struct Timer {
 }
 
 impl Timer {
-    pub fn new<A: AsRef<str>, S: Display>(app_name: A, name: S) -> Self {
+    pub fn new<A: AsRef<Path>, S: Display>(app_name: A, name: S) -> Self {
         let dirstr = shmem_dir_queues_string(&app_name);
         let _ = std::fs::create_dir_all(&dirstr);
 

--- a/crates/flux-communication/src/timer.rs
+++ b/crates/flux-communication/src/timer.rs
@@ -1,12 +1,10 @@
 use std::{collections::HashMap, fmt::Display, path::Path, sync::Mutex};
 
 use flux_timing::{Duration, Instant, InternalMessage, Nanos};
+use flux_utils::directories::{local_share_dir, shmem_dir_queues_with_base};
 use once_cell::sync::Lazy;
 
-use crate::{
-    queue::{Producer, Queue, QueueType},
-    shmem_dir_queues_string,
-};
+use crate::queue::{Producer, Queue, QueueType};
 
 /// A single timing interval measured on one machine.
 ///
@@ -61,7 +59,15 @@ pub struct Timer {
 
 impl Timer {
     pub fn new<A: AsRef<Path>, S: Display>(app_name: A, name: S) -> Self {
-        let dirstr = shmem_dir_queues_string(&app_name);
+        Self::new_with_base_dir(local_share_dir(), app_name, name)
+    }
+
+    pub fn new_with_base_dir<D: AsRef<Path>, A: AsRef<Path>, S: Display>(
+        base_dir: D,
+        app_name: A,
+        name: S,
+    ) -> Self {
+        let dirstr = shmem_dir_queues_with_base(base_dir, app_name).to_string_lossy().to_string();
         let _ = std::fs::create_dir_all(&dirstr);
 
         let file = format!("{dirstr}/timing-{name}");

--- a/crates/flux-timing/src/tracking_timestamp.rs
+++ b/crates/flux-timing/src/tracking_timestamp.rs
@@ -18,8 +18,8 @@ impl TrackingTimestamp {
         Self { ingestion_t: IngestionTime::now(), publish_delta: PublishDelta::new(id) }
     }
 
-    /// Note: this should not really be needed if Tiles are used properly throughout the system.
-    /// It's purely here due to legacy reasons. 
+    /// Note: this should not really be needed if Tiles are used properly
+    /// throughout the system. It's purely here due to legacy reasons.
     #[inline]
     pub fn new_without_tile() -> Self {
         Self { ingestion_t: IngestionTime::now(), publish_delta: PublishDelta::new(u16::MAX) }

--- a/crates/flux-utils/src/directories.rs
+++ b/crates/flux-utils/src/directories.rs
@@ -1,32 +1,52 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use directories::BaseDirs;
 use tracing::warn;
 
-pub fn local_share_dir<S: AsRef<str>>(app_name: S) -> PathBuf {
+pub fn local_share_dir() -> PathBuf {
     let Some(base_dirs) = BaseDirs::new() else {
         warn!("couldn't find basedirs, storing data in /tmp/<app_name>");
-        return PathBuf::from(format!("/tmp/{}", app_name.as_ref()));
+        return PathBuf::from("/tmp");
     };
-    base_dirs.data_dir().join(app_name.as_ref())
+    base_dirs.data_dir().to_path_buf()
 }
 
-pub fn data_dir<S: AsRef<str>>(app_name: S) -> PathBuf {
-    local_share_dir(app_name).join("data")
+pub fn data_dir<S: AsRef<Path>>(app_name: S) -> PathBuf {
+    data_dir_with_base(local_share_dir(),app_name)
 }
 
-pub fn shmem_dir<S: AsRef<str>>(app_name: S) -> PathBuf {
-    local_share_dir(app_name).join("shmem")
+pub fn shmem_dir<S: AsRef<Path>>(app_name: S) -> PathBuf {
+    shmem_dir_with_base(local_share_dir(), app_name)
 }
 
-pub fn logs_dir<S: AsRef<str>>(app_name: S) -> PathBuf {
-    local_share_dir(app_name).join("logs")
+pub fn logs_dir<S: AsRef<Path>>(app_name: S) -> PathBuf {
+    logs_dir_with_base(local_share_dir(), app_name)
 }
 
-pub fn shmem_dir_queues<S: AsRef<str>>(app_name: S) -> PathBuf {
+pub fn shmem_dir_queues<S: AsRef<Path>>(app_name: S) -> PathBuf {
     shmem_dir(app_name).join("queues")
 }
 
-pub fn shmem_dir_data<S: AsRef<str>>(app_name: S) -> PathBuf {
+pub fn shmem_dir_data<S: AsRef<Path>>(app_name: S) -> PathBuf {
     shmem_dir(app_name).join("data")
+}
+
+pub fn data_dir_with_base<D: AsRef<Path>, S: AsRef<Path>>(base_dir: D, app_name: S) -> PathBuf {
+    base_dir.as_ref().join(app_name.as_ref()).join("data")
+}
+
+pub fn shmem_dir_with_base<D: AsRef<Path>, S: AsRef<Path>>(base_dir: D, app_name: S) -> PathBuf {
+    base_dir.as_ref().join(app_name.as_ref()).join("shmem")
+}
+
+pub fn logs_dir_with_base<D: AsRef<Path>, S: AsRef<Path>>(base_dir: D, app_name: S) -> PathBuf {
+    base_dir.as_ref().join(app_name.as_ref()).join("logs")
+}
+
+pub fn shmem_dir_queues_with_base<D: AsRef<Path>, S: AsRef<Path>>(base_dir: D, app_name: S) -> PathBuf {
+    shmem_dir_with_base(base_dir, app_name).join("queues")
+}
+
+pub fn shmem_dir_data_with_base<D: AsRef<Path>, S: AsRef<Path>>(base_dir: D, app_name: S) -> PathBuf {
+    shmem_dir_with_base(base_dir, app_name).join("data")
 }

--- a/crates/flux-utils/src/directories.rs
+++ b/crates/flux-utils/src/directories.rs
@@ -12,7 +12,7 @@ pub fn local_share_dir() -> PathBuf {
 }
 
 pub fn data_dir<S: AsRef<Path>>(app_name: S) -> PathBuf {
-    data_dir_with_base(local_share_dir(),app_name)
+    data_dir_with_base(local_share_dir(), app_name)
 }
 
 pub fn shmem_dir<S: AsRef<Path>>(app_name: S) -> PathBuf {
@@ -43,10 +43,16 @@ pub fn logs_dir_with_base<D: AsRef<Path>, S: AsRef<Path>>(base_dir: D, app_name:
     base_dir.as_ref().join(app_name.as_ref()).join("logs")
 }
 
-pub fn shmem_dir_queues_with_base<D: AsRef<Path>, S: AsRef<Path>>(base_dir: D, app_name: S) -> PathBuf {
+pub fn shmem_dir_queues_with_base<D: AsRef<Path>, S: AsRef<Path>>(
+    base_dir: D,
+    app_name: S,
+) -> PathBuf {
     shmem_dir_with_base(base_dir, app_name).join("queues")
 }
 
-pub fn shmem_dir_data_with_base<D: AsRef<Path>, S: AsRef<Path>>(base_dir: D, app_name: S) -> PathBuf {
+pub fn shmem_dir_data_with_base<D: AsRef<Path>, S: AsRef<Path>>(
+    base_dir: D,
+    app_name: S,
+) -> PathBuf {
     shmem_dir_with_base(base_dir, app_name).join("data")
 }

--- a/crates/flux/Cargo.toml
+++ b/crates/flux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flux"
-version = "0.0.35"
+version = "0.0.36"
 edition.workspace = true
 rust-version.workspace = true
 license = "Apache-2.0 AND MIT"

--- a/crates/flux/src/persistence/persistable.rs
+++ b/crates/flux/src/persistence/persistable.rs
@@ -20,7 +20,10 @@ pub trait Persistable: for<'a> serde::Deserialize<'a> + serde::Serialize {
         Self::persist_dir_with_base_dir(local_share_dir(), app_name)
     }
 
-    fn persist_dir_with_base_dir<D: AsRef<Path>, S: AsRef<Path>>(base_dir: D, app_name: S) -> PathBuf {
+    fn persist_dir_with_base_dir<D: AsRef<Path>, S: AsRef<Path>>(
+        base_dir: D,
+        app_name: S,
+    ) -> PathBuf {
         data_dir_with_base(base_dir, app_name).join(Self::PERSIST_DIR)
     }
 
@@ -61,8 +64,16 @@ pub trait Persistable: for<'a> serde::Deserialize<'a> + serde::Serialize {
         read(Self::persist_dir(app_name).join(filename.as_ref()).with_added_extension("bin"))
     }
 
-    fn load_with_base_dir<D: AsRef<Path>, S: AsRef<Path>, P: AsRef<Path>>(base_dir: D, app_name: S, filename: P) -> Option<Vec<Self>> {
-        read(Self::persist_dir_with_base_dir(base_dir, app_name).join(filename.as_ref()).with_added_extension("bin"))
+    fn load_with_base_dir<D: AsRef<Path>, S: AsRef<Path>, P: AsRef<Path>>(
+        base_dir: D,
+        app_name: S,
+        filename: P,
+    ) -> Option<Vec<Self>> {
+        read(
+            Self::persist_dir_with_base_dir(base_dir, app_name)
+                .join(filename.as_ref())
+                .with_added_extension("bin"),
+        )
     }
 
     fn load_all<S: AsRef<Path>>(app_name: S) -> Option<Vec<Self>> {

--- a/crates/flux/src/persistence/persisting_tile.rs
+++ b/crates/flux/src/persistence/persisting_tile.rs
@@ -1,4 +1,7 @@
+use std::path::{Path, PathBuf};
+
 use flux_timing::{InternalMessage, Nanos};
+use flux_utils::directories::local_share_dir;
 
 use crate::{
     persistence::Persistable,
@@ -12,18 +15,23 @@ pub const TIMESTAMP_FORMAT_UTC: &str = "%Y-%m-%d_%H:%M_utc";
 pub struct PersistingQueueTile<T: Persistable> {
     pending_data: Vec<InternalMessage<T>>,
     last_persist_time: Nanos,
+    base_dir: PathBuf
 }
 
 impl<T: Persistable> PersistingQueueTile<T> {
     pub fn new() -> Self {
-        Self { pending_data: Vec::new(), last_persist_time: Nanos::now() }
+        Self::new_with_base_dir(local_share_dir())
+    }
+    pub fn new_with_base_dir<D: AsRef<Path>>(base_dir: D) -> Self {
+        Self { pending_data: Vec::new(), last_persist_time: Nanos::now(), base_dir: base_dir.as_ref().to_path_buf() }
     }
 
     fn handle_persisting(&mut self, now: Nanos, app_name: &'static str) {
         if !self.pending_data.is_empty() {
             let current_minute =
                 self.pending_data[0].publish_t().round_to_interval(PERSIST_INTERVAL);
-            InternalMessage::<T>::persist(
+            InternalMessage::<T>::persist_in_base_dir(
+                &self.base_dir,
                 app_name,
                 &self.pending_data,
                 Some(9),

--- a/crates/flux/src/persistence/persisting_tile.rs
+++ b/crates/flux/src/persistence/persisting_tile.rs
@@ -15,7 +15,7 @@ pub const TIMESTAMP_FORMAT_UTC: &str = "%Y-%m-%d_%H:%M_utc";
 pub struct PersistingQueueTile<T: Persistable> {
     pending_data: Vec<InternalMessage<T>>,
     last_persist_time: Nanos,
-    base_dir: PathBuf
+    base_dir: PathBuf,
 }
 
 impl<T: Persistable> PersistingQueueTile<T> {
@@ -23,7 +23,11 @@ impl<T: Persistable> PersistingQueueTile<T> {
         Self::new_with_base_dir(local_share_dir())
     }
     pub fn new_with_base_dir<D: AsRef<Path>>(base_dir: D) -> Self {
-        Self { pending_data: Vec::new(), last_persist_time: Nanos::now(), base_dir: base_dir.as_ref().to_path_buf() }
+        Self {
+            pending_data: Vec::new(),
+            last_persist_time: Nanos::now(),
+            base_dir: base_dir.as_ref().to_path_buf(),
+        }
     }
 
     fn handle_persisting(&mut self, now: Nanos, app_name: &'static str) {

--- a/crates/flux/src/spine/consumer.rs
+++ b/crates/flux/src/spine/consumer.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{ops::Deref, path::Path};
 
 use flux_timing::InternalMessage;
 use flux_utils::short_typename;
@@ -186,12 +186,13 @@ impl<T: 'static + Copy> SpineConsumer<T> {
 
 impl<T: 'static + Copy> SpineConsumer<T> {
     #[inline]
-    pub fn attach<S, Tl>(tile: &Tl, queue: SpineQueue<T>) -> Self
+    pub fn attach<D, S, Tl>(base_dir: D, tile: &Tl, queue: SpineQueue<T>) -> Self
     where
+        D: AsRef<Path>,
         S: FluxSpine,
         Tl: Tile<S>,
     {
-        let timer = Timer::new(S::app_name(), format!("{}-{}", tile.name(), short_typename::<T>()));
+        let timer = Timer::new_with_base_dir(base_dir, S::app_name(), format!("{}-{}", tile.name(), short_typename::<T>()));
         Self { timer, inner: queue::Consumer::from(queue) }
     }
 }

--- a/crates/flux/src/spine/mod.rs
+++ b/crates/flux/src/spine/mod.rs
@@ -2,6 +2,8 @@ mod adapter;
 mod consumer;
 mod scoped;
 
+use std::path::Path;
+
 pub use adapter::SpineAdapter;
 pub use consumer::SpineConsumer;
 use flux_timing::{IngestionTime, InternalMessage, TrackingTimestamp};
@@ -50,6 +52,7 @@ pub trait FluxSpine: Sized + Send {
 
     fn attach_consumers<Tl: Tile<Self>>(&mut self, tile: &Tl) -> Self::Consumers;
     fn attach_producers<Tl: Tile<Self>>(&mut self, tile: &Tl) -> Self::Producers;
+    fn new_in_base_dir(base_dir: impl AsRef<Path>) -> Self;
 
     fn register_tile(&mut self, name: TileName) -> u16;
     fn app_name() -> &'static str;

--- a/crates/flux/src/tile/metrics.rs
+++ b/crates/flux/src/tile/metrics.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::{fmt::Display, path::Path};
 
 use flux_communication::shmem_dir_queues_string;
 use flux_timing::{IngestionTime, Instant, Nanos};
@@ -75,7 +75,7 @@ pub struct TileMetrics {
 }
 
 impl TileMetrics {
-    pub fn new<A: AsRef<str>, S: Display>(app_name: A, tile_name: S) -> Self {
+    pub fn new<A: AsRef<Path>, S: Display>(app_name: A, tile_name: S) -> Self {
         let dirstr = shmem_dir_queues_string(&app_name);
         let _ = std::fs::create_dir_all(&dirstr);
 

--- a/crates/spine-derive/src/lib.rs
+++ b/crates/spine-derive/src/lib.rs
@@ -184,7 +184,7 @@ pub fn from_spine(attr: TokenStream, item: TokenStream) -> TokenStream {
             producer_fields
                 .push(quote! { pub #field_ident : ::flux::spine::SpineProducer<#inner_ty> });
             consumer_init.push(quote! {
-                            #field_ident : ::flux::spine::SpineConsumer::attach::<#struct_ident, _>(tile, spine.#field_ident)
+                            #field_ident : ::flux::spine::SpineConsumer::attach::<_, #struct_ident, _>(&spine.base_dir, tile, spine.#field_ident)
                         });
             producer_init.push(quote! { #field_ident : ::flux::communication::queue::Producer::from(spine.#field_ident) });
 

--- a/crates/spine-derive/src/lib.rs
+++ b/crates/spine-derive/src/lib.rs
@@ -354,6 +354,10 @@ pub fn from_spine(attr: TokenStream, item: TokenStream) -> TokenStream {
                 self.tile_info.register_tile(name)
             }
 
+            fn new_in_base_dir(base_dir: impl AsRef<std::path::Path>) -> Self {
+                Self::new_with_base_dir(base_dir, None)
+            }
+
             fn app_name() -> &'static str {
                 #app_name_tokens
             }


### PR DESCRIPTION
## Add configurable `base_dir` to shared memory and persistence paths

  All directory helpers previously hardcoded the base directory via `BaseDirs::data_dir()`. This PR threads an explicit `base_dir` parameter through the stack so callers can override where
  data lives.

  ### Changes

  - **`flux-utils/directories`** — `local_share_dir()` now returns just the base path (no app_name). Added `*_with_base` variants for all directory helpers. Changed `app_name` bounds from
  `AsRef<str>` to `AsRef<Path>`.

  - **`flux-communication`** — Added `shmem_queue_with_base_dir`, `ShmemData::open_or_init_with_base_dir`, `Timer::new_with_base_dir`. Originals remain as thin wrappers using
  `local_share_dir()`. Also: stale shmem files are now removed and retried instead of panicking.

  - **`flux/persistence`** — Added `persist_in_base_dir`, `persist_dir_with_base_dir`, `load_with_base_dir` to `Persistable`. `PersistingQueueTile` now stores a `base_dir` field.

  - **`flux/spine`** — New required trait method `fn new_in_base_dir(base_dir: impl AsRef<Path>) -> Self` on `FluxSpine`.

  - **`spine-derive`** — Generated spine structs carry a `base_dir: PathBuf` field. Macro generates `new_with_base_dir` and uses `_with_base_dir` variants for all shmem/data creation.

  ### Notes

  Non-breaking additive change. All existing APIs keep their defaults via `local_share_dir()`.