### PR TITLE
include tid in "Tile init complete" log

### DIFF
--- a/crates/flux-utils/src/lib.rs
+++ b/crates/flux-utils/src/lib.rs
@@ -11,5 +11,5 @@ pub use arrayvec::{ArrayStr, ArrayVec};
 pub use dcache::{DCache, DCacheError, DCachePtr, DCacheRef};
 pub use namespace::{ShortTypename, short_typename};
 pub use shared_vector::SharedVector;
-pub use thread::{ThreadPriority, thread_boot};
+pub use thread::{ThreadPriority, get_tid, thread_boot};
 pub use vsync::vsync;

--- a/crates/flux-utils/src/thread.rs
+++ b/crates/flux-utils/src/thread.rs
@@ -55,6 +55,16 @@ fn set_thread_affinity(core: usize) {
     }
 }
 
+#[cfg(target_os = "linux")]
+pub fn get_tid() -> i64 {
+    unsafe { libc::gettid() as i64 }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn get_tid() -> i64 {
+    0
+}
+
 pub fn thread_boot(core: Option<usize>, prio: ThreadPriority) {
     if let Some(core) = core {
         set_thread_affinity(core);

--- a/crates/flux/src/tile/mod.rs
+++ b/crates/flux/src/tile/mod.rs
@@ -3,7 +3,7 @@ pub mod metrics;
 use core::sync::atomic::Ordering;
 
 use flux_timing::{Duration, IngestionTime};
-use flux_utils::{ShortTypename, ThreadPriority, short_typename, thread_boot, vsync};
+use flux_utils::{ShortTypename, ThreadPriority, get_tid, short_typename, thread_boot, vsync};
 use tracing::{Level, info, span};
 
 use crate::{
@@ -94,7 +94,7 @@ where
             }
             std::hint::spin_loop();
         }
-        info!("Tile init complete");
+        info!(tid = get_tid(), "Tile init complete");
 
         loop {
             let ingestion_t = IngestionTime::now();


### PR DESCRIPTION
## Summary
- Log the kernel thread id alongside the existing "Tile init complete" message so the line correlates with `taskset`, `top -H`, and perf output.
- New `flux_utils::get_tid()` wraps `libc::gettid()` on Linux and returns `0` elsewhere (matches the cfg pattern already used for `set_thread_prio`).

## Test plan
- [x] `cargo check -p flux`