### PR TITLE
experimental feature: work on signal

### DIFF
--- a/crates/flux-network/src/tcp/stream.rs
+++ b/crates/flux-network/src/tcp/stream.rs
@@ -700,6 +700,7 @@ impl TcpStream {
 /// Set `TCP_USER_TIMEOUT` on a mio `TcpStream`.
 /// After this duration of unacknowledged data the kernel closes the connection,
 /// overriding the system-wide `tcp_retries2` (~15 min default) for this socket.
+#[cfg(target_os = "linux")]
 pub(crate) fn set_user_timeout(stream: &mio::net::TcpStream, timeout_ms: u32) {
     use std::os::fd::AsRawFd;
     let fd = stream.as_raw_fd();
@@ -712,6 +713,12 @@ pub(crate) fn set_user_timeout(stream: &mio::net::TcpStream, timeout_ms: u32) {
             core::mem::size_of::<u32>() as libc::socklen_t,
         );
     }
+}
+
+/// Set `TCP_USER_TIMEOUT` on a mio `TcpStream`. Stub for non-Linux platforms.
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn set_user_timeout(_stream: &mio::net::TcpStream, _timeout_ms: u32) {
+    // TCP_USER_TIMEOUT is not supported on non-Linux platforms.
 }
 
 /// Set kernel `SO_SNDBUF` and `SO_RCVBUF` on a mio `TcpStream`.

--- a/crates/flux/Cargo.toml
+++ b/crates/flux/Cargo.toml
@@ -24,6 +24,7 @@ tracing.workspace = true
 zstd.workspace = true
 wincode = { workspace = true, optional = true }
 wincode-derive = { workspace = true, optional = true }
+mio = { workspace = true, optional = true }
 
 [dev-dependencies]
 shared_memory.workspace = true
@@ -36,6 +37,9 @@ wincode = [
     "dep:wincode-derive",
     "flux-utils/wincode",
     "flux-timing/wincode",
+]
+park = [
+    "dep:mio",
 ]
 
 [lints]

--- a/crates/flux/src/lib.rs
+++ b/crates/flux/src/lib.rs
@@ -5,6 +5,9 @@ pub mod spine;
 pub mod tile;
 mod timer;
 
+#[cfg(feature = "park")]
+pub mod park;
+
 pub use core_affinity;
 pub use flux_communication as communication;
 pub use flux_timing as timing;

--- a/crates/flux/src/park.rs
+++ b/crates/flux/src/park.rs
@@ -1,0 +1,113 @@
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Mutex;
+use mio::Waker;
+
+pub struct Signal {
+    counter: AtomicU32,
+    wakers: Mutex<Vec<(u64, Waker)>>,
+    #[cfg(not(target_os = "linux"))]
+    cond: std::sync::Condvar,
+    #[cfg(not(target_os = "linux"))]
+    mutex: Mutex<()>,
+}
+
+pub static SIGNAL: Signal = Signal::new();
+
+static NEXT_WAKER_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+impl Signal {
+    pub const fn new() -> Self {
+        Self {
+            counter: AtomicU32::new(0),
+            wakers: Mutex::new(Vec::new()),
+            #[cfg(not(target_os = "linux"))]
+            cond: std::sync::Condvar::new(),
+            #[cfg(not(target_os = "linux"))]
+            mutex: Mutex::new(()),
+        }
+    }
+
+    /// Read the current state of the atomic counter.
+    #[inline]
+    pub fn read_counter(&self) -> u32 {
+        self.counter.load(Ordering::Acquire)
+    }
+
+    /// Signal the sticky event. Increment the counter, wake all parked threads via
+    /// FUTEX_WAKE (on Linux) or Condvar (on non-Linux), and wake all registered mio Wakers.
+    pub fn signal(&self) {
+        self.counter.fetch_add(1, Ordering::Release);
+
+        #[cfg(target_os = "linux")]
+        {
+            unsafe {
+                libc::syscall(
+                    libc::SYS_futex,
+                    self.counter.as_ptr(),
+                    libc::FUTEX_WAKE,
+                    libc::c_int::MAX,
+                    std::ptr::null::<libc::timespec>(),
+                    std::ptr::null::<libc::c_int>(),
+                    0 as libc::c_int,
+                );
+            }
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            // Acquire lock to avoid race conditions with wait, though Condvar::notify_all
+            // itself doesn't require the lock to be held.
+            self.cond.notify_all();
+        }
+
+        // Wake registered mio wakers
+        let wakers = self.wakers.lock().unwrap();
+        for (_, waker) in wakers.iter() {
+            if let Err(e) = waker.wake() {
+                tracing::warn!("Failed to wake mio waker: {e}");
+            }
+        }
+    }
+
+    /// Park the current thread if the atomic counter is still equal to `expected`.
+    pub fn park(&self, expected: u32) {
+        #[cfg(target_os = "linux")]
+        {
+            unsafe {
+                libc::syscall(
+                    libc::SYS_futex,
+                    self.counter.as_ptr(),
+                    libc::FUTEX_WAIT,
+                    expected as libc::c_int,
+                    std::ptr::null::<libc::timespec>(),
+                    std::ptr::null::<libc::c_int>(),
+                    0 as libc::c_int,
+                );
+            }
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            let mut guard = self.mutex.lock().unwrap();
+            while self.counter.load(Ordering::Acquire) == expected {
+                guard = self.cond.wait(guard).unwrap();
+            }
+        }
+    }
+
+    /// Register a `mio::Waker` instance. It will be woken whenever `signal` is called.
+    /// Returns a unique token ID that can be used to unregister.
+    pub fn register_waker(&self, waker: Waker) -> u64 {
+        let id = NEXT_WAKER_ID.fetch_add(1, Ordering::Relaxed);
+        self.wakers.lock().unwrap().push((id, waker));
+        id
+    }
+
+    /// Unregister a `mio::Waker` instance by its ID.
+    pub fn unregister_waker(&self, id: u64) {
+        let mut guard = self.wakers.lock().unwrap();
+        if let Some(pos) = guard.iter().position(|(w_id, _)| *w_id == id) {
+            guard.swap_remove(pos);
+        }
+    }
+}

--- a/crates/flux/src/park.rs
+++ b/crates/flux/src/park.rs
@@ -1,10 +1,53 @@
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::cell::UnsafeCell;
+use std::hint::spin_loop;
+use std::mem::MaybeUninit;
+use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+#[cfg(not(target_os = "linux"))]
 use std::sync::Mutex;
+
 use mio::Waker;
+
+pub const MAX_SIGNAL_WAKERS: usize = 8;
+
+struct WakerSlot {
+    waker: UnsafeCell<MaybeUninit<Waker>>,
+}
+
+// SAFETY: a slot is written at most once before publication, then only read through shared
+// references until `Signal` is dropped with exclusive access.
+unsafe impl Sync for WakerSlot {}
+
+impl WakerSlot {
+    const fn uninit() -> Self {
+        Self { waker: UnsafeCell::new(MaybeUninit::uninit()) }
+    }
+
+    fn write(&self, waker: Waker) {
+        // SAFETY: each slot is reserved by a single successful `register_waker` call.
+        unsafe {
+            (*self.waker.get()).write(waker);
+        }
+    }
+
+    unsafe fn get(&self) -> &Waker {
+        // SAFETY: callers only read slots below `published_wakers`, which are initialized and
+        // never mutated again.
+        unsafe { &*(*self.waker.get()).as_ptr() }
+    }
+
+    unsafe fn drop_initialized(&mut self) {
+        // SAFETY: callers only drop slots known to have been initialized.
+        unsafe {
+            self.waker.get_mut().assume_init_drop();
+        }
+    }
+}
 
 pub struct Signal {
     counter: AtomicU32,
-    wakers: Mutex<Vec<(u64, Waker)>>,
+    reserved_wakers: AtomicUsize,
+    published_wakers: AtomicUsize,
+    wakers: [WakerSlot; MAX_SIGNAL_WAKERS],
     #[cfg(not(target_os = "linux"))]
     cond: std::sync::Condvar,
     #[cfg(not(target_os = "linux"))]
@@ -13,13 +56,13 @@ pub struct Signal {
 
 pub static SIGNAL: Signal = Signal::new();
 
-static NEXT_WAKER_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
-
 impl Signal {
     pub const fn new() -> Self {
         Self {
             counter: AtomicU32::new(0),
-            wakers: Mutex::new(Vec::new()),
+            reserved_wakers: AtomicUsize::new(0),
+            published_wakers: AtomicUsize::new(0),
+            wakers: [const { WakerSlot::uninit() }; MAX_SIGNAL_WAKERS],
             #[cfg(not(target_os = "linux"))]
             cond: std::sync::Condvar::new(),
             #[cfg(not(target_os = "linux"))]
@@ -60,9 +103,11 @@ impl Signal {
             self.cond.notify_all();
         }
 
-        // Wake registered mio wakers
-        let wakers = self.wakers.lock().unwrap();
-        for (_, waker) in wakers.iter() {
+        let published_wakers = self.published_wakers.load(Ordering::Acquire);
+        for slot in &self.wakers[..published_wakers] {
+            // SAFETY: `published_wakers` is only advanced after slots in the initialized prefix
+            // have been written, and initialized slots are never mutated again.
+            let waker = unsafe { slot.get() };
             if let Err(e) = waker.wake() {
                 tracing::warn!("Failed to wake mio waker: {e}");
             }
@@ -96,18 +141,40 @@ impl Signal {
     }
 
     /// Register a `mio::Waker` instance. It will be woken whenever `signal` is called.
-    /// Returns a unique token ID that can be used to unregister.
-    pub fn register_waker(&self, waker: Waker) -> u64 {
-        let id = NEXT_WAKER_ID.fetch_add(1, Ordering::Relaxed);
-        self.wakers.lock().unwrap().push((id, waker));
-        id
-    }
+    ///
+    /// # Panics
+    ///
+    /// Panics if more than [`MAX_SIGNAL_WAKERS`] are registered.
+    pub fn register_waker(&self, waker: Waker) {
+        let Ok(slot) =
+            self.reserved_wakers.fetch_update(Ordering::AcqRel, Ordering::Acquire, |registered| {
+                (registered < MAX_SIGNAL_WAKERS).then_some(registered + 1)
+            })
+        else {
+            panic!("cannot register more than {MAX_SIGNAL_WAKERS} signal wakers");
+        };
 
-    /// Unregister a `mio::Waker` instance by its ID.
-    pub fn unregister_waker(&self, id: u64) {
-        let mut guard = self.wakers.lock().unwrap();
-        if let Some(pos) = guard.iter().position(|(w_id, _)| *w_id == id) {
-            guard.swap_remove(pos);
+        self.wakers[slot].write(waker);
+
+        while self
+            .published_wakers
+            .compare_exchange_weak(slot, slot + 1, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            spin_loop();
+        }
+    }
+}
+
+impl Drop for Signal {
+    fn drop(&mut self) {
+        let initialized = *self.published_wakers.get_mut();
+
+        for slot in &mut self.wakers[..initialized] {
+            // SAFETY: `published_wakers` is the initialized prefix.
+            unsafe {
+                slot.drop_initialized();
+            }
         }
     }
 }

--- a/crates/flux/src/spine/adapter.rs
+++ b/crates/flux/src/spine/adapter.rs
@@ -21,6 +21,8 @@ pub struct SpineAdapter<S: FluxSpine> {
     pub producers: S::Producers,
     pub stop_flag: Option<Arc<AtomicUsize>>,
     did_work: bool,
+    #[cfg(feature = "park")]
+    waker_registered: bool,
 }
 
 impl<S: FluxSpine> SpineAdapter<S> {
@@ -31,6 +33,8 @@ impl<S: FluxSpine> SpineAdapter<S> {
             producers: spine.attach_producers(tile),
             stop_flag: None,
             did_work: false,
+            #[cfg(feature = "park")]
+            waker_registered: false,
         }
     }
 
@@ -45,6 +49,8 @@ impl<S: FluxSpine> SpineAdapter<S> {
             producers: spine.attach_producers(tile),
             stop_flag: Some(stop_flag),
             did_work: false,
+            #[cfg(feature = "park")]
+            waker_registered: false,
         }
     }
 
@@ -59,8 +65,15 @@ impl<S: FluxSpine> SpineAdapter<S> {
 
     #[cfg(feature = "park")]
     #[inline]
-    pub fn register_waker(&self, waker: mio::Waker) {
+    pub fn register_waker(&mut self, waker: mio::Waker) {
+        self.waker_registered = true;
         crate::park::SIGNAL.register_waker(waker)
+    }
+
+    #[cfg(feature = "park")]
+    #[inline]
+    pub fn waker_registered(&self) -> bool {
+        self.waker_registered
     }
 
     /// Called by `attach_tile` before each `loop_body`.

--- a/crates/flux/src/spine/adapter.rs
+++ b/crates/flux/src/spine/adapter.rs
@@ -52,7 +52,21 @@ impl<S: FluxSpine> SpineAdapter<S> {
     pub fn request_stop_scope(&self) {
         if let Some(f) = &self.stop_flag {
             f.store(SIGINT as usize, Ordering::Relaxed);
+            #[cfg(feature = "park")]
+            crate::park::SIGNAL.signal();
         }
+    }
+
+    #[cfg(feature = "park")]
+    #[inline]
+    pub fn register_waker(&self, waker: mio::Waker) -> u64 {
+        crate::park::SIGNAL.register_waker(waker)
+    }
+
+    #[cfg(feature = "park")]
+    #[inline]
+    pub fn unregister_waker(&self, id: u64) {
+        crate::park::SIGNAL.unregister_waker(id);
     }
 
     /// Called by `attach_tile` before each `loop_body`.

--- a/crates/flux/src/spine/adapter.rs
+++ b/crates/flux/src/spine/adapter.rs
@@ -1,6 +1,6 @@
 use std::sync::{
-    Arc,
     atomic::{AtomicUsize, Ordering},
+    Arc,
 };
 
 use flux_timing::{IngestionTime, InternalMessage};
@@ -59,14 +59,8 @@ impl<S: FluxSpine> SpineAdapter<S> {
 
     #[cfg(feature = "park")]
     #[inline]
-    pub fn register_waker(&self, waker: mio::Waker) -> u64 {
+    pub fn register_waker(&self, waker: mio::Waker) {
         crate::park::SIGNAL.register_waker(waker)
-    }
-
-    #[cfg(feature = "park")]
-    #[inline]
-    pub fn unregister_waker(&self, id: u64) {
-        crate::park::SIGNAL.unregister_waker(id);
     }
 
     /// Called by `attach_tile` before each `loop_body`.

--- a/crates/flux/src/spine/mod.rs
+++ b/crates/flux/src/spine/mod.rs
@@ -83,6 +83,8 @@ pub trait SpineProducers {
     {
         let msg = InternalMessage::new(self.timestamp().with_new_publish_delta(), d);
         self.as_ref().produce_without_first(&msg);
+        #[cfg(feature = "park")]
+        crate::park::SIGNAL.signal();
     }
 
     fn produce_with_ingestion<T: Copy>(&self, d: T, ingestion_t: IngestionTime)
@@ -91,6 +93,8 @@ pub trait SpineProducers {
     {
         let msg = InternalMessage::new(self.timestamp().with_ingestion_t(ingestion_t), d);
         self.as_ref().produce_without_first(&msg);
+        #[cfg(feature = "park")]
+        crate::park::SIGNAL.signal();
     }
 
     fn forward<T: Copy>(&self, msg: &InternalMessage<T>)
@@ -98,6 +102,8 @@ pub trait SpineProducers {
         Self: AsRef<SpineProducer<T>>,
     {
         self.as_ref().produce_without_first(msg);
+        #[cfg(feature = "park")]
+        crate::park::SIGNAL.signal();
     }
 
     fn produce_with_dcache<T: 'static + Copy, F: FnOnce(&mut [u8])>(
@@ -113,6 +119,8 @@ pub trait SpineProducers {
         let dref = if let Some((len, f)) = payload { Some(p.dcache.write(len, f)?) } else { None };
         let msg = InternalMessage::new(ts, DCacheMsg::new(data, dref));
         p.inner.produce_without_first(&msg);
+        #[cfg(feature = "park")]
+        crate::park::SIGNAL.signal();
         Ok(())
     }
 
@@ -124,6 +132,8 @@ pub trait SpineProducers {
         let p: &SpineProducerWithDCache<T> = self.as_ref();
         let msg = InternalMessage::new(ts, DCacheMsg::new(data, Some(dref)));
         p.inner.produce_without_first(&msg);
+        #[cfg(feature = "park")]
+        crate::park::SIGNAL.signal();
     }
 
     fn produce_with_dcache_and_ingestion<T: 'static + Copy, F: FnOnce(&mut [u8])>(
@@ -140,6 +150,8 @@ pub trait SpineProducers {
         let dref = if let Some((len, f)) = payload { Some(p.dcache.write(len, f)?) } else { None };
         let msg = InternalMessage::new(ts, DCacheMsg::new(data, dref));
         p.inner.produce_without_first(&msg);
+        #[cfg(feature = "park")]
+        crate::park::SIGNAL.signal();
         Ok(())
     }
 }

--- a/crates/flux/src/spine/scoped.rs
+++ b/crates/flux/src/spine/scoped.rs
@@ -43,6 +43,8 @@ fn setup_panic_hook(
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {
         stop_flag.store(SIGINT as usize, Ordering::Relaxed);
+        #[cfg(feature = "park")]
+        crate::park::SIGNAL.signal();
         if let Some(on_panic) = &on_panic {
             on_panic(panic_info);
         }

--- a/crates/flux/src/spine/standalone_producer.rs
+++ b/crates/flux/src/spine/standalone_producer.rs
@@ -18,6 +18,8 @@ impl<T: 'static + Copy> StandaloneProducer<T> {
     pub fn produce_with_ingestion(&self, d: T, ingestion_t: IngestionTime) {
         let msg = InternalMessage::new(self.timestamp.with_ingestion_t(ingestion_t), d);
         self.producer.produce_without_first(&msg);
+        #[cfg(feature = "park")]
+        crate::park::SIGNAL.signal();
     }
 }
 
@@ -49,6 +51,8 @@ impl<T: 'static + Copy> StandaloneDCacheProducer<T> {
         };
         let msg = InternalMessage::new(ts, DCacheMsg::new(data, dref));
         self.inner.inner.produce_without_first(&msg);
+        #[cfg(feature = "park")]
+        crate::park::SIGNAL.signal();
         Ok(())
     }
 }

--- a/crates/flux/src/tile/mod.rs
+++ b/crates/flux/src/tile/mod.rs
@@ -130,6 +130,10 @@ where
         }
 
         tile.teardown(&mut adapter);
+
+        #[cfg(feature = "park")]
+        crate::park::SIGNAL.signal();
+
         info!("Tile teardown complete");
     });
 }

--- a/crates/flux/src/tile/mod.rs
+++ b/crates/flux/src/tile/mod.rs
@@ -96,6 +96,9 @@ where
         }
         info!(tid = get_tid(), "Tile init complete");
 
+        #[cfg(feature = "park")]
+        let mut expected = crate::park::SIGNAL.read_counter();
+
         loop {
             let ingestion_t = IngestionTime::now();
 
@@ -108,12 +111,21 @@ where
                 tile.loop_body(&mut adapter);
             });
 
+            let worked = adapter.did_work();
             if let Some(m) = &mut metrics {
-                m.end(adapter.did_work());
+                m.end(worked);
             }
 
             if stop_flag.load(Ordering::Relaxed) != 0 {
                 break;
+            }
+
+            #[cfg(feature = "park")]
+            {
+                if !worked {
+                    crate::park::SIGNAL.park(expected);
+                }
+                expected = crate::park::SIGNAL.read_counter();
             }
         }
 

--- a/crates/flux/src/tile/mod.rs
+++ b/crates/flux/src/tile/mod.rs
@@ -122,7 +122,7 @@ where
 
             #[cfg(feature = "park")]
             {
-                if !worked {
+                if !worked && !adapter.waker_registered() {
                     crate::park::SIGNAL.park(expected);
                 }
                 expected = crate::park::SIGNAL.read_counter();

--- a/crates/flux/tests/park.rs
+++ b/crates/flux/tests/park.rs
@@ -1,10 +1,10 @@
 #[cfg(feature = "park")]
 mod tests {
-    use std::sync::Arc;
+    use flux::park::Signal;
     use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
     use std::thread;
     use std::time::Duration;
-    use flux::park::Signal;
 
     #[test]
     fn test_park_unpark() {
@@ -52,7 +52,7 @@ mod tests {
         let mut poll = mio::Poll::new().unwrap();
         let waker = mio::Waker::new(poll.registry(), mio::Token(42)).unwrap();
 
-        let id = signal.register_waker(waker);
+        signal.register_waker(waker);
 
         signal.signal();
 
@@ -67,7 +67,5 @@ mod tests {
         }
 
         assert!(found, "mio waker was not woken");
-
-        signal.unregister_waker(id);
     }
 }

--- a/crates/flux/tests/park.rs
+++ b/crates/flux/tests/park.rs
@@ -1,0 +1,73 @@
+#[cfg(feature = "park")]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::thread;
+    use std::time::Duration;
+    use flux::park::Signal;
+
+    #[test]
+    fn test_park_unpark() {
+        let signal = Arc::new(Signal::new());
+        let signal_clone = signal.clone();
+        let parked = Arc::new(AtomicBool::new(false));
+        let parked_clone = parked.clone();
+
+        let counter = signal.read_counter();
+
+        let handle = thread::spawn(move || {
+            parked_clone.store(true, Ordering::Release);
+            signal_clone.park(counter);
+            parked_clone.store(false, Ordering::Release);
+        });
+
+        // Wait for thread to run and park
+        thread::sleep(Duration::from_millis(50));
+        assert!(parked.load(Ordering::Acquire));
+
+        // Signal to unpark
+        signal.signal();
+
+        handle.join().unwrap();
+        assert!(!parked.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn test_sticky_behavior() {
+        let signal = Signal::new();
+        let counter = signal.read_counter();
+
+        // Signal first (sticky)
+        signal.signal();
+
+        // Park with old counter should not block
+        let start = std::time::Instant::now();
+        signal.park(counter);
+        assert!(start.elapsed() < Duration::from_millis(50));
+    }
+
+    #[test]
+    fn test_mio_waker() {
+        let signal = Signal::new();
+        let mut poll = mio::Poll::new().unwrap();
+        let waker = mio::Waker::new(poll.registry(), mio::Token(42)).unwrap();
+
+        let id = signal.register_waker(waker);
+
+        signal.signal();
+
+        let mut events = mio::Events::with_capacity(10);
+        poll.poll(&mut events, Some(Duration::from_millis(500))).unwrap();
+
+        let mut found = false;
+        for event in events.iter() {
+            if event.token() == mio::Token(42) {
+                found = true;
+            }
+        }
+
+        assert!(found, "mio waker was not woken");
+
+        signal.unregister_waker(id);
+    }
+}


### PR DESCRIPTION
adds a `park` feature to Flux. 

If this feature is enabled threads will be parked if no work was done on a loop and woken whenever a message is added to a spine queue. 

Also supports network triggers via `mio::Waker`. 

On linux the thread parking / waking uses futex. 