### PR TITLE
Replace multi-callback poll_with with single PollEvent enum

### DIFF
--- a/crates/flux-network/src/tcp/mod.rs
+++ b/crates/flux-network/src/tcp/mod.rs
@@ -1,7 +1,7 @@
 mod connector;
 mod stream;
 
-pub use connector::{SendBehavior, TcpConnector};
+pub use connector::{PollEvent, SendBehavior, TcpConnector};
 pub use stream::{ConnState, TcpStream, TcpTelemetry};
 
 const STREAM: mio::Token = mio::Token(0);

--- a/crates/flux-network/tests/tcp_roundtrip.rs
+++ b/crates/flux-network/tests/tcp_roundtrip.rs
@@ -4,7 +4,7 @@ use std::{
     time::Duration,
 };
 
-use flux_network::tcp::{SendBehavior, TcpConnector};
+use flux_network::tcp::{PollEvent, SendBehavior, TcpConnector};
 use wincode_derive::{SchemaRead, SchemaWrite};
 
 #[derive(Debug, PartialEq, SchemaRead, SchemaWrite)]
@@ -28,61 +28,64 @@ fn tcp_roundtrip() {
     let bind_addr = SocketAddr::from((IpAddr::V4(Ipv4Addr::LOCALHOST), 24712));
 
     let mut listener = TcpConnector::default();
-    let listening_token = listener.listen_at(bind_addr).unwrap();
+    let _listening_token = listener.listen_at(bind_addr).unwrap();
 
     let server = thread::spawn(move || {
-        let mut connected_stream = None;
+        let mut accepted_stream = None;
 
-        while connected_stream.is_none() {
-            listener.poll_with(
-                |connection| connected_stream = Some(connection),
-                |_, _, _| panic!("shouldn't have gotten here"),
-            );
+        while accepted_stream.is_none() {
+            listener.poll_with(|event| match event {
+                PollEvent::Accept { stream, .. } => accepted_stream = Some(stream),
+                PollEvent::Message { .. } => panic!("shouldn't have gotten here"),
+                _ => {}
+            });
         }
-        assert_eq!(connected_stream.as_ref().unwrap().listener, listening_token);
+
+        let stream_token = accepted_stream.unwrap();
 
         let mut recv = None;
         loop {
-            listener.poll_with(
-                |_| {},
-                |token, frame, _send_ts| {
-                    assert_eq!(token, connected_stream.as_ref().unwrap().incoming_stream);
-                    let msg: TestMsg = wincode::deserialize(frame).unwrap();
+            listener.poll_with(|event| {
+                if let PollEvent::Message { token, payload, .. } = event {
+                    assert_eq!(token, stream_token);
+                    let msg: TestMsg = wincode::deserialize(payload).unwrap();
                     recv = Some(msg);
-                },
-            );
+                }
+            });
             if recv.is_some() {
                 break;
             }
             thread::sleep(Duration::from_micros(50));
         }
-        listener.write_or_enqueue_with(
-            SendBehavior::Single(connected_stream.as_ref().unwrap().incoming_stream),
-            |buf| wincode_ser_into_slice(buf, &TestMsg(111)),
-        );
-        listener.poll_with(|_| {}, |_, _, _send_ts| panic!("shouldn't have gotten here"));
+        listener.write_or_enqueue_with(SendBehavior::Single(stream_token), |buf| {
+            wincode_ser_into_slice(buf, &TestMsg(111))
+        });
+        listener.poll_with(|event| {
+            if let PollEvent::Message { .. } = event {
+                panic!("shouldn't have gotten here");
+            }
+        });
         assert_eq!(recv, Some(TestMsg(222)));
     });
 
     let client = thread::spawn(move || {
         std::thread::sleep(std::time::Duration::from_millis(10));
         let mut conn = TcpConnector::default();
-        let tok = conn.connect(bind_addr).unwrap();
+        let _tok = conn.connect(bind_addr).unwrap();
         // Then responds
-        conn.write_or_enqueue_with(SendBehavior::Single(tok), |buf| {
+        conn.write_or_enqueue_with(SendBehavior::Single(_tok), |buf| {
             wincode_ser_into_slice(buf, &TestMsg(222))
         });
 
         // Client waits for server message
         let mut recv = None;
         loop {
-            conn.poll_with(
-                |_| {},
-                |_, frame, _send_ts| {
-                    let msg: TestMsg = wincode::deserialize(frame).unwrap();
+            conn.poll_with(|event| {
+                if let PollEvent::Message { payload, .. } = event {
+                    let msg: TestMsg = wincode::deserialize(payload).unwrap();
                     recv = Some(msg);
-                },
-            );
+                }
+            });
             if recv.is_some() {
                 break;
             }


### PR DESCRIPTION
Adds PollEvent::Disconnect so callers are notified when a connection is severed, fixing silent connection cleanup that left callers unaware.