### PR TITLE
add drop backlog option

### DIFF
--- a/crates/flux-network/src/tcp/connector.rs
+++ b/crates/flux-network/src/tcp/connector.rs
@@ -69,6 +69,7 @@ struct ConnectionManager {
     /// longer than `timeout` are disconnected (outbound scheduled for
     /// reconnection).
     max_backlog: Option<(usize, Duration)>,
+    drop_outbound_backlog_on_disconnect: bool,
     /// Whether to set `TCP_NODELAY` on sockets (disables Nagle's algorithm).
     nodelay: bool,
 
@@ -97,6 +98,7 @@ impl Default for ConnectionManager {
             user_timeout_ms: DEFAULT_TCP_USER_TIMEOUT_MS,
             dcache: None,
             max_backlog: None,
+            drop_outbound_backlog_on_disconnect: false,
             nodelay: true,
             to_be_reconnected: Vec::with_capacity(10),
             reconnected_to: Vec::with_capacity(10),
@@ -125,6 +127,9 @@ impl ConnectionManager {
         match stream {
             ConnectionVariant::Outbound(mut tcp_connection) => {
                 tcp_connection.close(self.poll.registry());
+                if self.drop_outbound_backlog_on_disconnect {
+                    tcp_connection.clear_send_backlog();
+                }
                 self.to_be_reconnected.push((token, ConnectionVariant::Outbound(tcp_connection)));
             }
             ConnectionVariant::Inbound(mut tcp_connection) => {
@@ -164,24 +169,26 @@ impl ConnectionManager {
         write_frame_header(&mut self.bcast_header, self.bcast_payload.len(), Nanos::now());
 
         let max_backlog = self.max_backlog;
-        for (_, c) in &mut self.to_be_reconnected {
-            let ConnectionVariant::Outbound(tcp) = c else {
-                unreachable!("only outbound should be auto reconnected");
-            };
-            Self::push_reconnect_backlog_shared(
-                max_backlog,
-                tcp,
-                &self.bcast_header,
-                &self.bcast_payload,
-            );
+        if !self.drop_outbound_backlog_on_disconnect {
+            for (_, c) in &mut self.to_be_reconnected {
+                let ConnectionVariant::Outbound(tcp) = c else {
+                    unreachable!("only outbound should be auto reconnected");
+                };
+                Self::push_reconnect_backlog_shared(
+                    max_backlog,
+                    tcp,
+                    &self.bcast_header,
+                    &self.bcast_payload,
+                );
+            }
         }
 
         let mut i = self.conns.len();
         while i != 0 {
             i -= 1;
             match &mut self.conns[i].1 {
-                ConnectionVariant::Outbound(tcp_connection) |
-                ConnectionVariant::Inbound(tcp_connection) => {
+                ConnectionVariant::Outbound(tcp_connection)
+                | ConnectionVariant::Inbound(tcp_connection) => {
                     let state = tcp_connection.write_or_enqueue_shared(
                         self.poll.registry(),
                         &self.bcast_header,
@@ -190,8 +197,9 @@ impl ConnectionManager {
                     if state == ConnState::Disconnected {
                         let token = self.conns[i].0;
                         self.disconnect_at_index_pending(i);
-                        if let Some((_, ConnectionVariant::Outbound(tcp))) =
-                            self.to_be_reconnected.iter_mut().find(|(t, _)| *t == token)
+                        if !self.drop_outbound_backlog_on_disconnect
+                            && let Some((_, ConnectionVariant::Outbound(tcp))) =
+                                self.to_be_reconnected.iter_mut().find(|(t, _)| *t == token)
                         {
                             Self::push_reconnect_backlog_shared(
                                 max_backlog,
@@ -271,8 +279,8 @@ impl ConnectionManager {
 
                 if let Some(i) = self.conns.iter().position(|(t, _)| *t == token) {
                     match &mut self.conns[i].1 {
-                        ConnectionVariant::Outbound(tcp_connection) |
-                        ConnectionVariant::Inbound(tcp_connection) => {
+                        ConnectionVariant::Outbound(tcp_connection)
+                        | ConnectionVariant::Inbound(tcp_connection) => {
                             let state = tcp_connection.write_or_enqueue_shared(
                                 self.poll.registry(),
                                 &self.bcast_header,
@@ -281,8 +289,9 @@ impl ConnectionManager {
                             if state == ConnState::Disconnected {
                                 tracing::warn!("issue when writing to {token:?} disconnecting");
                                 self.disconnect_at_index_pending(i);
-                                if let Some((_, ConnectionVariant::Outbound(tcp))) =
-                                    self.to_be_reconnected.iter_mut().find(|(t, _)| *t == token)
+                                if !self.drop_outbound_backlog_on_disconnect
+                                    && let Some((_, ConnectionVariant::Outbound(tcp))) =
+                                        self.to_be_reconnected.iter_mut().find(|(t, _)| *t == token)
                                 {
                                     Self::push_reconnect_backlog_shared(
                                         self.max_backlog,
@@ -305,12 +314,14 @@ impl ConnectionManager {
                 } else if let Some((_, ConnectionVariant::Outbound(tcp))) =
                     self.to_be_reconnected.iter_mut().find(|(t, _)| *t == token)
                 {
-                    Self::push_reconnect_backlog_shared(
-                        self.max_backlog,
-                        tcp,
-                        &self.bcast_header,
-                        &self.bcast_payload,
-                    );
+                    if !self.drop_outbound_backlog_on_disconnect {
+                        Self::push_reconnect_backlog_shared(
+                            self.max_backlog,
+                            tcp,
+                            &self.bcast_header,
+                            &self.bcast_payload,
+                        );
+                    }
                 } else {
                     error!("tcp sending: unknown token {token:?}");
                 }
@@ -328,8 +339,8 @@ impl ConnectionManager {
                 self.telemetry,
                 self.dcache.is_some(),
             );
-            if let Some(msg) = &self.on_connect_msg &&
-                tcp_stream.write_or_enqueue_with(self.poll.registry(), |buf: &mut Vec<u8>| {
+            if let Some(msg) = &self.on_connect_msg
+                && tcp_stream.write_or_enqueue_with(self.poll.registry(), |buf: &mut Vec<u8>| {
                     buf.extend_from_slice(msg);
                 }) == ConnState::Disconnected
             {
@@ -478,8 +489,8 @@ impl ConnectionManager {
 
         loop {
             match &mut self.conns[stream_id].1 {
-                ConnectionVariant::Outbound(tcp_connection) |
-                ConnectionVariant::Inbound(tcp_connection) => {
+                ConnectionVariant::Outbound(tcp_connection)
+                | ConnectionVariant::Inbound(tcp_connection) => {
                     if tcp_connection.poll_with(
                         self.poll.registry(),
                         e,
@@ -523,8 +534,8 @@ impl ConnectionManager {
                             self.dcache.is_some(),
                         );
 
-                        if let Some(msg) = &self.on_connect_msg &&
-                            conn.write_or_enqueue_with(
+                        if let Some(msg) = &self.on_connect_msg
+                            && conn.write_or_enqueue_with(
                                 self.poll.registry(),
                                 |buf: &mut Vec<u8>| {
                                     buf.extend_from_slice(msg);
@@ -563,8 +574,8 @@ impl ConnectionManager {
 
         loop {
             match &mut self.conns[stream_id].1 {
-                ConnectionVariant::Outbound(tcp_connection) |
-                ConnectionVariant::Inbound(tcp_connection) => {
+                ConnectionVariant::Outbound(tcp_connection)
+                | ConnectionVariant::Inbound(tcp_connection) => {
                     let dcache =
                         self.dcache.as_deref().expect("dcache required for poll_with_produce");
                     if tcp_connection.poll_with_produce(
@@ -610,8 +621,8 @@ impl ConnectionManager {
                             self.telemetry,
                             self.dcache.is_some(),
                         );
-                        if let Some(msg) = &self.on_connect_msg &&
-                            conn.write_or_enqueue_with(
+                        if let Some(msg) = &self.on_connect_msg
+                            && conn.write_or_enqueue_with(
                                 self.poll.registry(),
                                 |buf: &mut Vec<u8>| {
                                     buf.extend_from_slice(msg);
@@ -745,6 +756,15 @@ impl TcpConnector {
     /// succeeds. The exceeded-since timer resets on reconnect.
     pub fn with_max_backlog(mut self, max: usize, timeout: Duration) -> Self {
         self.conn_mgr.max_backlog = Some((max, timeout));
+        self
+    }
+
+    /// Drops queued outbound messages when a connection is moved to reconnect.
+    ///
+    /// While that outbound connection is disconnected, sends to it are also
+    /// dropped instead of being queued for replay after reconnect.
+    pub fn with_drop_outbound_backlog_on_disconnect(mut self, enabled: bool) -> Self {
+        self.conn_mgr.drop_outbound_backlog_on_disconnect = enabled;
         self
     }
 

--- a/crates/flux-network/src/tcp/stream.rs
+++ b/crates/flux-network/src/tcp/stream.rs
@@ -687,6 +687,15 @@ impl TcpStream {
         let _ = self.stream.shutdown(std::net::Shutdown::Both);
     }
 
+    pub(crate) fn clear_send_backlog(&mut self) {
+        self.send_backlog.clear();
+        self.send_buf.clear();
+        self.send_cursor = 0;
+        self.header_buf.fill(0);
+        self.writable_armed = false;
+        self.backlog_exceeded_since = None;
+    }
+
     pub(crate) fn peer(&self) -> SocketAddr {
         self.peer_addr
     }

--- a/crates/flux-network/tests/tcp_roundtrip.rs
+++ b/crates/flux-network/tests/tcp_roundtrip.rs
@@ -139,3 +139,61 @@ fn backlog_disconnect_is_reported() {
     drop(client);
     assert!(disconnected, "backlog disconnect was not reported");
 }
+
+fn receive_after_reconnect(drop_backlog: bool) -> Option<TestMsg> {
+    let probe =
+        std::net::TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).expect("probe");
+    let bind_addr = probe.local_addr().unwrap();
+    drop(probe);
+
+    let mut listener = TcpConnector::default();
+    listener.listen_at(bind_addr).unwrap();
+
+    let mut client = TcpConnector::default()
+        .with_drop_outbound_backlog_on_disconnect(drop_backlog)
+        .with_reconnect_interval(flux_timing::Duration::from_millis(1));
+    let token = client.connect(bind_addr).unwrap();
+
+    let mut accepted = 0;
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while accepted == 0 && std::time::Instant::now() < deadline {
+        listener.poll_with(|event| {
+            if let PollEvent::Accept { .. } = event {
+                accepted += 1;
+            }
+        });
+        client.poll_with(|_| {});
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(accepted, 1, "listener did not accept initial client");
+
+    client.disconnect(token);
+    client.write_or_enqueue_with(SendBehavior::Single(token), |buf| {
+        wincode_ser_into_vec(buf, &TestMsg(333));
+    });
+    client.force_reconnect();
+
+    let mut recv = None;
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while recv.is_none() && std::time::Instant::now() < deadline {
+        listener.poll_with(|event| {
+            if let PollEvent::Message { payload: bytes, .. } = event {
+                recv = Some(wincode::deserialize(bytes).unwrap());
+            }
+        });
+        client.poll_with(|_| {});
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    recv
+}
+
+#[test]
+fn disconnected_outbound_replays_backlog_by_default() {
+    assert_eq!(receive_after_reconnect(false), Some(TestMsg(333)));
+}
+
+#[test]
+fn disconnected_outbound_can_drop_backlog() {
+    assert_eq!(receive_after_reconnect(true), None);
+}


### PR DESCRIPTION
# PR Summary

## Summary

Adds an opt-in lossy reconnect mode for outbound TCP connections:

```rust
TcpConnector::default().with_drop_outbound_backlog_on_disconnect(true)
```

When enabled, queued outbound messages are cleared when the connection is moved
to reconnect, and sends to that disconnected token are dropped instead of being
queued for replay after reconnect.

## Motivation

Some TCP streams carry best-effort updates where stale messages are not useful.
For those streams, replaying an old backlog after reconnect can be worse than
dropping it. This mode keeps the default reliable behavior unchanged while
allowing callers to opt into lossy reconnect semantics.

## Changes

- Added `with_drop_outbound_backlog_on_disconnect` to `TcpConnector`.
- Added `TcpStream::clear_send_backlog`.
- Skips disconnected-token backlog growth when the new mode is enabled.
- Preserves existing default behavior for all current callers.

## Tests

Added roundtrip coverage for both behaviors:

- default outbound reconnect replays queued backlog
- opt-in lossy outbound reconnect drops queued backlog

Validated with:

```bash
cargo test -p flux-network --test tcp_roundtrip -- --nocapture
cargo check -p flux-network
```
