### PR TITLE
include struct name in _ffi_check_ symbol

### DIFF
--- a/crates/spine-derive/src/lib.rs
+++ b/crates/spine-derive/src/lib.rs
@@ -169,7 +169,7 @@ pub fn from_spine(attr: TokenStream, item: TokenStream) -> TokenStream {
                 ::flux::utils::short_typename::<#inner_ty>().to_string()
             });
 
-            let check_fn = format_ident!("_ffi_check_{}", field_ident);
+            let check_fn = format_ident!("_ffi_check_{}_{}", struct_ident, field_ident);
             let inner_ty_span = inner_ty.span();
             ffi_check_items
                 .push(quote_spanned! { inner_ty_span => fn #check_fn(var: *const #inner_ty); });
@@ -319,7 +319,7 @@ pub fn from_spine(attr: TokenStream, item: TokenStream) -> TokenStream {
             let PathArguments::AngleBracketed(args) = &last_seg.arguments &&
             let Some(GenericArgument::Type(inner_ty)) = args.args.first()
         {
-            let check_fn = format_ident!("_ffi_check_{}", field_ident);
+            let check_fn = format_ident!("_ffi_check_{}_{}", struct_ident, field_ident);
             let inner_ty_span = inner_ty.span();
             ffi_check_items
                 .push(quote_spanned! { inner_ty_span => fn #check_fn(var: *const #inner_ty); });


### PR DESCRIPTION
Two #[from_spine] structs in the same module that share a field name generated colliding extern fn names. Make the symbol _ffi_check_<struct>_<field>.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gattaca-com/flux/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->