### PR TITLE
fix: TileMetrics base_dir + ShmemData stale-flink recovery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,4 @@ wincode = "0.2.5"
 wincode-derive = "0.2.3"
 mio = { version = "1.1.1", features = ["net", "os-poll"] }
 url = "2.5.8"
+tempfile = "3"

--- a/crates/flux-communication/src/lib.rs
+++ b/crates/flux-communication/src/lib.rs
@@ -22,6 +22,15 @@ pub fn shmem_dir_queues_string<S: AsRef<Path>>(app_name: S) -> String {
     queues_dir.to_string_lossy().to_string()
 }
 
+pub fn shmem_dir_queues_string_with_base<D: AsRef<Path>, S: AsRef<Path>>(
+    base_dir: D,
+    app_name: S,
+) -> String {
+    shmem_dir_queues_with_base(base_dir, app_name)
+        .to_string_lossy()
+        .to_string()
+}
+
 pub fn shmem_queue<S: AsRef<Path>, T: Copy>(
     app_name: S,
     len: usize,

--- a/crates/flux-communication/src/shmem_data.rs
+++ b/crates/flux-communication/src/shmem_data.rs
@@ -55,17 +55,14 @@ impl<T> ShmemData<T> {
                 Ok(Self { inner })
             }
             Err(ShmemError::LinkExists) => {
-                let Ok(shmem) = ShmemConf::new().flink(&shmem_file).open() else {
-                    if shmem_file.exists() {
-                        tracing::warn!(
-                            "couldn't open shmem file {}, recreating and retrying",
-                            shmem_file.display()
-                        );
-                        std::fs::remove_file(shmem_file)
-                            .expect("couldn't remove shmem file for TileInfo");
-                        return Self::open_or_init_with_base_dir(dir, app_name, init_f);
-                    }
-                    panic!("couldn't open shmem file {}", shmem_file.display());
+                let Ok(shmem) = ShmemConf::new().flink(&shmem_file).open().inspect_err(|e| {
+                    tracing::warn!(
+                        "couldn't open shmem file {}, removing and retrying: {e}",
+                        shmem_file.display()
+                    );
+                }) else {
+                    let _ = std::fs::remove_file(&shmem_file);
+                    return Self::open_or_init_with_base_dir(dir, app_name, init_f);
                 };
 
                 let inner = Self::shmem_ptr(shmem);

--- a/crates/flux/Cargo.toml
+++ b/crates/flux/Cargo.toml
@@ -28,6 +28,9 @@ zstd.workspace = true
 wincode = { workspace = true, optional = true }
 wincode-derive = { workspace = true, optional = true }
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [features]
 default = []
 wincode = [

--- a/crates/flux/Cargo.toml
+++ b/crates/flux/Cargo.toml
@@ -29,6 +29,7 @@ wincode = { workspace = true, optional = true }
 wincode-derive = { workspace = true, optional = true }
 
 [dev-dependencies]
+shared_memory.workspace = true
 tempfile.workspace = true
 
 [features]

--- a/crates/flux/src/spine/mod.rs
+++ b/crates/flux/src/spine/mod.rs
@@ -56,6 +56,7 @@ pub trait FluxSpine: Sized + Send {
 
     fn register_tile(&mut self, name: TileName) -> u16;
     fn app_name() -> &'static str;
+    fn base_dir(&self) -> &Path;
 
     /// Removes all files related to a given spine. Does not clear the shared
     /// memory itself. CAUTION: this includes data files.

--- a/crates/flux/src/tile/metrics.rs
+++ b/crates/flux/src/tile/metrics.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, path::Path};
 
-use flux_communication::{shmem_dir_queues_string, shmem_dir_queues_string_with_base};
+use flux_communication::shmem_dir_queues_string_with_base;
 use flux_timing::{IngestionTime, Instant, Nanos};
 
 use crate::communication::queue::{Producer, Queue, QueueType};
@@ -75,21 +75,7 @@ pub struct TileMetrics {
 }
 
 impl TileMetrics {
-    pub fn new<A: AsRef<Path>, S: Display>(app_name: A, tile_name: S) -> Self {
-        let dirstr = shmem_dir_queues_string(&app_name);
-        let _ = std::fs::create_dir_all(&dirstr);
-
-        let file = format!("{dirstr}/tilemetrics-{tile_name}");
-        let queue = Queue::create_or_open_shared(file, QUEUE_SIZE, QueueType::SPMC);
-
-        Self {
-            latest_begin: Instant::default(),
-            sample: TileSample { busy_min: u64::MAX, ..Default::default() },
-            producer: Producer::from(queue),
-        }
-    }
-
-    pub fn new_with_base_dir<D: AsRef<Path>, A: AsRef<Path>, S: Display>(
+    pub fn new<D: AsRef<Path>, A: AsRef<Path>, S: Display>(
         base_dir: D,
         app_name: A,
         tile_name: S,

--- a/crates/flux/src/tile/metrics.rs
+++ b/crates/flux/src/tile/metrics.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, path::Path};
 
-use flux_communication::shmem_dir_queues_string;
+use flux_communication::{shmem_dir_queues_string, shmem_dir_queues_string_with_base};
 use flux_timing::{IngestionTime, Instant, Nanos};
 
 use crate::communication::queue::{Producer, Queue, QueueType};
@@ -77,6 +77,24 @@ pub struct TileMetrics {
 impl TileMetrics {
     pub fn new<A: AsRef<Path>, S: Display>(app_name: A, tile_name: S) -> Self {
         let dirstr = shmem_dir_queues_string(&app_name);
+        let _ = std::fs::create_dir_all(&dirstr);
+
+        let file = format!("{dirstr}/tilemetrics-{tile_name}");
+        let queue = Queue::create_or_open_shared(file, QUEUE_SIZE, QueueType::SPMC);
+
+        Self {
+            latest_begin: Instant::default(),
+            sample: TileSample { busy_min: u64::MAX, ..Default::default() },
+            producer: Producer::from(queue),
+        }
+    }
+
+    pub fn new_with_base_dir<D: AsRef<Path>, A: AsRef<Path>, S: Display>(
+        base_dir: D,
+        app_name: A,
+        tile_name: S,
+    ) -> Self {
+        let dirstr = shmem_dir_queues_string_with_base(base_dir, &app_name);
         let _ = std::fs::create_dir_all(&dirstr);
 
         let file = format!("{dirstr}/tilemetrics-{tile_name}");

--- a/crates/flux/src/tile/mod.rs
+++ b/crates/flux/src/tile/mod.rs
@@ -77,11 +77,7 @@ where
         SpineAdapter::connect_tile_with_stop_flag(&tile, spine.spine, stop_flag.clone());
 
     let mut metrics = if config.metrics {
-        Some(TileMetrics::new_with_base_dir(
-            spine.spine.base_dir(),
-            S::app_name(),
-            tile.name(),
-        ))
+        Some(TileMetrics::new(spine.spine.base_dir(), S::app_name(), tile.name()))
     } else {
         None
     };

--- a/crates/flux/src/tile/mod.rs
+++ b/crates/flux/src/tile/mod.rs
@@ -76,8 +76,15 @@ where
     let mut adapter =
         SpineAdapter::connect_tile_with_stop_flag(&tile, spine.spine, stop_flag.clone());
 
-    let mut metrics =
-        if config.metrics { Some(TileMetrics::new(S::app_name(), tile.name())) } else { None };
+    let mut metrics = if config.metrics {
+        Some(TileMetrics::new_with_base_dir(
+            spine.spine.base_dir(),
+            S::app_name(),
+            tile.name(),
+        ))
+    } else {
+        None
+    };
 
     spine.scope.spawn(move || {
         let _span = span!(Level::INFO, "", tile = %tile.name()).entered();

--- a/crates/flux/tests/spine.rs
+++ b/crates/flux/tests/spine.rs
@@ -12,6 +12,7 @@ use flux::{
 use flux_timing::Duration;
 use flux_utils::directories::{shmem_dir_data_with_base, shmem_dir_queues_with_base};
 use serde::{Deserialize, Serialize};
+use shared_memory::ShmemConf;
 use spine_derive::from_spine;
 
 #[derive(Clone, Copy, Default, Debug, Serialize, Deserialize)]
@@ -40,8 +41,6 @@ struct TestSpine {
     pub qb: SpineQueue<MsgB>,
 }
 
-// ── Tiles ────────────────────────────────────────────────────────────────────
-
 #[derive(Clone, Copy, Default)]
 struct Writer;
 
@@ -69,9 +68,15 @@ impl Tile<TestSpine> for Reader {
     }
 }
 
-// ── Helpers ──────────────────────────────────────────────────────────────────
+fn cleanup_shmem(root: &std::path::Path) {
+    for flink in all_files_under(root) {
+        if let Ok(mut shmem) = ShmemConf::new().flink(&flink).open() {
+            shmem.set_owner(true);
+        }
+    }
+    let _ = std::fs::remove_dir_all(root);
+}
 
-/// Recursively collect every file under `root`.
 fn all_files_under(root: &std::path::Path) -> Vec<std::path::PathBuf> {
     let mut out = Vec::new();
     if !root.exists() {
@@ -89,11 +94,9 @@ fn all_files_under(root: &std::path::Path) -> Vec<std::path::PathBuf> {
     out
 }
 
-// ── Tests ────────────────────────────────────────────────────────────────────
-
 /// Creates a spine with a custom temp `base_dir`, attaches two tiles
 /// (writer + reader), runs until the reader receives a message, then
-/// asserts that **every** shared-memory file was created inside the
+/// asserts that every shared-memory file was created inside the
 /// specified `base_dir` and nowhere else.
 #[test]
 fn all_shmem_files_reside_in_base_dir() {
@@ -119,22 +122,17 @@ fn all_shmem_files_reside_in_base_dir() {
         );
     });
 
-    // Verify the message arrived (sanity check that the spine worked).
     assert_eq!(got.load(Ordering::Relaxed), 42, "reader should have received the value");
 
-    // ── Assert all shmem files are inside base_dir ───────────────────────
     let files = all_files_under(base);
     assert!(!files.is_empty(), "expected at least one shmem file inside {}", base.display());
 
-    // Queues dir should exist and contain the queue + timing + metrics files.
     let queues_dir = shmem_dir_queues_with_base(base, "spine-test-app");
     assert!(queues_dir.is_dir(), "queues dir should exist: {}", queues_dir.display());
 
-    // Data dir should exist and contain the TileInfo shmem.
     let data_dir = shmem_dir_data_with_base(base, "spine-test-app");
     assert!(data_dir.is_dir(), "data dir should exist: {}", data_dir.display());
 
-    // Check that TileInfo shmem file exists.
     let tile_info_file = data_dir.join("TileInfo");
     assert!(
         tile_info_file.exists(),
@@ -142,7 +140,6 @@ fn all_shmem_files_reside_in_base_dir() {
         tile_info_file.display()
     );
 
-    // Check that message queue files exist.
     let queue_files: Vec<_> = files
         .iter()
         .filter(|p| {
@@ -157,7 +154,6 @@ fn all_shmem_files_reside_in_base_dir() {
         queue_files
     );
 
-    // Check that timing/latency files exist (one pair per consumer attachment).
     let timing_files: Vec<_> = files
         .iter()
         .filter(|p| {
@@ -176,7 +172,6 @@ fn all_shmem_files_reside_in_base_dir() {
         .collect();
     assert!(!latency_files.is_empty(), "expected latency shmem files, found none");
 
-    // Check that tile-metrics files exist (the previously broken path).
     let metrics_files: Vec<_> = files
         .iter()
         .filter(|p| {
@@ -186,11 +181,9 @@ fn all_shmem_files_reside_in_base_dir() {
         .collect();
     assert!(
         !metrics_files.is_empty(),
-        "expected tilemetrics shmem files inside base_dir, found none. \
-         This was the original bug: TileMetrics were created in local_share_dir instead."
+        "expected tilemetrics shmem files inside base_dir, found none"
     );
 
-    // Finally, assert every file is strictly under base.
     for f in &files {
         assert!(
             f.starts_with(base),
@@ -200,6 +193,5 @@ fn all_shmem_files_reside_in_base_dir() {
         );
     }
 
-    // Clean up.
-    let _ = std::fs::remove_dir_all(base);
+    cleanup_shmem(base);
 }

--- a/crates/flux/tests/spine.rs
+++ b/crates/flux/tests/spine.rs
@@ -1,0 +1,205 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
+
+use flux::{
+    communication::ShmemData,
+    persistence::Persistable,
+    spine::{SpineAdapter, SpineQueue},
+    tile::{Tile, TileConfig, TileInfo, attach_tile},
+};
+use flux_timing::Duration;
+use flux_utils::directories::{shmem_dir_data_with_base, shmem_dir_queues_with_base};
+use serde::{Deserialize, Serialize};
+use spine_derive::from_spine;
+
+#[derive(Clone, Copy, Default, Debug, Serialize, Deserialize)]
+#[repr(C)]
+struct MsgA(u64);
+
+impl Persistable for MsgA {
+    const PERSIST_DIR: &'static str = "msg_a";
+}
+
+#[derive(Clone, Copy, Default, Debug, Serialize, Deserialize)]
+#[repr(C)]
+struct MsgB(u8);
+
+impl Persistable for MsgB {
+    const PERSIST_DIR: &'static str = "msg_b";
+}
+
+#[from_spine("spine-test-app")]
+#[derive(Debug)]
+struct TestSpine {
+    pub tile_info: ShmemData<TileInfo>,
+    #[queue(size(2usize.pow(14)))]
+    pub qa: SpineQueue<MsgA>,
+    #[queue(size(2usize.pow(14)))]
+    pub qb: SpineQueue<MsgB>,
+}
+
+// ── Tiles ────────────────────────────────────────────────────────────────────
+
+#[derive(Clone, Copy, Default)]
+struct Writer;
+
+impl Tile<TestSpine> for Writer {
+    fn loop_body(&mut self, adapter: &mut SpineAdapter<TestSpine>) {
+        adapter.produce(MsgA(42));
+    }
+}
+
+#[derive(Clone)]
+struct Reader {
+    received: Arc<AtomicU64>,
+}
+
+impl Tile<TestSpine> for Reader {
+    fn loop_body(&mut self, adapter: &mut SpineAdapter<TestSpine>) {
+        let mut got_one = false;
+        adapter.consume(|m: MsgA, _| {
+            self.received.store(m.0, Ordering::Relaxed);
+            got_one = true;
+        });
+        if got_one {
+            adapter.request_stop_scope();
+        }
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Recursively collect every file under `root`.
+fn all_files_under(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut out = Vec::new();
+    if !root.exists() {
+        return out;
+    }
+    for entry in std::fs::read_dir(root).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.is_dir() {
+            out.extend(all_files_under(&path));
+        } else {
+            out.push(path);
+        }
+    }
+    out
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+/// Creates a spine with a custom temp `base_dir`, attaches two tiles
+/// (writer + reader), runs until the reader receives a message, then
+/// asserts that **every** shared-memory file was created inside the
+/// specified `base_dir` and nowhere else.
+#[test]
+fn all_shmem_files_reside_in_base_dir() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let base = tmp.path();
+
+    let mut spine = TestSpine::new_with_base_dir(base, None);
+
+    let got = Arc::new(AtomicU64::new(0));
+
+    std::thread::scope(|scope| {
+        let mut scoped = flux::spine::ScopedSpine::new(&mut spine, scope, None, None);
+
+        attach_tile(
+            Writer,
+            &mut scoped,
+            TileConfig::background(None, Some(Duration::from_millis(10))),
+        );
+        attach_tile(
+            Reader { received: got.clone() },
+            &mut scoped,
+            TileConfig::background(None, None),
+        );
+    });
+
+    // Verify the message arrived (sanity check that the spine worked).
+    assert_eq!(got.load(Ordering::Relaxed), 42, "reader should have received the value");
+
+    // ── Assert all shmem files are inside base_dir ───────────────────────
+    let files = all_files_under(base);
+    assert!(!files.is_empty(), "expected at least one shmem file inside {}", base.display());
+
+    // Queues dir should exist and contain the queue + timing + metrics files.
+    let queues_dir = shmem_dir_queues_with_base(base, "spine-test-app");
+    assert!(queues_dir.is_dir(), "queues dir should exist: {}", queues_dir.display());
+
+    // Data dir should exist and contain the TileInfo shmem.
+    let data_dir = shmem_dir_data_with_base(base, "spine-test-app");
+    assert!(data_dir.is_dir(), "data dir should exist: {}", data_dir.display());
+
+    // Check that TileInfo shmem file exists.
+    let tile_info_file = data_dir.join("TileInfo");
+    assert!(
+        tile_info_file.exists(),
+        "TileInfo shmem should exist at {}",
+        tile_info_file.display()
+    );
+
+    // Check that message queue files exist.
+    let queue_files: Vec<_> = files
+        .iter()
+        .filter(|p| {
+            let name = p.file_name().unwrap().to_string_lossy();
+            name.contains("InternalMessage")
+        })
+        .collect();
+    assert!(
+        queue_files.len() >= 2,
+        "expected at least 2 queue files (MsgA + MsgB), got {}: {:?}",
+        queue_files.len(),
+        queue_files
+    );
+
+    // Check that timing/latency files exist (one pair per consumer attachment).
+    let timing_files: Vec<_> = files
+        .iter()
+        .filter(|p| {
+            let name = p.file_name().unwrap().to_string_lossy();
+            name.starts_with("timing-")
+        })
+        .collect();
+    assert!(!timing_files.is_empty(), "expected timing shmem files, found none");
+
+    let latency_files: Vec<_> = files
+        .iter()
+        .filter(|p| {
+            let name = p.file_name().unwrap().to_string_lossy();
+            name.starts_with("latency-")
+        })
+        .collect();
+    assert!(!latency_files.is_empty(), "expected latency shmem files, found none");
+
+    // Check that tile-metrics files exist (the previously broken path).
+    let metrics_files: Vec<_> = files
+        .iter()
+        .filter(|p| {
+            let name = p.file_name().unwrap().to_string_lossy();
+            name.starts_with("tilemetrics-")
+        })
+        .collect();
+    assert!(
+        !metrics_files.is_empty(),
+        "expected tilemetrics shmem files inside base_dir, found none. \
+         This was the original bug: TileMetrics were created in local_share_dir instead."
+    );
+
+    // Finally, assert every file is strictly under base.
+    for f in &files {
+        assert!(
+            f.starts_with(base),
+            "shmem file {} is NOT inside base_dir {}",
+            f.display(),
+            base.display()
+        );
+    }
+
+    // Clean up.
+    let _ = std::fs::remove_dir_all(base);
+}

--- a/crates/spine-derive/src/lib.rs
+++ b/crates/spine-derive/src/lib.rs
@@ -361,6 +361,10 @@ pub fn from_spine(attr: TokenStream, item: TokenStream) -> TokenStream {
             fn app_name() -> &'static str {
                 #app_name_tokens
             }
+
+            fn base_dir(&self) -> &std::path::Path {
+                &self.base_dir
+            }
         }
 
         // start() method with only the necessary PersistingQueues


### PR DESCRIPTION
## Summary

Two fixes for shared-memory file handling.

### 1. TileMetrics ignores spine `base_dir`

`TileMetrics::new()` always used `shmem_dir_queues_string()` which resolves to
`local_share_dir()`, ignoring the spine's configured `base_dir`. Every other
shmem creation path (queues, TileInfo, consumer timers, latency) correctly
threads `base_dir` through — TileMetrics was the sole exception.

**Changes:**
- Add `base_dir()` to the `FluxSpine` trait (generated by the derive macro)
- Add `TileMetrics::new_with_base_dir()` + `shmem_dir_queues_string_with_base()`
- `attach_tile` now passes `spine.base_dir()` into `TileMetrics`
- New integration test `spine.rs`: creates a spine in a temp dir, attaches
  tiles, and asserts **all** shmem files (including `tilemetrics-*`) land
  inside the specified `base_dir`

### 2. `ShmemData` panics on stale flink instead of recovering

When `create()` returns `LinkExists` and `open()` subsequently fails,
`ShmemData` had two panic paths:
1. Flink exists but `open()` fails → `.expect()` on `remove_file()` panics
2. Flink removed by another process (race) → unconditional `panic!()`

Both `Queue::create_or_open_shared` and `SeqlockArray::create_or_open_shared`
handle this gracefully: silently remove the stale flink and retry.
`ShmemData` now follows the same pattern.

## Test plan

```
cargo test            # all 54 tests pass
cargo test --test spine   # new integration test
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gattaca-com/flux/pull/33" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
