### PR TITLE
make signal handler optional

### DIFF
--- a/crates/flux-timing/src/duration.rs
+++ b/crates/flux-timing/src/duration.rs
@@ -419,7 +419,8 @@ mod tests {
     }
 
     /// Assert drift < 500ppm of expected, minimum 10ns absolute.
-    /// from_nanos path uses ticks_per_micro (~3200) so truncation can reach ~200ppm.
+    /// from_nanos path uses ticks_per_micro (~3200) so truncation can reach
+    /// ~200ppm.
     fn check(ours: Duration, expected: std::time::Duration) {
         let actual_ns = to_ns(ours);
         let expected_ns = expected.as_nanos();

--- a/crates/flux/tests/e2e.rs
+++ b/crates/flux/tests/e2e.rs
@@ -75,7 +75,7 @@ fn end_to_end_send_receive_and_exit() {
     let want = 42u64;
 
     std::thread::scope(|scope| {
-        let mut scoped = flux::spine::ScopedSpine::new(&mut spine, scope, None);
+        let mut scoped = flux::spine::ScopedSpine::new(&mut spine, scope, None, None);
 
         attach_tile(
             ProducerTile { val: want },

--- a/crates/spine-derive/src/lib.rs
+++ b/crates/spine-derive/src/lib.rs
@@ -368,11 +368,11 @@ pub fn from_spine(attr: TokenStream, item: TokenStream) -> TokenStream {
             #generated_new_method_token_stream // Use the correctly generated new method
 
             #[::flux::tracing::instrument(skip_all, fields(system = "Spine"))]
-            pub fn start<F>(mut self, on_panic: Option<Box<dyn Fn(&::std::panic::PanicHookInfo<'_>) + Sync + Send>>, f: F)
+            pub fn start<F>(mut self, on_panic: Option<Box<dyn Fn(&::std::panic::PanicHookInfo<'_>) + Sync + Send>>, custom_signal_handler: Option<::std::time::Duration>, f: F)
             where F: FnOnce(&mut ::flux::spine::ScopedSpine<'_, '_, #struct_ident>),
             {
                 std::thread::scope(|s| {
-                    let mut scoped = ::flux::spine::ScopedSpine::new(&mut self, s, on_panic);
+                    let mut scoped = ::flux::spine::ScopedSpine::new(&mut self, s, on_panic, custom_signal_handler);
                     f(&mut scoped);
 
                     ::flux::core_affinity::set_for_current(*::flux::core_affinity::get_core_ids().unwrap().last().unwrap());
@@ -383,12 +383,12 @@ pub fn from_spine(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
 
             #[::flux::tracing::instrument(skip_all, fields(system = "Spine"))]
-            pub fn start_no_persist<F>(mut self, on_panic: Option<Box<dyn Fn(&::std::panic::PanicHookInfo<'_>) + Sync + Send>>, f: F)
+            pub fn start_no_persist<F>(mut self, on_panic: Option<Box<dyn Fn(&::std::panic::PanicHookInfo<'_>) + Sync + Send>>, custom_signal_handler: Option<::std::time::Duration>, f: F)
             where
                 F: FnOnce(&mut ::flux::spine::ScopedSpine<'_, '_, #struct_ident>),
             {
                 std::thread::scope(|s| {
-                    let mut scoped = ::flux::spine::ScopedSpine::new(&mut self, s, on_panic);
+                    let mut scoped = ::flux::spine::ScopedSpine::new(&mut self, s, on_panic, custom_signal_handler);
                     f(&mut scoped);
                 })
             }


### PR DESCRIPTION
don't always want to run a signal handler. e.g., if all tiles. as using this means tile teardown can't be more than 500ms previously.