### PR TITLE
refactor(flux-communication): drop unused Producer Default impl

### DIFF
--- a/crates/flux-communication/src/queue/mod.rs
+++ b/crates/flux-communication/src/queue/mod.rs
@@ -605,13 +605,6 @@ pub struct Producer<T> {
     pub produced_first: u8, // 1
     pub queue: Queue<T>,
 }
-impl<T: Copy> Default for Producer<T> {
-    fn default() -> Self {
-        let dummy_queue = Queue::new(2, QueueType::MPMC);
-        dummy_queue.into()
-    }
-}
-
 impl<T: Copy> From<Queue<T>> for Producer<T> {
     fn from(queue: Queue<T>) -> Self {
         Self { produced_first: 0, queue }


### PR DESCRIPTION
`Producer<T>::default()` constructed a 2-slot dummy `Queue` just to satisfy the `Default` bound, but nothing in the workspace calls it and nothing downstream (builder, overseer) references it either. The impl was pure dead weight — a `Producer` without a real `Queue` has no meaningful semantics anyway.

Removing it also tightens the API contract: a `Producer` must be derived from a real `Queue` via `From<Queue<T>>`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gattaca-com/flux/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
