### PR TITLE
remove wincode_ser_into_slice

### DIFF
--- a/crates/flux-network/Cargo.toml
+++ b/crates/flux-network/Cargo.toml
@@ -7,9 +7,6 @@ license = "Apache-2.0 AND MIT"
 keywords = ["low-latency", "performance", "communication"]
 repository = "https://github.com/gattaca-com/flux"
 
-[features]
-wincode = ["dep:wincode"]
-
 [dependencies]
 flux-communication.workspace = true
 flux-timing.workspace = true

--- a/crates/flux-network/src/tcp/mod.rs
+++ b/crates/flux-network/src/tcp/mod.rs
@@ -5,15 +5,3 @@ pub use connector::{SendBehavior, TcpConnector};
 pub use stream::{ConnState, TcpStream, TcpTelemetry};
 
 const STREAM: mio::Token = mio::Token(0);
-
-#[cfg(feature = "wincode")]
-#[inline]
-pub fn wincode_ser_into_slice<T>(buf: &mut [u8], value: &T) -> usize
-where
-    T: wincode::SchemaWrite<Src = T>,
-{
-    let len = buf.len();
-    let mut cursor = buf;
-    wincode::serialize_into(&mut cursor, value).unwrap();
-    len - cursor.len()
-}


### PR DESCRIPTION
write_or_enqueue_with now accepts Vec<u8> and forwards it as a slice with len = vec.len(), not vec.capacity()