### PR TITLE
feat(queue): add Queue::try_open_shared returning Result instead of panicking

### DIFF
--- a/crates/flux-communication/src/queue/mod.rs
+++ b/crates/flux-communication/src/queue/mod.rs
@@ -516,6 +516,15 @@ impl<T: Copy> Queue<T> {
         }
     }
 
+    /// Open an existing shared-memory queue, returning an error instead of
+    /// panicking if the queue is invalid (e.g. poisoned, wrong element size).
+    pub fn try_open_shared<P: AsRef<Path>>(shmem_file: P) -> Result<Self, QueueError> {
+        let shmem_file = shmem_file.as_ref();
+        Ok(Self {
+            inner: InnerQueue::open_shared(shmem_file)?,
+        })
+    }
+
     /// Size in bytes of the queue region for `len` slots
     pub(crate) fn byte_size(len: usize) -> usize {
         InnerQueue::<T>::size_of(len)


### PR DESCRIPTION
## Problem

`Queue::open_shared()` calls `.expect()` on the result of `InnerQueue::open_shared()`, which panics if the queue is invalid (e.g. poisoned elements from a crashed writer, wrong element size). This makes it impossible for consumers to handle invalid queues gracefully.

The overseer hits this on startup when stale queues exist from a crashed builder:
```
thread 'main' panicked at queue/mod.rs:515:18:
Couldn't open shared queue, was it initialized?: ElementPoisoned(70)
```

## Solution

Add `Queue::try_open_shared()` — same logic as `open_shared()` but returns `Result<Self, QueueError>` instead of panicking. This lets consumers (like the overseer) skip or retry poisoned queues gracefully.

`open_shared()` is left unchanged for backward compatibility.

## Changes
- `crates/flux-communication/src/queue/mod.rs` — 9 lines added
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gattaca-com/flux/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
