### PR TITLE
tcp: persistent TcpStream across reconnects

### DIFF
--- a/crates/flux-network/src/tcp/stream.rs
+++ b/crates/flux-network/src/tcp/stream.rs
@@ -166,6 +166,7 @@ impl TcpStream {
         self.rx_state = Default::default();
         self.rx_buf.clear();
         self.send_buf.clear();
+        self.send_cursor = 0;
         self.header_buf.fill(0);
         self.stream = stream;
         if !self.send_backlog.is_empty() {


### PR DESCRIPTION
## Summary
- Store `ConnectionVariant` in `to_be_reconnected` instead of just `SocketAddr`, preserving backlog across reconnects via `reset_with_new_stream`
- Send `on_connect_msg` on successful initial `connect()` (was missing)
- Add `send_cursor` to `drain_backlog` to avoid `drain(..n)` reallocation
- Set `TCP_NODELAY` explicitly instead of inside `from_stream_with_telemetry`

## Test plan
- [x] `cargo test -p flux-network --test tcp_roundtrip`
- [x] `cargo test -p overseer --test data_gather`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gattaca-com/flux/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
