### PR TITLE
frame retransmission fix

### DIFF
--- a/crates/flux-network/src/tcp/stream.rs
+++ b/crates/flux-network/src/tcp/stream.rs
@@ -249,7 +249,8 @@ impl TcpStream {
             }
             Ok(n) if n == self.send_buf.len() + FRAME_HEADER_SIZE => ConnState::Alive,
             Ok(n) => {
-                let data = self.alloc_vec(n);
+                let data = self.alloc_vec(0);
+                self.send_cursor = n;
                 self.enqueue_back(registry, data)
             }
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {


### PR DESCRIPTION
store complete frame in the vec, bump the cursor instead 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gattaca-com/flux/pull/35" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
