### PR TITLE
Shared vector + Standalone producer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ quanta = "0.12.3"
 governor = "0.6.3"
 bitcode = { features = ["serde"], version = "0.6.3" }
 zstd = "0.13.2"
+rand = "0.9.0"
+spin = "0.10"
 signal-hook = "0.3.18"
 tracing = "0.1.40"
 thiserror = "1.0.58"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ rust-version = "1.91.0"
 version = "0.1.0"
 
 [workspace.dependencies]
-flux = { path = "crates/flux", version = "0.0.37" }
-flux-communication = { path = "crates/flux-communication", version = "0.0.26" }
-flux-timing = { path = "crates/flux-timing", version = "0.0.15" }
-flux-utils = { path = "crates/flux-utils", version = "0.0.22" }
+flux = { path = "crates/flux", version = "0.0.38" }
+flux-communication = { path = "crates/flux-communication", version = "0.0.27" }
+flux-timing = { path = "crates/flux-timing", version = "0.0.16" }
+flux-utils = { path = "crates/flux-utils", version = "0.0.23" }
 flux-network = { path = "crates/flux-network", version = "0.0.8" }
-spine-derive = { path = "crates/spine-derive", version = "0.0.9" }
+spine-derive = { path = "crates/spine-derive", version = "0.0.10" }
 flux-overseer = { path = "crates/flux-overseer", version = "0.0.11" }
 flux-timekeeper = { path = "crates/flux-timekeeper", version = "0.0.29" }
 type-hash = { path = "crates/type-hash", version = "0.0.1" }

--- a/crates/flux-communication/Cargo.toml
+++ b/crates/flux-communication/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flux-communication"
-version = "0.0.26"
+version = "0.0.27"
 edition.workspace = true
 rust-version.workspace = true
 license = "Apache-2.0 AND MIT"

--- a/crates/flux-communication/src/lib.rs
+++ b/crates/flux-communication/src/lib.rs
@@ -26,9 +26,7 @@ pub fn shmem_dir_queues_string_with_base<D: AsRef<Path>, S: AsRef<Path>>(
     base_dir: D,
     app_name: S,
 ) -> String {
-    shmem_dir_queues_with_base(base_dir, app_name)
-        .to_string_lossy()
-        .to_string()
+    shmem_dir_queues_with_base(base_dir, app_name).to_string_lossy().to_string()
 }
 
 pub fn shmem_queue<S: AsRef<Path>, T: Copy>(

--- a/crates/flux-timing/Cargo.toml
+++ b/crates/flux-timing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flux-timing"
-version = "0.0.15"
+version = "0.0.16"
 edition.workspace = true
 rust-version.workspace = true
 license = "Apache-2.0 AND MIT"

--- a/crates/flux-timing/src/lib.rs
+++ b/crates/flux-timing/src/lib.rs
@@ -18,4 +18,4 @@ pub use internal_message::InternalMessage;
 pub use nanos::Nanos;
 pub use publish_delta::PublishDelta;
 pub use repeater::Repeater;
-pub use tracking_timestamp::TrackingTimestamp;
+pub use tracking_timestamp::{TrackingTimestamp, UNREGISTERED_TILE_ID};

--- a/crates/flux-timing/src/tracking_timestamp.rs
+++ b/crates/flux-timing/src/tracking_timestamp.rs
@@ -3,6 +3,9 @@ use type_hash_derive::TypeHash;
 
 use crate::{IngestionTime, Instant, Nanos, PublishDelta};
 
+/// Sentinel tile_id for producers not registered with a spine tile.
+pub const UNREGISTERED_TILE_ID: u16 = u16::MAX;
+
 /// This is used in InternalMessage to track who published
 /// a message when.
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Default, Deserialize, TypeHash)]
@@ -22,7 +25,10 @@ impl TrackingTimestamp {
     /// throughout the system. It's purely here due to legacy reasons.
     #[inline]
     pub fn new_without_tile() -> Self {
-        Self { ingestion_t: IngestionTime::now(), publish_delta: PublishDelta::new(u16::MAX) }
+        Self {
+            ingestion_t: IngestionTime::now(),
+            publish_delta: PublishDelta::new(UNREGISTERED_TILE_ID),
+        }
     }
 
     #[inline]

--- a/crates/flux-utils/Cargo.toml
+++ b/crates/flux-utils/Cargo.toml
@@ -16,6 +16,8 @@ directories.workspace = true
 libc.workspace = true
 tracing.workspace = true
 serde.workspace = true
+rand.workspace = true
+spin.workspace = true
 wincode = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/flux-utils/Cargo.toml
+++ b/crates/flux-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flux-utils"
-version = "0.0.22"
+version = "0.0.23"
 edition.workspace = true
 rust-version.workspace = true
 license = "Apache-2.0 AND MIT"

--- a/crates/flux-utils/src/lib.rs
+++ b/crates/flux-utils/src/lib.rs
@@ -2,10 +2,12 @@ mod arrayvec;
 mod assert;
 pub mod directories;
 mod namespace;
+mod shared_vector;
 mod thread;
 mod vsync;
 
 pub use arrayvec::{ArrayStr, ArrayVec};
 pub use namespace::{ShortTypename, short_typename};
+pub use shared_vector::SharedVector;
 pub use thread::{ThreadPriority, thread_boot};
 pub use vsync::vsync;

--- a/crates/flux-utils/src/shared_vector.rs
+++ b/crates/flux-utils/src/shared_vector.rs
@@ -1,0 +1,434 @@
+use std::{
+    cmp::max,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+
+pub struct SharedVector<T> {
+    data: Box<[spin::RwLock<Option<Arc<T>>>]>,
+    next_position: AtomicUsize,
+    start_clearing_position: AtomicUsize,
+    mask: usize,
+}
+
+impl<T> Default for SharedVector<T> {
+    fn default() -> Self {
+        Self::with_capacity(16 * 1024)
+    }
+}
+
+impl<T> SharedVector<T> {
+    pub fn with_capacity(capacity: usize) -> Self {
+        let real_size = capacity.next_power_of_two();
+        let mut uninit_data = Box::new_uninit_slice(real_size);
+
+        for elem in uninit_data.iter_mut() {
+            elem.write(spin::RwLock::new(None));
+        }
+
+        let data = unsafe { uninit_data.assume_init() };
+
+        Self {
+            data,
+            next_position: AtomicUsize::new(0),
+            start_clearing_position: AtomicUsize::new(0),
+            mask: real_size - 1,
+        }
+    }
+
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.mask + 1
+    }
+
+    #[inline]
+    fn convert_to_index(&self, position: usize) -> usize {
+        position & self.mask
+    }
+
+    #[inline]
+    fn is_outdated_position(&self, position: usize) -> bool {
+        position + self.capacity() < self.next_position.load(Ordering::Acquire)
+    }
+
+    #[inline]
+    fn push_internal(&self, item: Option<Arc<T>>) -> usize {
+        let current_position = self.next_position.fetch_add(1, Ordering::Release);
+        let current_index = self.convert_to_index(current_position);
+        let current_address = unsafe { self.data.get_unchecked(current_index) };
+
+        {
+            let mut guard = current_address.write();
+            *guard = item;
+        }
+
+        current_position
+    }
+
+    /// Pushes an item and returns id of the latest item.
+    /// Returns the position where the item was pushed.
+    /// Designed for multiple producer usage.
+    #[inline]
+    pub fn push(&self, item: T) -> usize {
+        self.push_internal(Some(Arc::new(item)))
+    }
+
+    /// Retrieves an item by index.
+    /// Designed for multiple concurrent readers.
+    #[inline]
+    pub fn get(&self, position: usize) -> Option<Arc<T>> {
+        let index = self.convert_to_index(position);
+        let position_address = unsafe { self.data.get_unchecked(index) };
+
+        let result;
+        {
+            let guard = position_address.read();
+            result = guard.as_ref().map(Arc::clone);
+        }
+        if self.is_outdated_position(position) {
+            return None;
+        }
+        result
+    }
+
+    /// Clears all items and invalidates existing indices, only objects that was
+    /// received from get will be still valid. Returns the latest position
+    /// which was cleared. Designed for only single clearing at a time and
+    /// supports multiple push and get at the same time.
+    #[inline]
+    pub fn clear(&self) -> usize {
+        let last_pos = self.next_position.load(Ordering::Acquire);
+        let start_pos = max(
+            last_pos.saturating_sub(self.capacity()),
+            self.start_clearing_position.load(Ordering::Relaxed),
+        );
+        if last_pos == start_pos {
+            return last_pos.saturating_sub(1);
+        }
+
+        let capacity_used = (last_pos.saturating_sub(start_pos)) as f64 / self.capacity() as f64;
+
+        if capacity_used > 0.9 {
+            tracing::warn!(
+                "Shared vector reached more than {}% of the capacity between clearing, consider increasing capacity",
+                capacity_used * 100.0
+            );
+        }
+
+        for i in start_pos..last_pos {
+            let pos = self.convert_to_index(i);
+            let current_address = unsafe { self.data.get_unchecked(pos) };
+            {
+                let mut guard = current_address.write();
+                *guard = None;
+            }
+        }
+
+        // Clear called only from single thread, so we can use relaxed ordering.
+        // Variable is atomic to allow use immutable shared_vector in clear from Arc.
+        self.start_clearing_position.store(last_pos, Ordering::Relaxed);
+        last_pos.saturating_sub(1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread;
+
+    use super::*;
+
+    #[test]
+    fn test_new_shared_vector() {
+        let vector: SharedVector<i32> = SharedVector::default();
+        assert!(vector.get(0).is_none());
+    }
+
+    #[test]
+    fn test_push_and_get() {
+        let vector = SharedVector::default();
+
+        let index = vector.push(42);
+        let retrieved = vector.get(index);
+
+        assert!(retrieved.is_some());
+        assert_eq!(*retrieved.unwrap(), 42);
+    }
+
+    #[test]
+    fn test_push_multiple_items() {
+        let vector = SharedVector::default();
+
+        let index1 = vector.push(1);
+        let index2 = vector.push(2);
+        let index3 = vector.push(3);
+
+        assert_eq!(*vector.get(index1).unwrap(), 1);
+        assert_eq!(*vector.get(index2).unwrap(), 2);
+        assert_eq!(*vector.get(index3).unwrap(), 3);
+    }
+
+    #[test]
+    fn test_clear_invalidates_indices() {
+        let vector = SharedVector::default();
+
+        let index1 = vector.push(100);
+        let index2 = vector.push(200);
+
+        assert_eq!(*vector.get(index1).unwrap(), 100);
+        assert_eq!(*vector.get(index2).unwrap(), 200);
+
+        vector.clear();
+
+        assert!(vector.get(index1).is_none());
+        assert!(vector.get(index2).is_none());
+    }
+
+    #[test]
+    fn test_push_after_clear() {
+        let vector = SharedVector::default();
+
+        let old_index = vector.push(1);
+        vector.clear();
+        let new_index = vector.push(2);
+
+        assert!(vector.get(old_index).is_none());
+        assert_eq!(*vector.get(new_index).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_custom_struct() {
+        #[derive(Clone, Debug, PartialEq)]
+        struct TestData {
+            id: u32,
+            name: String,
+        }
+
+        let vector = SharedVector::default();
+        let test_item = TestData { id: 1, name: "test".to_string() };
+
+        let index = vector.push(test_item.clone());
+        let retrieved = vector.get(index);
+
+        assert!(retrieved.is_some());
+        assert_eq!(*retrieved.unwrap(), test_item);
+    }
+
+    #[test]
+    fn test_multiple_clears() {
+        let vector = SharedVector::default();
+
+        let index = vector.push(1);
+        assert_eq!(*vector.get(index).unwrap(), 1);
+
+        vector.clear();
+        vector.clear();
+
+        assert!(vector.get(index).is_none());
+
+        let new_index = vector.push(2);
+        assert_eq!(*vector.get(new_index).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_arc_sharing() {
+        let vector = SharedVector::default();
+
+        let index = vector.push(42);
+        let element = vector.get(index).unwrap();
+        vector.clear();
+
+        assert_eq!(*element, 42);
+    }
+
+    #[test]
+    fn test_sequential_read() {
+        const NUM_READERS: usize = 4;
+        const N: usize = 1_000_000;
+
+        let vector = Arc::new(SharedVector::with_capacity(N));
+        vector.push(0);
+
+        thread::scope(|s| {
+            {
+                let vector = vector.clone();
+                s.spawn(move || {
+                    for i in 1..N {
+                        vector.push(i);
+                    }
+                });
+            }
+
+            for _ in 0..NUM_READERS {
+                let vector = vector.clone();
+                s.spawn(move || {
+                    let mut i = 0;
+                    while i < N {
+                        if let Some(value) = vector.get(i) {
+                            assert_eq!(*value, i);
+                            i += 1;
+                        }
+                    }
+                });
+            }
+        });
+    }
+
+    #[test]
+    fn test_random_read() {
+        const NUM_READERS: usize = 4;
+        const N: usize = 1_000_000;
+
+        let vector = Arc::new(SharedVector::with_capacity(N));
+        vector.push(0);
+
+        let latest_id = Arc::new(AtomicUsize::new(0));
+        thread::scope(|s| {
+            {
+                let vector = vector.clone();
+                let latest_id = latest_id.clone();
+                s.spawn(move || {
+                    for i in 1..N {
+                        latest_id.store(vector.push(i), Ordering::Release);
+                    }
+                });
+            }
+
+            for _ in 0..NUM_READERS {
+                let vector = vector.clone();
+                let latest_id = latest_id.clone();
+                s.spawn(move || {
+                    use rand::Rng;
+                    let mut rng = rand::rng();
+                    for _ in 0..N {
+                        let vector_size = latest_id.load(Ordering::Acquire) + 1;
+                        let element_id = rng.random_range(0..vector_size);
+
+                        let value = vector.get(element_id).unwrap();
+                        assert_eq!(*value, element_id);
+                    }
+                });
+            }
+        });
+    }
+
+    #[test]
+    fn test_latest_read() {
+        const NUM_READERS: usize = 4;
+        const N: usize = 1_000_000;
+
+        // Capacity is 1 to catch more concurrency issues which rarely happen, but still
+        // possible
+        let vector = Arc::new(SharedVector::with_capacity(1));
+        vector.push(0);
+
+        let latest_id = Arc::new(AtomicUsize::new(0));
+        thread::scope(|s| {
+            {
+                let vector = vector.clone();
+                let latest_id = latest_id.clone();
+                s.spawn(move || {
+                    for i in 1..N {
+                        latest_id.store(vector.push(i), Ordering::Release);
+                    }
+                });
+            }
+
+            for _ in 0..NUM_READERS {
+                let vector = vector.clone();
+                let latest_id = latest_id.clone();
+                s.spawn(move || {
+                    for _ in 0..N {
+                        let latest_id = latest_id.load(Ordering::Acquire);
+                        if let Some(value) = vector.get(latest_id) {
+                            assert_eq!(*value, latest_id);
+                        }
+                    }
+                });
+            }
+        });
+    }
+
+    #[test]
+    fn test_latest_read_with_clear() {
+        use rand::Rng;
+
+        const NUM_READERS: usize = 4;
+        const N: usize = 10_000_000;
+
+        let vector = Arc::new(SharedVector::with_capacity(32));
+
+        let success_count = Arc::new(AtomicUsize::new(0));
+        let read_count = Arc::new(AtomicUsize::new(0));
+
+        let reader_latest_id = Arc::new(AtomicUsize::new(usize::MAX));
+        thread::scope(|s| {
+            {
+                let vector = vector.clone();
+                let reader_latest_id = reader_latest_id.clone();
+                s.spawn(move || {
+                    let mut rng = rand::rng();
+                    let mut writer_latest_id = vector.push(0);
+                    for _ in 1..N {
+                        let operation = rng.random_range(0..1_000_000);
+                        match operation {
+                            0..100 => {
+                                reader_latest_id.store(usize::MAX, Ordering::Release);
+                                writer_latest_id = vector.clear();
+                            }
+                            100..1_000 => {
+                                std::thread::sleep(std::time::Duration::from_micros(1));
+                            }
+                            _ => {
+                                writer_latest_id = vector.push(writer_latest_id + 1);
+                                reader_latest_id.store(writer_latest_id, Ordering::Release);
+                            }
+                        }
+                    }
+                });
+            }
+
+            for _ in 0..NUM_READERS {
+                let vector = vector.clone();
+                let reader_latest_id = reader_latest_id.clone();
+                let success_count = success_count.clone();
+                let read_count = read_count.clone();
+                s.spawn(move || {
+                    let mut rng = rand::rng();
+                    for _ in 0..N {
+                        let latest_id = loop {
+                            let id = reader_latest_id.load(Ordering::Acquire);
+                            if id != usize::MAX {
+                                break id;
+                            }
+                        };
+                        if rng.random_range(0..1_000) == 0 {
+                            let sleep_time = rng.random_range(0..100);
+                            std::thread::sleep(std::time::Duration::from_micros(sleep_time));
+                        }
+
+                        read_count.fetch_add(1, Ordering::Relaxed);
+                        if let Some(value) = vector.get(latest_id) {
+                            assert_eq!(*value, latest_id);
+                            success_count.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                });
+            }
+        });
+
+        let read_rate = read_count.load(Ordering::Relaxed) as f64 / (N * NUM_READERS) as f64;
+        let success_read_rate = success_count.load(Ordering::Relaxed) as f64 /
+            (read_count.load(Ordering::Relaxed)) as f64;
+
+        assert!(read_rate > 0.99, "read_rate: {read_rate}");
+        assert!(success_read_rate > 0.99, "success_read_rate: {success_read_rate}");
+
+        println!(
+            "Success rate: {}, operations: {}",
+            success_read_rate,
+            read_count.load(Ordering::Relaxed)
+        );
+    }
+}

--- a/crates/flux/Cargo.toml
+++ b/crates/flux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flux"
-version = "0.0.37"
+version = "0.0.38"
 edition.workspace = true
 rust-version.workspace = true
 license = "Apache-2.0 AND MIT"

--- a/crates/flux/src/spine/mod.rs
+++ b/crates/flux/src/spine/mod.rs
@@ -1,6 +1,7 @@
 mod adapter;
 mod consumer;
 mod scoped;
+mod standalone_producer;
 
 use std::path::Path;
 
@@ -9,6 +10,7 @@ pub use consumer::SpineConsumer;
 use flux_timing::{IngestionTime, InternalMessage, TrackingTimestamp};
 use flux_utils::directories::shmem_dir;
 pub use scoped::ScopedSpine;
+pub use standalone_producer::StandaloneProducer;
 
 use crate::{
     communication::queue::{self},
@@ -22,7 +24,7 @@ pub trait SpineProducers {
     fn timestamp(&self) -> &TrackingTimestamp;
     fn timestamp_mut(&mut self) -> &mut TrackingTimestamp;
 
-    fn produce<T: Copy>(&mut self, d: T)
+    fn produce<T: Copy>(&self, d: T)
     where
         Self: AsRef<SpineProducer<T>>,
     {
@@ -30,7 +32,7 @@ pub trait SpineProducers {
         self.as_ref().produce_without_first(&msg);
     }
 
-    fn produce_with_ingestion<T: Copy>(&mut self, d: T, ingestion_t: IngestionTime)
+    fn produce_with_ingestion<T: Copy>(&self, d: T, ingestion_t: IngestionTime)
     where
         Self: AsRef<SpineProducer<T>>,
     {
@@ -38,7 +40,7 @@ pub trait SpineProducers {
         self.as_ref().produce_without_first(&msg);
     }
 
-    fn forward<T: Copy>(&mut self, msg: &InternalMessage<T>)
+    fn forward<T: Copy>(&self, msg: &InternalMessage<T>)
     where
         Self: AsRef<SpineProducer<T>>,
     {
@@ -57,6 +59,16 @@ pub trait FluxSpine: Sized + Send {
     fn register_tile(&mut self, name: TileName) -> u16;
     fn app_name() -> &'static str;
     fn base_dir(&self) -> &Path;
+
+    /// Returns a [`StandaloneProducer`] for the queue of message type `T`and
+    /// registers `name` as a tile entry.
+    fn standalone_producer_for<T: Copy>(&mut self, name: TileName) -> StandaloneProducer<T>
+    where
+        Self: AsRef<SpineQueue<T>>,
+    {
+        let id = self.register_tile(name);
+        StandaloneProducer::new(*<Self as AsRef<SpineQueue<T>>>::as_ref(self), id)
+    }
 
     /// Removes all files related to a given spine. Does not clear the shared
     /// memory itself. CAUTION: this includes data files.

--- a/crates/flux/src/spine/standalone_producer.rs
+++ b/crates/flux/src/spine/standalone_producer.rs
@@ -1,0 +1,38 @@
+use flux_timing::{TrackingTimestamp, UNREGISTERED_TILE_ID};
+
+use super::{SpineProducer, SpineProducers, SpineQueue};
+use crate::communication::queue;
+
+#[derive(Debug)]
+pub struct StandaloneProducer<T: 'static + Copy> {
+    producer: SpineProducer<T>,
+    timestamp: TrackingTimestamp,
+}
+
+impl<T: 'static + Copy> StandaloneProducer<T> {
+    pub(super) fn new(queue: SpineQueue<T>, tile_id: u16) -> Self {
+        Self { producer: queue::Producer::from(queue), timestamp: TrackingTimestamp::new(tile_id) }
+    }
+}
+
+impl<T: 'static + Copy> SpineProducers for StandaloneProducer<T> {
+    fn timestamp(&self) -> &TrackingTimestamp {
+        &self.timestamp
+    }
+
+    fn timestamp_mut(&mut self) -> &mut TrackingTimestamp {
+        &mut self.timestamp
+    }
+}
+
+impl<T: 'static + Copy> AsRef<SpineProducer<T>> for StandaloneProducer<T> {
+    fn as_ref(&self) -> &SpineProducer<T> {
+        &self.producer
+    }
+}
+
+impl<T: 'static + Copy> From<SpineQueue<T>> for StandaloneProducer<T> {
+    fn from(queue: SpineQueue<T>) -> Self {
+        Self::new(queue, UNREGISTERED_TILE_ID)
+    }
+}

--- a/crates/flux/tests/spine.rs
+++ b/crates/flux/tests/spine.rs
@@ -134,11 +134,7 @@ fn all_shmem_files_reside_in_base_dir() {
     assert!(data_dir.is_dir(), "data dir should exist: {}", data_dir.display());
 
     let tile_info_file = data_dir.join("TileInfo");
-    assert!(
-        tile_info_file.exists(),
-        "TileInfo shmem should exist at {}",
-        tile_info_file.display()
-    );
+    assert!(tile_info_file.exists(), "TileInfo shmem should exist at {}", tile_info_file.display());
 
     let queue_files: Vec<_> = files
         .iter()

--- a/crates/spine-derive/Cargo.toml
+++ b/crates/spine-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spine-derive"
-version = "0.0.9"
+version = "0.0.10"
 description = "Attribute macro that auto-generates the boilerplate impls for Spine queues."
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/spine-derive/src/lib.rs
+++ b/crates/spine-derive/src/lib.rs
@@ -139,6 +139,7 @@ pub fn from_spine(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let mut as_ref_impls = Vec::<proc_macro2::TokenStream>::new();
     let mut as_mut_impls = Vec::<proc_macro2::TokenStream>::new();
+    let mut spine_as_ref_impls = Vec::<proc_macro2::TokenStream>::new();
     let mut persisting = Vec::<proc_macro2::TokenStream>::new();
     let mut message_types = Vec::<proc_macro2::TokenStream>::new();
 
@@ -159,6 +160,12 @@ pub fn from_spine(attr: TokenStream, item: TokenStream) -> TokenStream {
             as_ref_impls.push(quote! {
                 impl AsRef<::flux::spine::SpineProducer<#inner_ty>> for #producers_ident {
                     fn as_ref(&self)->&::flux::spine::SpineProducer<#inner_ty>{ &self.#field_ident }
+                }
+            });
+
+            spine_as_ref_impls.push(quote! {
+                impl AsRef<::flux::spine::SpineQueue<#inner_ty>> for #struct_ident {
+                    fn as_ref(&self) -> &::flux::spine::SpineQueue<#inner_ty> { &self.#field_ident }
                 }
             });
 
@@ -319,7 +326,7 @@ pub fn from_spine(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
 
         #[derive(Clone, Copy, Debug)]
-        #vis struct #producers_ident { #producer_fields, pub timestamp: ::flux::timing::TrackingTimestamp }
+        #vis struct #producers_ident { #producer_fields, timestamp: ::flux::timing::TrackingTimestamp }
         impl #producers_ident {
             pub fn attach<Tl: ::flux::tile::Tile<#struct_ident>>(tile: &Tl, spine:&mut #struct_ident)->Self {
                 let id = spine.tile_info.register_tile(tile.name());
@@ -337,6 +344,7 @@ pub fn from_spine(attr: TokenStream, item: TokenStream) -> TokenStream {
         // AsRef / AsMut passthroughs + legacy impls
         #(#as_ref_impls)*
         #(#as_mut_impls)*
+        #(#spine_as_ref_impls)*
 
         impl ::flux::spine::FluxSpine for #struct_ident {
             type Consumers = #consumers_ident;


### PR DESCRIPTION
Adding two changes in the same PR because I need both in my current Helix task

StandaloneProducer is a hack for getting access into spine queues for something that cannot be put into a tile - in Helix it's the axum server serving proposer & builder api
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gattaca-com/flux/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
