### PR TITLE
fix: replace open_shared with try_open_shared in flux-ctl and flux-timekeeper

### DIFF
--- a/crates/flux-communication/src/queue/mod.rs
+++ b/crates/flux-communication/src/queue/mod.rs
@@ -520,9 +520,7 @@ impl<T: Copy> Queue<T> {
     /// panicking if the queue is invalid (e.g. poisoned, wrong element size).
     pub fn try_open_shared<P: AsRef<Path>>(shmem_file: P) -> Result<Self, QueueError> {
         let shmem_file = shmem_file.as_ref();
-        Ok(Self {
-            inner: InnerQueue::open_shared(shmem_file)?,
-        })
+        Ok(Self { inner: InnerQueue::open_shared(shmem_file)? })
     }
 
     /// Size in bytes of the queue region for `len` slots

--- a/crates/flux-ctl/src/tui/render.rs
+++ b/crates/flux-ctl/src/tui/render.rs
@@ -962,27 +962,18 @@ pub fn render_help_popup(area: Rect, buf: &mut Buffer, tab: FluxTab) {
                 " Apps tab ",
                 Style::default().fg(Color::Cyan).bold(),
             )));
-            lines.push(Line::from(vec![
-                key("Enter"),
-                Span::raw("Open segment / toggle app group"),
-            ]));
-            lines.push(Line::from(vec![
-                key("Esc / Bksp"),
-                Span::raw("Back / clear filter / quit"),
-            ]));
+            lines
+                .push(Line::from(vec![key("Enter"), Span::raw("Open segment / toggle app group")]));
+            lines
+                .push(Line::from(vec![key("Esc / Bksp"), Span::raw("Back / clear filter / quit")]));
             lines.push(Line::from(vec![key("/"), Span::raw("Filter segments by name")]));
             lines.push(Line::from(vec![
                 key("s"),
                 Span::raw("Cycle sort (name → kind → status → activity)"),
             ]));
-            lines.push(Line::from(vec![
-                key("a"),
-                Span::raw("Toggle show/hide dead segments"),
-            ]));
-            lines.push(Line::from(vec![
-                key("Tab"),
-                Span::raw("Switch focus (groups ↔ processes)"),
-            ]));
+            lines.push(Line::from(vec![key("a"), Span::raw("Toggle show/hide dead segments")]));
+            lines
+                .push(Line::from(vec![key("Tab"), Span::raw("Switch focus (groups ↔ processes)")]));
             lines.push(Line::from(vec![key("d"), Span::raw("Destroy dead segment")]));
             lines.push(Line::from(vec![key("D"), Span::raw("Destroy all dead segments")]));
             lines.push(Line::from(vec![key("r"), Span::raw("Force refresh")]));

--- a/crates/flux-ctl/src/tui/tile_metrics.rs
+++ b/crates/flux-ctl/src/tui/tile_metrics.rs
@@ -152,10 +152,9 @@ impl TileGroup {
                 continue;
             }
 
-            // Open may panic on corrupted shmem — catch it.
-            let Ok(queue) = std::panic::catch_unwind(|| Queue::<TileSample>::open_shared(&path))
-            else {
-                continue;
+            let queue = match Queue::<TileSample>::try_open_shared(&path) {
+                Ok(q) => q,
+                Err(_) => continue,
             };
 
             let consumer = Consumer::new(queue, "flux-ctl-tile").without_log();

--- a/crates/flux-timekeeper/src/data/tile_metrics.rs
+++ b/crates/flux-timekeeper/src/data/tile_metrics.rs
@@ -148,9 +148,9 @@ impl TileMetricsView {
                 continue;
             }
 
-            let Ok(queue) = std::panic::catch_unwind(|| Queue::<TileSample>::open_shared(&path))
-            else {
-                continue;
+            let queue = match Queue::<TileSample>::try_open_shared(&path) {
+                Ok(q) => q,
+                Err(_) => continue,
             };
 
             let consumer = Consumer::new(queue, "tile-metrics").without_log();

--- a/crates/flux-timekeeper/src/timekeeper.rs
+++ b/crates/flux-timekeeper/src/timekeeper.rs
@@ -604,9 +604,16 @@ impl TimeKeeper {
             let name = entry.path().as_os_str().to_str().unwrap().to_string();
             if let Some((_dir, real_name)) = name.split_once("latency-") {
                 if !self.timer_data.contains(real_name) {
-                    let latency_q = Queue::open_shared(format!("{queues_dir}/latency-{real_name}"));
+                    let latency_q =
+                        match Queue::try_open_shared(format!("{queues_dir}/latency-{real_name}")) {
+                            Ok(q) => q,
+                            Err(_) => continue,
+                        };
                     let processing_q =
-                        Queue::open_shared(format!("{queues_dir}/timing-{real_name}"));
+                        match Queue::try_open_shared(format!("{queues_dir}/timing-{real_name}")) {
+                            Ok(q) => q,
+                            Err(_) => continue,
+                        };
 
                     // only display queues that have entries
                     if latency_q.count() == 0 && processing_q.count() == 0 {


### PR DESCRIPTION
## Problem

Several consumer-side call sites still use `Queue::open_shared()` (which panics on corrupted/stale queues) or wrap it in `catch_unwind` as a band-aid. These should use `try_open_shared()` (added in #59) for graceful error handling.

## Changes

- **`flux-ctl/src/tui/tile_metrics.rs`** — `TileMetricsStore::tick`: replace `catch_unwind(open_shared)` with `try_open_shared`
- **`flux-timekeeper/src/timekeeper.rs`** — timing queue discovery: replace 2 bare `open_shared` calls with `try_open_shared`
- **`flux-timekeeper/src/data/tile_metrics.rs`** — tile metrics discovery: replace `catch_unwind(open_shared)` with `try_open_shared`

All sites now skip invalid queues gracefully instead of panicking.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gattaca-com/flux/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
