### PR TITLE
fix(tcp): auto-grow epoll event buffer to prevent connection starvation

### DIFF
--- a/crates/flux-network/src/tcp/connector.rs
+++ b/crates/flux-network/src/tcp/connector.rs
@@ -4,7 +4,7 @@ use flux::spine::{SpineProducerWithDCache, SpineProducers};
 use flux_timing::{Duration, Instant, Nanos, Repeater};
 use flux_utils::{DCachePtr, safe_panic};
 use mio::{Events, Interest, Poll, Token, event::Event, net::TcpListener};
-use tracing::{debug, error, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::tcp::{
     ConnState, TcpStream, TcpTelemetry,
@@ -61,6 +61,7 @@ struct ConnectionManager {
     telemetry: TcpTelemetry,
     socket_buf_size: Option<usize>,
     user_timeout_ms: u32,
+    nodelay: bool,
     dcache: Option<DCachePtr>,
     /// When set, connections whose send backlog exceeds `max` messages for
     /// longer than `timeout` are disconnected (outbound scheduled for
@@ -82,6 +83,7 @@ impl Default for ConnectionManager {
             telemetry: TcpTelemetry::Disabled,
             socket_buf_size: None,
             user_timeout_ms: DEFAULT_TCP_USER_TIMEOUT_MS,
+            nodelay: true,
             dcache: None,
             max_backlog: None,
             to_be_reconnected: Vec::with_capacity(10),
@@ -305,7 +307,7 @@ impl ConnectionManager {
             return None;
         };
         new_stream
-            .set_nodelay(true)
+            .set_nodelay(self.nodelay)
             .inspect_err(|e| {
                 error!("couldn't setup nodelay for tcp stream for {addr}: {e}");
             })
@@ -385,6 +387,7 @@ impl ConnectionManager {
                         if let Some(size) = self.socket_buf_size {
                             set_socket_buf_size(&stream, size);
                         }
+                        set_user_timeout(&stream, self.user_timeout_ms);
                         let token = Token(self.next_token);
                         if let Err(e) =
                             self.poll.registry().register(&mut stream, token, Interest::READABLE)
@@ -393,7 +396,7 @@ impl ConnectionManager {
                             let _ = stream.shutdown(std::net::Shutdown::Both);
                             continue;
                         };
-                        if let Err(e) = stream.set_nodelay(true) {
+                        if let Err(e) = stream.set_nodelay(self.nodelay) {
                             error!("couldn't set nodelay on stream to {addr}: {e}");
                             continue;
                         }
@@ -470,6 +473,7 @@ impl ConnectionManager {
                         if let Some(size) = self.socket_buf_size {
                             set_socket_buf_size(&stream, size);
                         }
+                        set_user_timeout(&stream, self.user_timeout_ms);
                         let token = Token(self.next_token);
                         if let Err(e) =
                             self.poll.registry().register(&mut stream, token, Interest::READABLE)
@@ -478,7 +482,7 @@ impl ConnectionManager {
                             let _ = stream.shutdown(std::net::Shutdown::Both);
                             continue;
                         };
-                        if let Err(e) = stream.set_nodelay(true) {
+                        if let Err(e) = stream.set_nodelay(self.nodelay) {
                             error!("couldn't set nodelay on stream to {addr}: {e}");
                             continue;
                         }
@@ -549,10 +553,11 @@ impl ConnectionManager {
 pub struct TcpConnector {
     events: Events,
     conn_mgr: ConnectionManager,
+    event_capacity: usize,
 }
 impl Default for TcpConnector {
     fn default() -> Self {
-        Self { events: Events::with_capacity(128), conn_mgr: ConnectionManager::default() }
+        Self { events: Events::with_capacity(128), conn_mgr: ConnectionManager::default(), event_capacity: 128 }
     }
 }
 impl TcpConnector {
@@ -598,10 +603,19 @@ impl TcpConnector {
         self
     }
 
-    /// Overrides the TCP_USER_TIMEOUT socket option applied to
-    /// outbound connections.
+    /// Overrides the TCP_USER_TIMEOUT socket option applied to all
+    /// connections (outbound, reconnected, and accepted inbound).
     pub fn with_user_timeout(mut self, timeout_ms: u32) -> Self {
         self.conn_mgr.user_timeout_ms = timeout_ms;
+        self
+    }
+
+    /// Sets TCP_NODELAY on all connections. Default: `true` (Nagle disabled).
+    ///
+    /// Set to `false` to allow Nagle's algorithm to coalesce small writes,
+    /// which can improve throughput at the cost of latency.
+    pub fn with_nodelay(mut self, nodelay: bool) -> Self {
+        self.conn_mgr.nodelay = nodelay;
         self
     }
 
@@ -617,6 +631,29 @@ impl TcpConnector {
     pub fn with_max_backlog(mut self, max: usize, timeout: Duration) -> Self {
         self.conn_mgr.max_backlog = Some((max, timeout));
         self
+    }
+
+    /// Sets the initial epoll event buffer capacity.
+    ///
+    /// The buffer auto-grows (doubles) whenever a `poll()` fills the current
+    /// capacity, so this only affects the starting size. Default: 128.
+    pub fn with_event_capacity(mut self, capacity: usize) -> Self {
+        self.event_capacity = capacity;
+        self.events = Events::with_capacity(capacity);
+        self
+    }
+
+    /// If the last `poll()` returned exactly `event_capacity` events, double
+    /// the buffer to avoid starving connections that didn't fit.
+    fn maybe_grow_events(&mut self, n_events: usize) {
+        // mio returns at most `capacity` events; hitting the limit means
+        // there were likely more fds ready than we could service.
+        if n_events >= self.event_capacity {
+            let new_cap = self.event_capacity * 2;
+            info!(old = self.event_capacity, new = new_cap, "epoll event buffer full, growing");
+            self.event_capacity = new_cap;
+            self.events = Events::with_capacity(new_cap);
+        }
     }
 
     /// Polls sockets once (non-blocking) and dispatches events via
@@ -640,14 +677,15 @@ impl TcpConnector {
             safe_panic!("got error polling {e}");
             return false;
         }
-        let mut o = false;
+        let mut n_events = 0usize;
 
         for e in self.events.iter() {
-            o = true;
+            n_events += 1;
             self.conn_mgr.handle_event(e, &mut handler);
         }
+        self.maybe_grow_events(n_events);
         self.conn_mgr.flush_backlogs();
-        o
+        n_events > 0
     }
 
     /// Like [`poll_with`] but for dcache-backed streams. The handler receives
@@ -671,13 +709,14 @@ impl TcpConnector {
             safe_panic!("got error polling {e}");
             return false;
         }
-        let mut o = false;
+        let mut n_events = 0usize;
         for e in self.events.iter() {
-            o = true;
+            n_events += 1;
             self.conn_mgr.handle_event_produce(e, produce, &mut on_msg);
         }
+        self.maybe_grow_events(n_events);
         self.conn_mgr.flush_backlogs();
-        o
+        n_events > 0
     }
 
     /// Writes immediately or enqueues bytes for later sending.

--- a/crates/flux-network/src/tcp/stream.rs
+++ b/crates/flux-network/src/tcp/stream.rs
@@ -430,7 +430,14 @@ impl TcpStream {
                 RxState::ReadingHeader { mut buf, mut have } => {
                     while have < FRAME_HEADER_SIZE {
                         match self.stream.read(&mut buf[have..]) {
-                            Ok(0) => return ReadOutcome::Disconnected,
+                            Ok(0) => {
+                                debug!(
+                                    peer = %self.peer_addr,
+                                    have,
+                                    "tcp: connection closed by peer (reading header)",
+                                );
+                                return ReadOutcome::Disconnected;
+                            }
 
                             Ok(n) => {
                                 have += n;
@@ -511,7 +518,15 @@ impl TcpStream {
                             self.stream.read(&mut buf[offset..msg_len])
                         };
                         match result {
-                            Ok(0) => return ReadOutcome::Disconnected,
+                            Ok(0) => {
+                                debug!(
+                                    peer = %self.peer_addr,
+                                    msg_len,
+                                    offset,
+                                    "tcp: connection closed by peer (reading payload)",
+                                );
+                                return ReadOutcome::Disconnected;
+                            }
                             Ok(n) => {
                                 offset += n;
                                 if offset == msg_len {


### PR DESCRIPTION
## Problem

`Events::with_capacity(128)` in `TcpConnector` caused epoll event starvation when >128 connections were active (e.g. the data gather receiver).

Mio uses edge-triggered epoll — connections that don't fit in the 128-event batch are deferred to the next `poll()` cycle. With heavy connections dominating each batch, lighter connections experienced ~1s read delays. The kernel measured this as `rcv_rtt: 999ms`, auto-tuned `rcv_space` down to ~14KB, and advertised a tiny TCP receive window — causing the sender to be `rwnd_limited: 99.7%` of the time.

## Diagnosis (from `ss -tnip` on both sides)

**Sender side:**
- `rwnd_limited: 99.7%` — blocked on receiver's window almost all the time
- `snd_wnd: 73728` (72KB) — tiny window from receiver
- `Send-Q: 931816` — ~1MB queued in kernel

**Receiver side (starved connection):**
- `rcv_space: 14480` (14KB) — kernel auto-tuned window down
- `rcv_rtt: 999ms` — kernel thinks app takes ~1s between reads

**Receiver side (healthy connection):**
- `rcv_space: 4734960` (4.7MB) — normal
- `bytes_received: 3.8GB` — orders of magnitude more throughput

## Fix

- After each `poll()`, if the number of returned events equals the buffer capacity, double it
- Log at `info` level when growth occurs (`"epoll event buffer full, growing"`)
- Add `.with_event_capacity(n)` builder method for callers that want a different starting size
- Default remains 128 — auto-grows as needed with zero overhead once stabilized
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gattaca-com/flux/pull/67" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
