### PR TITLE
refactor(tcp): rename dominated to already_queued for clarity

### DIFF
--- a/crates/flux-network/src/tcp/stream.rs
+++ b/crates/flux-network/src/tcp/stream.rs
@@ -196,10 +196,10 @@ impl TcpStream {
                 // Skip if the first backlog entry already carries an identical
                 // payload — avoids sending a duplicate on_connect message after
                 // reconnect when the previous one is still queued.
-                let dominated = self.send_backlog.front().is_some_and(|front| {
+                let already_queued = self.send_backlog.front().is_some_and(|front| {
                     front.len() >= FRAME_HEADER_SIZE && front[FRAME_HEADER_SIZE..] == **message
                 });
-                if !dominated {
+                if !already_queued {
                     self.serialise_frame(|bytes| bytes.extend_from_slice(message));
                     let data = self.alloc_vec(0);
                     return self.enqueue_front(registry, data);


### PR DESCRIPTION
Follow-up to #69 — renames the `dominated` variable to `already_queued` for better readability in `reset_with_new_stream()`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gattaca-com/flux/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
