### PR TITLE
fix(tcp): skip duplicate on_connect_msg when first backlog entry is identical

### DIFF
--- a/crates/flux-network/src/tcp/stream.rs
+++ b/crates/flux-network/src/tcp/stream.rs
@@ -193,9 +193,17 @@ impl TcpStream {
         if !self.send_backlog.is_empty() {
             self.writable_armed = false;
             if let Some(message) = on_connect_msg {
-                self.serialise_frame(|bytes| bytes.extend_from_slice(message));
-                let data = self.alloc_vec(0);
-                return self.enqueue_front(registry, data);
+                // Skip if the first backlog entry already carries an identical
+                // payload — avoids sending a duplicate on_connect message after
+                // reconnect when the previous one is still queued.
+                let dominated = self.send_backlog.front().is_some_and(|front| {
+                    front.len() >= FRAME_HEADER_SIZE && front[FRAME_HEADER_SIZE..] == **message
+                });
+                if !dominated {
+                    self.serialise_frame(|bytes| bytes.extend_from_slice(message));
+                    let data = self.alloc_vec(0);
+                    return self.enqueue_front(registry, data);
+                }
             }
             self.arm_writable(registry)
         } else if let Some(message) = on_connect_msg {


### PR DESCRIPTION
When a TCP stream reconnects and an `on_connect_msg` is configured, the message was always prepended to the send backlog via `enqueue_front`. If the previous `on_connect_msg` was still queued (e.g. rapid reconnect cycle), this produced duplicates at the head of the backlog.

Now compares the raw payload of the first backlog entry (`front[FRAME_HEADER_SIZE..]`) against the `on_connect_msg` and skips the enqueue when they match.

**Change**: `crates/flux-network/src/tcp/stream.rs` — `reset_with_new_stream()`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gattaca-com/flux/pull/69" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
