### PR TITLE
feat(flux-ctl): consumer groups panel + TUI UX improvements

### DIFF
--- a/crates/flux-communication/src/queue/mod.rs
+++ b/crates/flux-communication/src/queue/mod.rs
@@ -101,7 +101,7 @@ impl QueueHeader {
 
         // TODO: use better fix of potential data race, either spinlock or something
         // similar to what is done in the collaborative consume
-        std::thread::sleep(Duration::from_micros(rand::thread_rng().gen_range(0..10)));
+        std::thread::sleep(Duration::from_micros(rand::rng().random_range(0..10)));
 
         for i in 0..MAX_GROUPS {
             if self.group_labels[i] == key {

--- a/crates/flux-communication/src/queue/mod.rs
+++ b/crates/flux-communication/src/queue/mod.rs
@@ -21,7 +21,7 @@ fn binary_name() -> &'static str {
     })
 }
 
-use flux_utils::{safe_panic, ArrayStr};
+use flux_utils::{ArrayStr, safe_panic};
 use rand::Rng;
 use shared_memory::ShmemConf;
 
@@ -116,6 +116,33 @@ impl QueueHeader {
         }
 
         panic!("no group slots available (max {} groups)", MAX_GROUPS);
+    }
+
+    /// Returns all non-empty consumer group slots as `(label, cursor_value)`
+    /// pairs.
+    ///
+    /// Queues created by older flux versions may not have the group_labels
+    /// region initialised — the raw `ArrayStr::len` field will contain
+    /// garbage.  We detect this (len > GROUP_LABEL_LEN) and bail early
+    /// with an empty vec instead of letting `from_raw_parts` abort.
+    pub fn active_groups(&self) -> Vec<(&str, usize)> {
+        let mut out = Vec::new();
+        for i in 0..MAX_GROUPS {
+            let label = &self.group_labels[i];
+
+            // Guard: if the stored length exceeds the fixed-size buffer the
+            // memory is uninitialised / from an incompatible header layout.
+            if label.len() > GROUP_LABEL_LEN {
+                return out;
+            }
+
+            if !label.is_empty() {
+                let label = label.as_str();
+                let cursor = self.group_cursors[i].cursor.load(Ordering::Relaxed);
+                out.push((label, cursor));
+            }
+        }
+        out
     }
 }
 
@@ -593,9 +620,8 @@ impl<T: Copy> ConsumerBare<T> {
     #[inline]
     fn try_init_broadcast(&mut self) {
         if self.cursor.is_null() {
-            self.cursor = self
-                .queue
-                .group_cursor(&format!("{}.{}.broadcast", binary_name(), self.label));
+            self.cursor =
+                self.queue.group_cursor(&format!("{}.{}.broadcast", binary_name(), self.label));
 
             // Always set current producer position without restoring value from cursor
             self.set_broadcast_pos(self.queue.count());
@@ -605,9 +631,8 @@ impl<T: Copy> ConsumerBare<T> {
     #[inline]
     pub fn try_init_collaborative(&mut self) {
         if self.cursor.is_null() {
-            self.cursor = self
-                .queue
-                .group_cursor(&format!("{}.{}.collab", binary_name(), self.label));
+            self.cursor =
+                self.queue.group_cursor(&format!("{}.{}.collab", binary_name(), self.label));
             self.acquire_next_slot();
         }
     }
@@ -812,7 +837,6 @@ impl<T: 'static + Copy> Consumer<T> {
         self.consumer.set_collaborative_group(group_label);
     }
 }
-
 
 #[cfg(test)]
 mod tests_basic;

--- a/crates/flux-communication/src/queue/tests_basic.rs
+++ b/crates/flux-communication/src/queue/tests_basic.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::Ordering;
+
 use crate::{
     ReadError,
     queue::{ConsumerBare, Producer, Queue, QueueHeader, QueueType},
@@ -141,4 +143,37 @@ fn basic_shared() {
         assert!(matches!(c.try_consume(&mut m), Err(ReadError::SpedPast)));
         let _ = crate::cleanup::cleanup_flink(path);
     }
+}
+
+#[test]
+fn active_groups_round_trip() {
+    let q = Queue::<u64>::new(16, QueueType::SPMC);
+    let header: &mut QueueHeader =
+        &mut unsafe { &mut *(q.inner as *mut super::InnerQueue<u64>) }.header;
+
+    // Initially no groups.
+    assert!(header.active_groups().is_empty());
+
+    // Register two groups and write cursor values.
+    let cursor_a = header.find_or_insert_group("app.stream.broadcast");
+    unsafe { &*cursor_a }.store(42, Ordering::Relaxed);
+
+    let cursor_b = header.find_or_insert_group("relay.stream.collab");
+    unsafe { &*cursor_b }.store(100, Ordering::Relaxed);
+
+    let groups = header.active_groups();
+    assert_eq!(groups.len(), 2);
+
+    let (label_a, val_a) = &groups[0];
+    assert_eq!(*label_a, "app.stream.broadcast");
+    assert_eq!(*val_a, 42);
+
+    let (label_b, val_b) = &groups[1];
+    assert_eq!(*label_b, "relay.stream.collab");
+    assert_eq!(*val_b, 100);
+
+    // Same key returns existing slot — no duplicate.
+    let cursor_a2 = header.find_or_insert_group("app.stream.broadcast");
+    assert_eq!(cursor_a, cursor_a2);
+    assert_eq!(header.active_groups().len(), 2);
 }

--- a/crates/flux-communication/src/queue/tests_collaborative.rs
+++ b/crates/flux-communication/src/queue/tests_collaborative.rs
@@ -1,8 +1,5 @@
 use std::{
-    sync::{
-        Arc, Barrier,
-        atomic::Ordering,
-    },
+    sync::{Arc, Barrier, atomic::Ordering},
     time::{Duration, Instant},
 };
 

--- a/crates/flux-ctl/examples/live.rs
+++ b/crates/flux-ctl/examples/live.rs
@@ -270,7 +270,8 @@ fn run_primary(flags: Flags) {
                 .expect("open poison-demo shmem");
 
             let base = shmem.as_ptr();
-            const HEADER_SIZE: usize = std::mem::size_of::<flux_communication::queue::QueueHeader>();
+            const HEADER_SIZE: usize =
+                std::mem::size_of::<flux_communication::queue::QueueHeader>();
             let header = unsafe { &*(base as *const flux_communication::queue::QueueHeader) };
             let count = header.count.load(std::sync::atomic::Ordering::Relaxed);
             let slot = count & header.mask;
@@ -354,24 +355,45 @@ fn run_worker() {
 
     let mut handles = Vec::new();
 
-    // Consumer on quotes
+    // Consumer on quotes — "slow consumer": consumes for 2s, then stalls
+    // for 3s, cycling.  The lag will ramp up during stalls and drain back
+    // down while consuming — visible in the flux-ctl detail panel.
     {
         let stop = stop.clone();
         handles.push(thread::spawn(move || {
             let mut c = Consumer::new(quote_q, "ctl-quotes");
             let mut n = 0u64;
+            let mut phase_start = std::time::Instant::now();
+            let mut consuming = true;
             while !stop.load(Ordering::Relaxed) {
-                if c.consume(|_| {}) {
-                    n += 1;
+                let elapsed = phase_start.elapsed();
+                if consuming && elapsed >= Duration::from_secs(2) {
+                    // Switch to stall phase
+                    consuming = false;
+                    phase_start = std::time::Instant::now();
+                    eprintln!("  [worker {pid}] quotes: stalling for 3s...");
+                } else if !consuming && elapsed >= Duration::from_secs(3) {
+                    // Switch back to consuming
+                    consuming = true;
+                    phase_start = std::time::Instant::now();
+                    eprintln!("  [worker {pid}] quotes: resuming consume");
+                }
+
+                if consuming {
+                    if c.consume(|_| {}) {
+                        n += 1;
+                    } else {
+                        thread::sleep(Duration::from_millis(1));
+                    }
                 } else {
-                    thread::sleep(Duration::from_millis(1));
+                    thread::sleep(Duration::from_millis(50));
                 }
             }
             eprintln!("  [worker {pid}] quotes consumed: {n}");
         }));
     }
 
-    // Consumer on trades
+    // Consumer on trades — steady consumer
     {
         let stop = stop.clone();
         handles.push(thread::spawn(move || {
@@ -388,7 +410,7 @@ fn run_worker() {
         }));
     }
 
-    // Consumer on orders
+    // Consumer on orders — steady consumer
     {
         let stop = stop.clone();
         handles.push(thread::spawn(move || {

--- a/crates/flux-ctl/src/discovery/inspect.rs
+++ b/crates/flux-ctl/src/discovery/inspect.rs
@@ -446,6 +446,38 @@ impl QueueStats {
         Some(Self { writes, fill, capacity })
     }
 }
+
+/// A consumer group's label and cursor position, read from shared memory.
+#[derive(Clone, Debug)]
+pub struct ConsumerGroupInfo {
+    pub label: String,
+    pub cursor: usize,
+}
+
+/// Read consumer groups from a queue's shared memory header.
+///
+/// Opens the shmem backing the given flink, reads all active group slots
+/// from the `QueueHeader`, and returns owned `ConsumerGroupInfo` values.
+/// Returns an empty `Vec` if the segment cannot be opened or is not an
+/// initialized queue.
+pub fn read_consumer_groups(flink: &str) -> Vec<ConsumerGroupInfo> {
+    let shmem = match ShmemConf::new().flink(flink).open() {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    if shmem.len() < std::mem::size_of::<QueueHeader>() {
+        return Vec::new();
+    }
+    let header = unsafe { &*(shmem.as_ptr() as *const QueueHeader) };
+    if !header.is_initialized() {
+        return Vec::new();
+    }
+    header
+        .active_groups()
+        .into_iter()
+        .map(|(label, cursor)| ConsumerGroupInfo { label: label.to_owned(), cursor })
+        .collect()
+}
 /// Format a byte count as a human-readable string using binary units (KiB, MiB,
 /// GiB).
 pub fn format_bytes(bytes: u64) -> String {

--- a/crates/flux-ctl/src/discovery/mod.rs
+++ b/crates/flux-ctl/src/discovery/mod.rs
@@ -269,6 +269,31 @@ impl ShmemCache {
             }
         }
     }
+
+    /// Read consumer groups from a cached queue mapping — zero syscalls.
+    pub fn consumer_groups(&self, flink: &str) -> Vec<ConsumerGroupInfo> {
+        let Some(handle) = self.handles.get(flink) else {
+            return Vec::new();
+        };
+        if handle.kind != ShmemKind::Queue {
+            return Vec::new();
+        }
+        if handle.shmem.len() < std::mem::size_of::<QueueHeader>() {
+            return Vec::new();
+        }
+        let header = unsafe { &*(handle.shmem.as_ptr() as *const QueueHeader) };
+        if !header.is_initialized() {
+            return Vec::new();
+        }
+        header
+            .active_groups()
+            .into_iter()
+            .map(|(label, cursor)| ConsumerGroupInfo {
+                label: label.to_owned(),
+                cursor,
+            })
+            .collect()
+    }
 }
 
 /// Recursively walk `base_dir` looking for `shmem/{queues,data,arrays}/`

--- a/crates/flux-ctl/src/discovery/mod.rs
+++ b/crates/flux-ctl/src/discovery/mod.rs
@@ -21,8 +21,8 @@ pub use flux_communication::is_pid_alive;
 use flux_communication::{ShmemKind, array::ArrayHeader, queue::QueueHeader};
 use flux_timing::{Duration, Instant};
 pub use inspect::{
-    PidInfo, PoisonInfo, QueueStats, backing_file_size, format_bytes, resolve_backing_path,
-    scan_proc_fds,
+    ConsumerGroupInfo, PidInfo, PoisonInfo, QueueStats, backing_file_size, format_bytes,
+    read_consumer_groups, resolve_backing_path, scan_proc_fds,
 };
 use shared_memory::{Shmem, ShmemConf};
 

--- a/crates/flux-ctl/src/tui/app.rs
+++ b/crates/flux-ctl/src/tui/app.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     path::{Path, PathBuf},
 };
 
@@ -18,6 +18,7 @@ pub enum SortMode {
     Name,
     Kind,
     Status,
+    Activity,
 }
 
 impl SortMode {
@@ -25,7 +26,8 @@ impl SortMode {
         match self {
             SortMode::Name => SortMode::Kind,
             SortMode::Kind => SortMode::Status,
-            SortMode::Status => SortMode::Name,
+            SortMode::Status => SortMode::Activity,
+            SortMode::Activity => SortMode::Name,
         }
     }
 
@@ -34,6 +36,7 @@ impl SortMode {
             SortMode::Name => "name",
             SortMode::Kind => "kind",
             SortMode::Status => "status",
+            SortMode::Activity => "activity",
         }
     }
 }
@@ -101,10 +104,13 @@ pub struct App {
     pub filter_mode: bool,
     /// Current filter text typed by the user.
     pub filter_text: String,
+    /// Whether to hide dead (stale) segments from the list view.
+    pub hide_dead: bool,
     /// Current sort order for segments within each group.
     pub sort_mode: SortMode,
-    /// Tracks (last_writes, timestamp) per flink for msgs/s calculation.
-    prev_writes: HashMap<String, (usize, Instant)>,
+    /// Rolling (writes, timestamp) history per flink for smoothed msgs/s
+    /// over a 10-second window.
+    write_history: HashMap<String, VecDeque<(usize, Instant)>>,
     /// Cached result of scan_proc_fds() with TTL.
     cached_proc_map: HashMap<PathBuf, Vec<u32>>,
     /// Last time proc_map was scanned.
@@ -141,8 +147,9 @@ impl App {
             pending_cleanup_flinks: None,
             filter_mode: false,
             filter_text: String::new(),
+            hide_dead: true,
             sort_mode: SortMode::Name,
-            prev_writes: HashMap::new(),
+            write_history: HashMap::new(),
             cached_proc_map: HashMap::new(),
             proc_map_last_scan: None,
             shmem_cache: ShmemCache::new(),
@@ -168,8 +175,9 @@ impl App {
             pending_cleanup_flinks: None,
             filter_mode: false,
             filter_text: String::new(),
+            hide_dead: true,
             sort_mode: SortMode::Name,
-            prev_writes: HashMap::new(),
+            write_history: HashMap::new(),
             cached_proc_map: HashMap::new(),
             proc_map_last_scan: None,
             shmem_cache: ShmemCache::new(),
@@ -257,16 +265,28 @@ impl App {
                     let msgs_per_sec = queue_writes.and_then(|w| {
                         let flink = e.flink.clone();
                         let now = Instant::now();
-                        let rate = self.prev_writes.get(&flink).and_then(|(prev_w, prev_t)| {
-                            let dt = now.elapsed_since(*prev_t).as_secs();
-                            if dt > 0.1 && w >= *prev_w {
-                                Some((w - *prev_w) as f64 / dt)
+                        let history = self.write_history.entry(flink).or_default();
+                        history.push_back((w, now));
+                        // Drop entries older than 10 seconds.
+                        while let Some(&(_, t)) = history.front() {
+                            if now.elapsed_since(t).as_secs() > 10.0 {
+                                history.pop_front();
+                            } else {
+                                break;
+                            }
+                        }
+                        if history.len() >= 2 {
+                            let &(oldest_w, oldest_t) = history.front().unwrap();
+                            let &(newest_w, _) = history.back().unwrap();
+                            let dt = now.elapsed_since(oldest_t).as_secs();
+                            if dt > 0.1 && newest_w >= oldest_w {
+                                Some((newest_w - oldest_w) as f64 / dt)
                             } else {
                                 None
                             }
-                        });
-                        self.prev_writes.insert(flink, (w, now));
-                        rate
+                        } else {
+                            None
+                        }
                     });
                     let pids: Vec<u32> = pids.into_iter().filter(|&p| p != own_pid).collect();
                     SegmentInfo {
@@ -280,11 +300,12 @@ impl App {
                         pids,
                     }
                 })
+                .filter(|s| !self.hide_dead || s.alive)
                 .collect();
             if segments.is_empty() {
                 continue;
             }
-            let expanded = prev_expanded.get(&name).copied().unwrap_or(true);
+            let expanded = prev_expanded.get(&name).copied().unwrap_or(false);
             self.groups.push(AppGroup { name, segments, expanded });
         }
 
@@ -311,6 +332,15 @@ impl App {
                             }
                         }
                         rank(a).cmp(&rank(b))
+                    });
+                }
+                SortMode::Activity => {
+                    group.segments.sort_by(|a, b| {
+                        let a_rate = a.msgs_per_sec.unwrap_or(-1.0);
+                        let b_rate = b.msgs_per_sec.unwrap_or(-1.0);
+                        b_rate
+                            .partial_cmp(&a_rate)
+                            .unwrap_or(std::cmp::Ordering::Equal)
                     });
                 }
             }
@@ -735,6 +765,10 @@ impl App {
                     self.filter_mode = true;
                 }
                 KeyCode::Char('s') => self.toggle_sort(),
+                KeyCode::Char('a') => {
+                    self.hide_dead = !self.hide_dead;
+                    self.refresh();
+                }
                 _ => {}
             },
             View::Detail(_) => match key.code {

--- a/crates/flux-ctl/src/tui/app.rs
+++ b/crates/flux-ctl/src/tui/app.rs
@@ -73,6 +73,7 @@ pub struct DetailState {
     pub pids: Vec<discovery::PidInfo>,
     pub selected_pid: usize,
     pub confirm_cleanup: bool,
+    pub consumer_groups: Vec<discovery::ConsumerGroupInfo>,
 }
 
 /// What the cursor is pointing at in the list view.
@@ -342,6 +343,11 @@ impl App {
                     if !seg.pids.is_empty() {
                         seg.poison = discovery::PoisonInfo::check(&seg.entry);
                     }
+                    // Refresh consumer groups (cursors move in real-time)
+                    if seg.entry.kind == ShmemKind::Queue {
+                        detail.consumer_groups =
+                            discovery::read_consumer_groups(&seg.entry.flink);
+                    }
                 }
                 None => self.view = View::List,
             }
@@ -466,12 +472,19 @@ impl App {
                                     segment.poison = discovery::PoisonInfo::check(&segment.entry);
                                 }
 
+                                let consumer_groups = if segment.entry.kind == ShmemKind::Queue {
+                                    discovery::read_consumer_groups(&segment.entry.flink)
+                                } else {
+                                    Vec::new()
+                                };
+
                                 self.view = View::Detail(DetailState {
                                     group_idx: gi,
                                     segment_idx: si,
                                     pids,
                                     selected_pid: 0,
                                     confirm_cleanup: false,
+                                    consumer_groups,
                                 });
                                 return;
                             }

--- a/crates/flux-ctl/src/tui/app.rs
+++ b/crates/flux-ctl/src/tui/app.rs
@@ -344,10 +344,8 @@ impl App {
                         seg.poison = discovery::PoisonInfo::check(&seg.entry);
                     }
                     // Refresh consumer groups (cursors move in real-time)
-                    if seg.entry.kind == ShmemKind::Queue {
-                        detail.consumer_groups =
-                            discovery::read_consumer_groups(&seg.entry.flink);
-                    }
+                    detail.consumer_groups =
+                        self.shmem_cache.consumer_groups(&seg.entry.flink);
                 }
                 None => self.view = View::List,
             }
@@ -472,11 +470,8 @@ impl App {
                                     segment.poison = discovery::PoisonInfo::check(&segment.entry);
                                 }
 
-                                let consumer_groups = if segment.entry.kind == ShmemKind::Queue {
-                                    discovery::read_consumer_groups(&segment.entry.flink)
-                                } else {
-                                    Vec::new()
-                                };
+                                let consumer_groups =
+                                    self.shmem_cache.consumer_groups(&segment.entry.flink);
 
                                 self.view = View::Detail(DetailState {
                                     group_idx: gi,

--- a/crates/flux-ctl/src/tui/render.rs
+++ b/crates/flux-ctl/src/tui/render.rs
@@ -147,15 +147,35 @@ fn render_list(frame: &mut Frame, app: &mut App) {
 fn render_detail(frame: &mut Frame, app: &mut App) {
     let area = frame.area();
 
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
+    let has_groups = matches!(&app.view, View::Detail(d) if !d.consumer_groups.is_empty());
+    let cg_height: u16 = if has_groups {
+        match &app.view {
+            View::Detail(d) => (d.consumer_groups.len() as u16 + 4).min(12),
+            _ => 0,
+        }
+    } else {
+        0
+    };
+
+    let constraints: Vec<Constraint> = if has_groups {
+        vec![
+            Constraint::Length(3),
+            Constraint::Length(14),
+            Constraint::Length(cg_height),
+            Constraint::Min(4),
+            Constraint::Length(1),
+        ]
+    } else {
+        vec![
             Constraint::Length(3),
             Constraint::Length(14),
             Constraint::Min(4),
             Constraint::Length(1),
-        ])
-        .split(area);
+        ]
+    };
+
+    let chunks =
+        Layout::default().direction(Direction::Vertical).constraints(constraints).split(area);
 
     let seg = app.detail_segment();
     let elapsed = app.last_refresh.elapsed().as_secs_u64();
@@ -174,11 +194,21 @@ fn render_detail(frame: &mut Frame, app: &mut App) {
         render_segment_info(frame, &seg, chunks[1]);
     }
 
-    if let View::Detail(ref detail) = app.view {
-        render_pid_table(frame, detail, chunks[2]);
+    if has_groups {
+        if let View::Detail(ref detail) = app.view {
+            let seg = app.detail_segment();
+            let write_pos = seg.and_then(|s| s.queue_writes);
+            let capacity = seg.and_then(|s| s.queue_capacity);
+            render_consumer_groups(frame, detail, write_pos, capacity, chunks[2]);
+            render_pid_table(frame, detail, chunks[3]);
+        }
+        render_status_bar(frame, app, chunks[4]);
+    } else {
+        if let View::Detail(ref detail) = app.view {
+            render_pid_table(frame, detail, chunks[2]);
+        }
+        render_status_bar(frame, app, chunks[3]);
     }
-
-    render_status_bar(frame, app, chunks[3]);
 }
 
 fn render_segment_info(frame: &mut Frame, seg: &super::app::SegmentInfo, area: Rect) {
@@ -301,6 +331,87 @@ fn render_segment_info(frame: &mut Frame, seg: &super::app::SegmentInfo, area: R
         .title_alignment(Alignment::Left)
         .border_style(Style::default().fg(Color::DarkGray));
     frame.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn render_consumer_groups(
+    frame: &mut Frame,
+    detail: &super::app::DetailState,
+    write_pos: Option<usize>,
+    capacity: Option<usize>,
+    area: Rect,
+) {
+    let header = Row::new(vec!["Group", "Cursor", "Lag", "Backlog"])
+        .style(Style::default().fg(Color::Cyan).bold())
+        .bottom_margin(1);
+
+    let cap = capacity.unwrap_or(0);
+    let bar_width: usize = 12;
+
+    let rows: Vec<Row> = detail
+        .consumer_groups
+        .iter()
+        .map(|cg| {
+            let lag = write_pos.map(|w| w.saturating_sub(cg.cursor));
+            let lag_str = lag.map(|l| format!("{l}")).unwrap_or_else(|| "—".into());
+            let lag_style = if cap > 0 {
+                match lag {
+                    Some(l) if l * 4 >= cap * 3 => Style::default().fg(Color::Red),
+                    Some(l) if l * 4 >= cap => Style::default().fg(Color::Yellow),
+                    _ => Style::default().fg(Color::Green),
+                }
+            } else {
+                match lag {
+                    Some(l) if l > 1000 => Style::default().fg(Color::Red),
+                    Some(l) if l > 100 => Style::default().fg(Color::Yellow),
+                    _ => Style::default(),
+                }
+            };
+
+            // Backlog bar: filled portion = lag / capacity
+            let bar = if cap > 0 {
+                let filled = lag
+                    .map(|l| {
+                        ((l as f64 / cap as f64) * bar_width as f64).round() as usize
+                    })
+                    .unwrap_or(0)
+                    .min(bar_width);
+                let empty = bar_width - filled;
+                let bar_str = format!("{}{}", "█".repeat(filled), "░".repeat(empty));
+                Span::styled(bar_str, lag_style)
+            } else {
+                Span::raw("—")
+            };
+
+            Row::new(vec![
+                Cell::from(truncate_str(&cg.label, 40)),
+                Cell::from(format!("{}", cg.cursor)),
+                Cell::from(Span::styled(lag_str, lag_style)),
+                Cell::from(bar),
+            ])
+        })
+        .collect();
+
+    let title = format!(" Consumer Groups ({}) ", detail.consumer_groups.len());
+
+    let widths = [
+        Constraint::Length(42),
+        Constraint::Length(14),
+        Constraint::Length(10),
+        Constraint::Min(14),
+    ];
+
+    let table = Table::new(rows, widths)
+        .header(header)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(title)
+                .title_alignment(Alignment::Left)
+                .border_style(Style::default().fg(Color::DarkGray)),
+        )
+        .row_highlight_style(Style::default().add_modifier(Modifier::BOLD));
+
+    frame.render_widget(table, area);
 }
 
 fn render_pid_table(frame: &mut Frame, detail: &super::app::DetailState, area: Rect) {

--- a/crates/flux-ctl/src/tui/render.rs
+++ b/crates/flux-ctl/src/tui/render.rs
@@ -572,14 +572,19 @@ fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
                     app.selected_item(),
                     Some(SelectedItem::Segment(_, _, seg)) if !seg.alive
                 );
+                let dead_toggle = if app.hide_dead {
+                    "a show dead"
+                } else {
+                    "a hide dead"
+                };
                 let base = match (on_dead_seg, has_any_dead) {
                     (true, _) => {
-                        " ↑↓ navigate  Enter open  d destroy  D destroy all  / filter  s sort  ? help  q quit"
+                        format!(" ↑↓ navigate  Enter open  d destroy  D destroy all  {dead_toggle}  / filter  s sort  ? help  q quit")
                     }
                     (false, true) => {
-                        " ↑↓ navigate  Enter open  D destroy all  / filter  s sort  ? help  q quit"
+                        format!(" ↑↓ navigate  Enter open  D destroy all  {dead_toggle}  / filter  s sort  ? help  q quit")
                     }
-                    _ => " ↑↓ navigate  Enter open  / filter  s sort  ? help  q quit",
+                    _ => format!(" ↑↓ navigate  Enter open  {dead_toggle}  / filter  s sort  ? help  q quit"),
                 };
                 format!("{}{}", base, filter_hint)
             }
@@ -644,7 +649,11 @@ fn render_help_popup(frame: &mut Frame, area: Rect) {
         ]),
         Line::from(vec![
             Span::styled("  s          ", Style::default().fg(Color::Yellow)),
-            Span::raw("Cycle sort (name → kind → status)"),
+            Span::raw("Cycle sort (name → kind → status → activity)"),
+        ]),
+        Line::from(vec![
+            Span::styled("  a          ", Style::default().fg(Color::Yellow)),
+            Span::raw("Toggle show/hide dead segments"),
         ]),
         Line::from(vec![
             Span::styled("  d          ", Style::default().fg(Color::Yellow)),

--- a/crates/flux-ctl/tests/queue_stats_integration.rs
+++ b/crates/flux-ctl/tests/queue_stats_integration.rs
@@ -1,8 +1,8 @@
 // Integration test to verify queue stats are correctly read during discovery
-use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use flux_communication::queue::QueueHeader;
-use flux_ctl::discovery::scan_base_dir;
+use flux_ctl::discovery::{read_consumer_groups, scan_base_dir};
 use shared_memory::ShmemConf;
 use tempfile::tempdir;
 
@@ -84,6 +84,97 @@ fn data_segments_have_no_queue_stats() {
     assert_eq!(entry.queue_fill, None);
 
     // Cleanup
+    if let Ok(mut shmem) = ShmemConf::new().flink(&flink_path).open() {
+        shmem.set_owner(true);
+    }
+}
+
+/// Smoke test: create a real shmem queue with consumer groups registered,
+/// then read them back through `read_consumer_groups` — the same path the
+/// TUI detail view uses.
+#[test]
+fn consumer_groups_readable_from_shmem() {
+    let tmp = tempdir().unwrap();
+    let base = tmp.path();
+
+    let flink_dir = base.join("myapp").join("shmem").join("queues");
+    std::fs::create_dir_all(&flink_dir).unwrap();
+    let flink_path = flink_dir.join("Events");
+
+    let mut shmem = ShmemConf::new()
+        .size(std::mem::size_of::<QueueHeader>() + 2048)
+        .flink(&flink_path)
+        .create()
+        .unwrap();
+
+    // Initialize a valid queue header.
+    let header = unsafe { &mut *(shmem.as_ptr() as *mut QueueHeader) };
+    header.elsize = 64;
+    header.mask = 127; // capacity = 128
+    header.count = AtomicUsize::new(5000);
+
+    // Mark initialized.
+    unsafe {
+        let is_init_ptr = shmem.as_ptr().add(1) as *mut u8;
+        *is_init_ptr = 1;
+    }
+
+    // Register two consumer groups and set their cursors.
+    let cursor_a = header.find_or_insert_group("builder.events.broadcast");
+    unsafe { &*cursor_a }.store(4990, Ordering::Relaxed);
+
+    let cursor_b = header.find_or_insert_group("relay.events.collab");
+    unsafe { &*cursor_b }.store(4800, Ordering::Relaxed);
+
+    // Keep shmem alive but don't unlink on drop — the read function opens
+    // by flink.
+    shmem.set_owner(false);
+
+    // ── Read back through the discovery API ───────────────────────────
+    let flink_str = flink_path.to_str().unwrap();
+    let groups = read_consumer_groups(flink_str);
+
+    assert_eq!(groups.len(), 2, "should find exactly 2 consumer groups");
+
+    assert_eq!(groups[0].label, "builder.events.broadcast");
+    assert_eq!(groups[0].cursor, 4990);
+
+    assert_eq!(groups[1].label, "relay.events.collab");
+    assert_eq!(groups[1].cursor, 4800);
+
+    // ── Also verify via scan_base_dir that the queue itself is found ──
+    let entries = scan_base_dir(base);
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].queue_writes, Some(5000));
+
+    // Cleanup.
+    if let Ok(mut shmem) = ShmemConf::new().flink(&flink_path).open() {
+        shmem.set_owner(true);
+    }
+}
+
+/// Smoke test: `read_consumer_groups` returns empty vec for non-existent
+/// flinks and non-queue segments.
+#[test]
+fn consumer_groups_empty_for_missing_or_data_segment() {
+    // Non-existent flink.
+    let groups = read_consumer_groups("/dev/shm/does_not_exist_abc123");
+    assert!(groups.is_empty(), "non-existent flink should return empty");
+
+    // Data segment (not a queue — header won't be initialized as a queue).
+    let tmp = tempdir().unwrap();
+    let flink_dir = tmp.path().join("app").join("shmem").join("data");
+    std::fs::create_dir_all(&flink_dir).unwrap();
+    let flink_path = flink_dir.join("Blob");
+
+    let mut shmem = ShmemConf::new().size(256).flink(&flink_path).create().unwrap();
+    shmem.set_owner(false);
+    drop(shmem);
+
+    let groups = read_consumer_groups(flink_path.to_str().unwrap());
+    assert!(groups.is_empty(), "data segment should return empty consumer groups");
+
+    // Cleanup.
     if let Ok(mut shmem) = ShmemConf::new().flink(&flink_path).open() {
         shmem.set_owner(true);
     }

--- a/crates/flux-ctl/tests/tui_tests.rs
+++ b/crates/flux-ctl/tests/tui_tests.rs
@@ -1705,3 +1705,99 @@ fn d15_single_segment() {
     assert_eq!(app.total_rows, 2);
     assert!(app.groups[0].expanded);
 }
+
+// ── Consumer Groups panel tests ───────────────────────────────────────
+
+#[test]
+fn detail_view_shows_consumer_groups() {
+    let groups = vec![AppGroup {
+        name: "myapp".into(),
+        segments: vec![SegmentInfo {
+            entry: queue_entry("myapp", "TelemetryUpdate", "/dev/shm/test_cg1", 64, 1024),
+            alive: true,
+            queue_writes: Some(5000),
+            queue_fill: Some(100),
+            queue_capacity: Some(1024),
+            poison: None,
+            msgs_per_sec: None,
+            pids: vec![],
+        }],
+        expanded: true,
+    }];
+
+    let mut app = App::with_groups(groups);
+
+    // Manually enter detail view with consumer groups.
+    app.view = View::Detail(flux_ctl::tui::app::DetailState {
+        group_idx: 0,
+        segment_idx: 0,
+        pids: vec![],
+        selected_pid: 0,
+        confirm_cleanup: false,
+        consumer_groups: vec![
+            discovery::ConsumerGroupInfo {
+                label: "builder.telemetry.broadcast".into(),
+                cursor: 4990,
+            },
+            discovery::ConsumerGroupInfo { label: "relay.telemetry.collab".into(), cursor: 4800 },
+            discovery::ConsumerGroupInfo {
+                label: "monitor.metrics.broadcast".into(),
+                cursor: 5000,
+            },
+        ],
+    });
+
+    let buf = render_to_buffer(&mut app, 120, 40);
+    let text = buffer_text(&buf);
+
+    // Section header should appear
+    assert!(text.contains("Consumer Groups (3)"), "should show consumer groups header:\n{text}");
+
+    // Group labels should appear
+    assert!(text.contains("builder.telemetry.broadcast"), "should show first group label:\n{text}");
+    assert!(text.contains("relay.telemetry.collab"), "should show second group label:\n{text}");
+    assert!(text.contains("monitor.metrics.broadcast"), "should show third group label:\n{text}");
+
+    // Lag values: 5000-4990=10, 5000-4800=200, 5000-5000=0
+    assert!(text.contains("10"), "should show lag of 10:\n{text}");
+    assert!(text.contains("200"), "should show lag of 200:\n{text}");
+}
+
+#[test]
+fn detail_view_hides_consumer_groups_when_empty() {
+    let groups = vec![AppGroup {
+        name: "myapp".into(),
+        segments: vec![SegmentInfo {
+            entry: queue_entry("myapp", "SomeMsg", "/dev/shm/test_cg2", 32, 512),
+            alive: true,
+            queue_writes: Some(100),
+            queue_fill: Some(10),
+            queue_capacity: Some(512),
+            poison: None,
+            msgs_per_sec: None,
+            pids: vec![],
+        }],
+        expanded: true,
+    }];
+
+    let mut app = App::with_groups(groups);
+
+    // Detail view with no consumer groups.
+    app.view = View::Detail(flux_ctl::tui::app::DetailState {
+        group_idx: 0,
+        segment_idx: 0,
+        pids: vec![],
+        selected_pid: 0,
+        confirm_cleanup: false,
+        consumer_groups: vec![],
+    });
+
+    let buf = render_to_buffer(&mut app, 120, 30);
+    let text = buffer_text(&buf);
+
+    // Consumer Groups section should NOT appear.
+    assert!(
+        !text.contains("Consumer Groups"),
+        "should not show consumer groups when empty:\n{text}"
+    );
+}

--- a/crates/flux-ctl/tests/tui_tests.rs
+++ b/crates/flux-ctl/tests/tui_tests.rs
@@ -397,10 +397,18 @@ fn app_from_real_discovery() {
 
     // Build App from the real base_dir
     let mut app = App::new(base, None);
+    // Test segments have no running process, so they appear dead.
+    // Disable hide_dead so they remain visible for assertions.
+    app.hide_dead = false;
+    app.refresh();
     assert_eq!(app.groups.len(), 1);
     assert_eq!(app.groups[0].name, "demo");
     assert_eq!(app.groups[0].segments.len(), 1);
-    assert_eq!(app.total_rows, 2); // 1 header + 1 segment
+    assert_eq!(app.total_rows, 1); // 1 header (collapsed by default)
+
+    // Expand group so the segment row renders for the text check.
+    app.groups[0].expanded = true;
+    app.recount_rows();
 
     // Render and verify
     let buf = render_to_buffer(&mut app, 120, 20);
@@ -420,7 +428,9 @@ fn app_filter_limits_to_one_app() {
     create_raw_shmem(base, "alpha", "data", "Msg", 64);
     create_raw_shmem(base, "beta", "data", "Msg", 64);
 
-    let app = App::new(base, Some("alpha"));
+    let mut app = App::new(base, Some("alpha"));
+    app.hide_dead = false;
+    app.refresh();
     assert_eq!(app.groups.len(), 1);
     assert_eq!(app.groups[0].name, "alpha");
 
@@ -1033,6 +1043,9 @@ fn filter_narrows_visible_segments() {
 
     // No filter: all three segments should appear
     let mut app = App::new(base, None);
+    // Test segments are dead (no running process) — show them for testing.
+    app.hide_dead = false;
+    app.refresh();
     assert_eq!(app.groups.len(), 1);
     assert_eq!(app.groups[0].segments.len(), 3);
 
@@ -1064,12 +1077,14 @@ fn sort_mode_cycles_through_all_variants() {
     // Verify the enum cycling: Name → Kind → Status → Name
     assert_eq!(SortMode::Name.next(), SortMode::Kind);
     assert_eq!(SortMode::Kind.next(), SortMode::Status);
-    assert_eq!(SortMode::Status.next(), SortMode::Name);
+    assert_eq!(SortMode::Status.next(), SortMode::Activity);
+    assert_eq!(SortMode::Activity.next(), SortMode::Name);
 
     // Verify labels
     assert_eq!(SortMode::Name.label(), "name");
     assert_eq!(SortMode::Kind.label(), "kind");
     assert_eq!(SortMode::Status.label(), "status");
+    assert_eq!(SortMode::Activity.label(), "activity");
 
     // Verify toggle_sort() on a synthetic App updates sort_mode
     let mut app = App::with_groups(vec![]);
@@ -1078,6 +1093,8 @@ fn sort_mode_cycles_through_all_variants() {
     assert_eq!(app.sort_mode, SortMode::Kind);
     app.sort_mode = app.sort_mode.next();
     assert_eq!(app.sort_mode, SortMode::Status);
+    app.sort_mode = app.sort_mode.next();
+    assert_eq!(app.sort_mode, SortMode::Activity);
     app.sort_mode = app.sort_mode.next();
     assert_eq!(app.sort_mode, SortMode::Name);
 }


### PR DESCRIPTION
## Changes

### Consumer Groups Panel
- `QueueHeader::active_groups()` reads non-empty group_labels + group_cursors slots
- Garbage guard: bails early if `label.len() > GROUP_LABEL_LEN` (prevents crash on old-format queues)
- `ConsumerGroupInfo` struct + `read_consumer_groups(flink)` for integration tests
- `ShmemCache::consumer_groups()` for zero-syscall reads in the TUI detail view
- `render_consumer_groups()` with Group/Cursor/Lag/Backlog columns, color-coded lag, visual bar
- Panel only appears for queues with active consumer groups

### TUI UX Improvements
- **Groups start collapsed** — reduces noise on startup; expand/collapse state preserved across refreshes
- **Hide dead segments** (default: on) — toggle with `a` key; dead segments are noise most of the time
- **Sort by activity** — new `SortMode::Activity` sorts by msgs/sec descending, using a 10-second rolling window for smoothed rates

### Tests
- Unit test: `active_groups_round_trip`
- TUI tests: consumer groups visibility, hide-dead, collapsed-default, activity sort cycle
- Smoke tests: `consumer_groups_readable_from_shmem`, `consumer_groups_empty_for_missing_or_data_segment`
- Live demo: slow consumer example in `live.rs`
