### PR TITLE
add Timer::record_scoped RAII guard

### DIFF
--- a/crates/flux-communication/src/timer.rs
+++ b/crates/flux-communication/src/timer.rs
@@ -144,6 +144,7 @@ impl Timer {
     }
 
     #[inline]
+    #[must_use = "the returned guard records on drop; binding it to `_` drops it immediately"]
     pub fn record_scoped(&mut self) -> ScopedRecord<'_> {
         self.start();
         ScopedRecord { timer: self }

--- a/crates/flux-communication/src/timer.rs
+++ b/crates/flux-communication/src/timer.rs
@@ -143,6 +143,12 @@ impl Timer {
         self.emit_processing();
     }
 
+    #[inline]
+    pub fn record_scoped(&mut self) -> ScopedRecord<'_> {
+        self.start();
+        ScopedRecord { timer: self }
+    }
+
     /// Finish processing, then emit upstream latency.
     ///
     /// Processing interval:
@@ -245,6 +251,17 @@ impl Timer {
         let o = f();
         self.record_processing();
         o
+    }
+}
+
+pub struct ScopedRecord<'a> {
+    timer: &'a mut Timer,
+}
+
+impl Drop for ScopedRecord<'_> {
+    #[inline]
+    fn drop(&mut self) {
+        self.timer.record_processing();
     }
 }
 


### PR DESCRIPTION
## Summary
- New `Timer::record_scoped()` method that starts the timer and returns a `ScopedRecord` guard
- Guard calls `record_processing()` automatically on drop

Usage:
```rust
fn my_function(&mut self) {
    let _guard = self.timer.record_scoped();
    // ... work ...
} // record_processing() fires here
```

## Test plan
- [x] `cargo check -p flux-communication`

🤖 Generated with [Claude Code](https://claude.com/claude-code)