### PR TITLE
new separate `TcpClient` and `TcpServer`

### DIFF
--- a/crates/flux-network/src/tcp/client.rs
+++ b/crates/flux-network/src/tcp/client.rs
@@ -1,0 +1,580 @@
+use std::{
+    collections::VecDeque,
+    io,
+    net::{Shutdown, SocketAddr},
+};
+
+use flux_timing::{Duration, Instant, Nanos, Repeater};
+use flux_utils::safe_panic;
+use mio::{Events, Interest, Poll, Token, event::Event};
+use tracing::{debug, error, warn};
+
+use crate::tcp::{
+    ConnState, SendBehavior, TcpStream, TcpTelemetry,
+    stream::{
+        DEFAULT_TCP_USER_TIMEOUT_MS, FRAME_HEADER_SIZE, build_frame_vec, set_socket_buf_size,
+        set_user_timeout, write_frame_header,
+    },
+};
+
+// Endpoints are few; keep the framed stream inline to avoid indirection on the
+// connected IO path.
+#[allow(clippy::large_enum_variant)]
+enum EndpointState {
+    Disconnected,
+    Connecting(mio::net::TcpStream),
+    Connected(crate::tcp::TcpStream),
+}
+
+struct Endpoint {
+    token: Token,
+    peer_addr: SocketAddr,
+    state: EndpointState,
+    send_backlog: VecDeque<Vec<u8>>,
+    backlog_exceeded_since: Option<Instant>,
+}
+
+/// Event emitted by [`TcpClient::poll_with`].
+pub enum ClientEvent<Payload> {
+    /// A persistent endpoint established a TCP connection.
+    Connected { token: Token, peer_addr: SocketAddr },
+    /// An established connection was lost. The endpoint remains managed and
+    /// will be retried until it is removed.
+    Disconnect { token: Token, peer_addr: SocketAddr },
+    /// A complete framed message was received.
+    Message { token: Token, payload: Payload, send_ts: Nanos },
+}
+
+struct ClientManager {
+    poll: Poll,
+    endpoints: Vec<Endpoint>,
+    reconnector: Repeater,
+    on_connect_msg: Option<Vec<u8>>,
+    telemetry: TcpTelemetry,
+    socket_buf_size: Option<usize>,
+    user_timeout_ms: u32,
+    max_backlog: Option<(usize, Duration)>,
+    drop_backlog_on_disconnect: bool,
+    nodelay: bool,
+    pending_disconnects: Vec<Token>,
+    next_token: usize,
+    bcast_header: [u8; FRAME_HEADER_SIZE],
+    bcast_payload: Vec<u8>,
+}
+
+impl Default for ClientManager {
+    fn default() -> Self {
+        Self {
+            poll: Poll::new().expect("couldn't set up a poll for tcp client"),
+            endpoints: Vec::with_capacity(5),
+            reconnector: Repeater::every(Duration::from_secs(2)),
+            on_connect_msg: None,
+            telemetry: TcpTelemetry::Disabled,
+            socket_buf_size: None,
+            user_timeout_ms: DEFAULT_TCP_USER_TIMEOUT_MS,
+            max_backlog: None,
+            drop_backlog_on_disconnect: false,
+            nodelay: true,
+            pending_disconnects: Vec::with_capacity(10),
+            next_token: 0,
+            bcast_header: [0; FRAME_HEADER_SIZE],
+            bcast_payload: Vec::with_capacity(TcpStream::SEND_BUF_SIZE),
+        }
+    }
+}
+
+impl ClientManager {
+    fn connect(&mut self, peer_addr: SocketAddr) -> Token {
+        let token = Token(self.next_token);
+        self.next_token += 1;
+        self.endpoints.push(Endpoint {
+            token,
+            peer_addr,
+            state: EndpointState::Disconnected,
+            send_backlog: VecDeque::with_capacity(64),
+            backlog_exceeded_since: None,
+        });
+        self.start_connect(self.endpoints.len() - 1);
+        token
+    }
+
+    fn start_connect(&mut self, index: usize) {
+        let endpoint = &self.endpoints[index];
+        debug_assert!(matches!(endpoint.state, EndpointState::Disconnected));
+        let token = endpoint.token;
+        let peer_addr = endpoint.peer_addr;
+
+        let Ok(mut socket) = mio::net::TcpStream::connect(peer_addr)
+            .inspect_err(|err| warn!(?err, %peer_addr, "couldn't start tcp connection"))
+        else {
+            return;
+        };
+        if let Some(size) = self.socket_buf_size {
+            set_socket_buf_size(&socket, size);
+        }
+        if let Err(err) = self.poll.registry().register(&mut socket, token, Interest::WRITABLE) {
+            error!(?err, %peer_addr, "couldn't register connecting tcp stream");
+            return;
+        }
+        self.endpoints[index].state = EndpointState::Connecting(socket);
+    }
+
+    fn maybe_reconnect(&mut self) {
+        if !self.reconnector.fired() {
+            return;
+        }
+        for index in 0..self.endpoints.len() {
+            if matches!(self.endpoints[index].state, EndpointState::Disconnected) {
+                self.start_connect(index);
+            }
+        }
+    }
+
+    fn connect_complete(socket: &mio::net::TcpStream) -> io::Result<bool> {
+        if let Some(err) = socket.take_error()? {
+            return Err(err);
+        }
+        match socket.peer_addr() {
+            Ok(_) => Ok(true),
+            Err(err)
+                if matches!(
+                    err.kind(),
+                    io::ErrorKind::NotConnected | io::ErrorKind::WouldBlock
+                ) || matches!(err.raw_os_error(), Some(libc::EINPROGRESS | libc::EALREADY)) =>
+            {
+                Ok(false)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    fn finish_connect<F>(&mut self, index: usize, handler: &mut F)
+    where
+        F: for<'a> FnMut(ClientEvent<&'a [u8]>),
+    {
+        let endpoint = &self.endpoints[index];
+        let EndpointState::Connecting(socket) = &endpoint.state else { return };
+        match Self::connect_complete(socket) {
+            Ok(false) => return,
+            Err(err) => {
+                debug!(?err, peer_addr = %endpoint.peer_addr, "tcp connection attempt failed");
+                self.disconnect_at_index(index);
+                return;
+            }
+            Ok(true) => {}
+        }
+
+        let EndpointState::Connecting(mut socket) =
+            std::mem::replace(&mut self.endpoints[index].state, EndpointState::Disconnected)
+        else {
+            unreachable!();
+        };
+        let token = self.endpoints[index].token;
+        let peer_addr = self.endpoints[index].peer_addr;
+
+        if self.nodelay &&
+            let Err(err) = socket.set_nodelay(true)
+        {
+            warn!(?err, %peer_addr, "couldn't set nodelay on tcp client stream");
+            let _ = self.poll.registry().deregister(&mut socket);
+            let _ = socket.shutdown(Shutdown::Both);
+            return;
+        }
+        set_user_timeout(&socket, self.user_timeout_ms);
+        if let Err(err) = self.poll.registry().reregister(&mut socket, token, Interest::READABLE) {
+            warn!(?err, %peer_addr, "couldn't register connected tcp client stream");
+            let _ = socket.shutdown(Shutdown::Both);
+            return;
+        }
+
+        let mut stream =
+            TcpStream::from_client_stream_with_telemetry(socket, token, peer_addr, self.telemetry);
+        let backlog = std::mem::take(&mut self.endpoints[index].send_backlog);
+        if stream.install_send_backlog(self.poll.registry(), backlog, self.on_connect_msg.as_ref()) ==
+            ConnState::Disconnected
+        {
+            self.endpoints[index].state = EndpointState::Connected(stream);
+            self.disconnect_at_index(index);
+            return;
+        }
+
+        self.endpoints[index].backlog_exceeded_since = None;
+        self.endpoints[index].state = EndpointState::Connected(stream);
+        debug!(%peer_addr, "tcp client connected");
+        handler(ClientEvent::Connected { token, peer_addr });
+    }
+
+    fn handle_event<F>(&mut self, event: &Event, handler: &mut F)
+    where
+        F: for<'a> FnMut(ClientEvent<&'a [u8]>),
+    {
+        let token = event.token();
+        let Some(index) = self.endpoints.iter().position(|endpoint| endpoint.token == token) else {
+            safe_panic!("tcp client got event for unknown token");
+            return;
+        };
+
+        match self.endpoints[index].state {
+            EndpointState::Connecting(_) => self.finish_connect(index, handler),
+            EndpointState::Connected(_) => {
+                let peer_addr = self.endpoints[index].peer_addr;
+                let EndpointState::Connected(stream) = &mut self.endpoints[index].state else {
+                    unreachable!();
+                };
+                if stream.poll_with(
+                    self.poll.registry(),
+                    event,
+                    None,
+                    &mut |token, payload, send_ts| {
+                        handler(ClientEvent::Message { token, payload, send_ts });
+                    },
+                ) == ConnState::Disconnected
+                {
+                    handler(ClientEvent::Disconnect { token, peer_addr });
+                    self.disconnect_at_index(index);
+                }
+            }
+            EndpointState::Disconnected => {
+                safe_panic!("tcp client got event for disconnected token");
+            }
+        }
+    }
+
+    fn disconnect_at_index(&mut self, index: usize) {
+        let old_state =
+            std::mem::replace(&mut self.endpoints[index].state, EndpointState::Disconnected);
+        match old_state {
+            EndpointState::Disconnected => {}
+            EndpointState::Connecting(mut socket) => {
+                let _ = self.poll.registry().deregister(&mut socket);
+                let _ = socket.shutdown(Shutdown::Both);
+            }
+            EndpointState::Connected(mut stream) => {
+                if self.drop_backlog_on_disconnect {
+                    self.endpoints[index].send_backlog.clear();
+                } else {
+                    self.endpoints[index].send_backlog = stream.take_send_backlog();
+                }
+                stream.close(self.poll.registry());
+            }
+        }
+        if self.drop_backlog_on_disconnect {
+            self.endpoints[index].send_backlog.clear();
+        }
+        self.endpoints[index].backlog_exceeded_since = None;
+    }
+
+    fn disconnect_pending(&mut self, index: usize) {
+        let token = self.endpoints[index].token;
+        self.disconnect_at_index(index);
+        self.pending_disconnects.push(token);
+    }
+
+    fn disconnect(&mut self, token: Token) {
+        if let Some(index) = self.endpoints.iter().position(|endpoint| endpoint.token == token) {
+            self.disconnect_at_index(index);
+        }
+    }
+
+    fn disconnect_all(&mut self) {
+        for index in 0..self.endpoints.len() {
+            self.disconnect_at_index(index);
+        }
+    }
+
+    fn remove(&mut self, token: Token) {
+        let Some(index) = self.endpoints.iter().position(|endpoint| endpoint.token == token) else {
+            return;
+        };
+        self.disconnect_at_index(index);
+        self.endpoints.swap_remove(index);
+        self.pending_disconnects.retain(|pending| *pending != token);
+    }
+
+    fn drain_pending_disconnects<F>(&mut self, handler: &mut F) -> bool
+    where
+        F: for<'a> FnMut(ClientEvent<&'a [u8]>),
+    {
+        let worked = !self.pending_disconnects.is_empty();
+        for token in self.pending_disconnects.drain(..) {
+            if let Some(endpoint) = self.endpoints.iter().find(|endpoint| endpoint.token == token) {
+                handler(ClientEvent::Disconnect { token, peer_addr: endpoint.peer_addr });
+            }
+        }
+        worked
+    }
+
+    fn currently_disconnected(&self) -> impl Iterator<Item = Token> + '_ {
+        self.endpoints.iter().filter_map(|endpoint| {
+            (!matches!(endpoint.state, EndpointState::Connected(_))).then_some(endpoint.token)
+        })
+    }
+
+    fn force_reconnect(&mut self) {
+        self.reconnector.force_fire();
+        self.maybe_reconnect();
+    }
+
+    fn backlog_len(endpoint: &Endpoint) -> usize {
+        match &endpoint.state {
+            EndpointState::Connected(stream) => stream.send_backlog.len(),
+            EndpointState::Disconnected | EndpointState::Connecting(_) => {
+                endpoint.send_backlog.len()
+            }
+        }
+    }
+
+    fn backlog_exceeded(
+        max_backlog: Option<(usize, Duration)>,
+        endpoint: &mut Endpoint,
+        additional_messages: usize,
+    ) -> bool {
+        let Some((max, timeout)) = max_backlog else { return false };
+        if Self::backlog_len(endpoint).saturating_add(additional_messages) <= max {
+            endpoint.backlog_exceeded_since = None;
+            return false;
+        }
+        let now = Instant::now();
+        let since = endpoint.backlog_exceeded_since.get_or_insert(now);
+        now.saturating_sub(*since) >= timeout
+    }
+
+    fn push_disconnected_frame(
+        max_backlog: Option<(usize, Duration)>,
+        endpoint: &mut Endpoint,
+        header: &[u8; FRAME_HEADER_SIZE],
+        payload: &[u8],
+    ) {
+        if !Self::backlog_exceeded(max_backlog, endpoint, 1) {
+            endpoint.send_backlog.push_back(build_frame_vec(header, payload));
+        }
+    }
+
+    fn broadcast<F>(&mut self, serialise: &F)
+    where
+        F: Fn(&mut Vec<u8>),
+    {
+        self.bcast_payload.clear();
+        serialise(&mut self.bcast_payload);
+        if self.bcast_payload.is_empty() {
+            return;
+        }
+        write_frame_header(&mut self.bcast_header, self.bcast_payload.len(), Nanos::now());
+
+        for index in 0..self.endpoints.len() {
+            if !matches!(self.endpoints[index].state, EndpointState::Connected(_)) {
+                if !self.drop_backlog_on_disconnect {
+                    Self::push_disconnected_frame(
+                        self.max_backlog,
+                        &mut self.endpoints[index],
+                        &self.bcast_header,
+                        &self.bcast_payload,
+                    );
+                }
+                continue;
+            }
+
+            let state = {
+                let EndpointState::Connected(stream) = &mut self.endpoints[index].state else {
+                    unreachable!();
+                };
+                stream.write_or_enqueue_shared(
+                    self.poll.registry(),
+                    &self.bcast_header,
+                    &self.bcast_payload,
+                )
+            };
+            let backlog_exceeded =
+                Self::backlog_exceeded(self.max_backlog, &mut self.endpoints[index], 0);
+            if state == ConnState::Disconnected {
+                self.disconnect_pending(index);
+                if !self.drop_backlog_on_disconnect {
+                    Self::push_disconnected_frame(
+                        self.max_backlog,
+                        &mut self.endpoints[index],
+                        &self.bcast_header,
+                        &self.bcast_payload,
+                    );
+                }
+            } else if backlog_exceeded {
+                self.disconnect_pending(index);
+            }
+        }
+    }
+
+    fn write_or_enqueue_with<F>(&mut self, where_to: SendBehavior, serialise: F)
+    where
+        F: Fn(&mut Vec<u8>),
+    {
+        let SendBehavior::Single(token) = where_to else {
+            self.broadcast(&serialise);
+            return;
+        };
+        let Some(index) = self.endpoints.iter().position(|endpoint| endpoint.token == token) else {
+            error!(?token, "tcp client send to unknown token");
+            return;
+        };
+
+        self.bcast_payload.clear();
+        serialise(&mut self.bcast_payload);
+        if self.bcast_payload.is_empty() {
+            return;
+        }
+        write_frame_header(&mut self.bcast_header, self.bcast_payload.len(), Nanos::now());
+
+        if !matches!(self.endpoints[index].state, EndpointState::Connected(_)) {
+            if !self.drop_backlog_on_disconnect {
+                Self::push_disconnected_frame(
+                    self.max_backlog,
+                    &mut self.endpoints[index],
+                    &self.bcast_header,
+                    &self.bcast_payload,
+                );
+            }
+            return;
+        }
+
+        let state = {
+            let EndpointState::Connected(stream) = &mut self.endpoints[index].state else {
+                unreachable!();
+            };
+            stream.write_or_enqueue_shared(
+                self.poll.registry(),
+                &self.bcast_header,
+                &self.bcast_payload,
+            )
+        };
+        let backlog_exceeded =
+            Self::backlog_exceeded(self.max_backlog, &mut self.endpoints[index], 0);
+        if state == ConnState::Disconnected {
+            self.disconnect_pending(index);
+            if !self.drop_backlog_on_disconnect {
+                Self::push_disconnected_frame(
+                    self.max_backlog,
+                    &mut self.endpoints[index],
+                    &self.bcast_header,
+                    &self.bcast_payload,
+                );
+            }
+        } else if backlog_exceeded {
+            self.disconnect_pending(index);
+        }
+    }
+}
+
+/// Non-blocking manager for persistent outbound TCP endpoints.
+///
+/// Each [`Self::connect`] call creates one endpoint with a stable token. The
+/// client attempts it immediately and retries from [`Self::poll_with`] until
+/// [`Self::remove`] is called.
+pub struct TcpClient {
+    events: Events,
+    manager: ClientManager,
+}
+
+impl Default for TcpClient {
+    fn default() -> Self {
+        Self { events: Events::with_capacity(128), manager: ClientManager::default() }
+    }
+}
+
+impl TcpClient {
+    pub fn with_reconnect_interval(mut self, interval: Duration) -> Self {
+        self.manager.reconnector = Repeater::every(interval);
+        self
+    }
+
+    pub fn with_on_connect_msg(mut self, msg: Vec<u8>) -> Self {
+        assert!(msg.len() <= TcpStream::SEND_BUF_SIZE, "on_connect_msg exceeds send buffer size");
+        self.manager.on_connect_msg = Some(msg);
+        self
+    }
+
+    pub fn with_telemetry(mut self, telemetry: TcpTelemetry) -> Self {
+        self.manager.telemetry = telemetry;
+        self
+    }
+
+    pub fn with_socket_buf_size(mut self, size: usize) -> Self {
+        self.manager.socket_buf_size = Some(size);
+        self
+    }
+
+    pub fn with_user_timeout(mut self, timeout_ms: u32) -> Self {
+        self.manager.user_timeout_ms = timeout_ms;
+        self
+    }
+
+    pub fn with_nodelay(mut self, nodelay: bool) -> Self {
+        self.manager.nodelay = nodelay;
+        self
+    }
+
+    pub fn with_max_backlog(mut self, max: usize, timeout: Duration) -> Self {
+        self.manager.max_backlog = Some((max, timeout));
+        self
+    }
+
+    pub fn with_drop_backlog_on_disconnect(mut self, enabled: bool) -> Self {
+        self.manager.drop_backlog_on_disconnect = enabled;
+        self
+    }
+
+    /// Adds a persistent outbound endpoint and returns its stable token.
+    #[must_use = "the token identifies the persistent outbound endpoint"]
+    pub fn connect(&mut self, peer_addr: SocketAddr) -> Token {
+        self.manager.connect(peer_addr)
+    }
+
+    /// Polls sockets once and dispatches lifecycle and message events.
+    pub fn poll_with<F>(&mut self, mut handler: F) -> bool
+    where
+        F: for<'a> FnMut(ClientEvent<&'a [u8]>),
+    {
+        let mut worked = self.manager.drain_pending_disconnects(&mut handler);
+        self.manager.maybe_reconnect();
+        if let Err(err) = self.manager.poll.poll(&mut self.events, Some(std::time::Duration::ZERO))
+        {
+            safe_panic!("tcp client poll failed: {err}");
+            return false;
+        }
+        for event in &self.events {
+            worked = true;
+            self.manager.handle_event(event, &mut handler);
+        }
+        worked |= self.manager.drain_pending_disconnects(&mut handler);
+        worked
+    }
+
+    pub fn write_or_enqueue_with<F>(&mut self, where_to: SendBehavior, serialise: F)
+    where
+        F: Fn(&mut Vec<u8>),
+    {
+        self.manager.write_or_enqueue_with(where_to, serialise);
+    }
+
+    /// Closes an endpoint's current socket and schedules it for reconnection.
+    pub fn disconnect(&mut self, token: Token) {
+        self.manager.disconnect(token);
+    }
+
+    /// Closes every current socket and schedules all endpoints for reconnect.
+    pub fn disconnect_all(&mut self) {
+        self.manager.disconnect_all();
+    }
+
+    /// Permanently removes an endpoint and its queued messages.
+    pub fn remove(&mut self, token: Token) {
+        self.manager.remove(token);
+    }
+
+    /// Returns endpoints that are disconnected or still connecting.
+    pub fn currently_disconnected(&self) -> impl Iterator<Item = Token> + '_ {
+        self.manager.currently_disconnected()
+    }
+
+    /// Immediately retries endpoints that are currently disconnected.
+    pub fn force_reconnect(&mut self) {
+        self.manager.force_reconnect();
+    }
+}

--- a/crates/flux-network/src/tcp/mod.rs
+++ b/crates/flux-network/src/tcp/mod.rs
@@ -1,5 +1,9 @@
+mod client;
 mod connector;
+mod server;
 mod stream;
 
+pub use client::{ClientEvent, TcpClient};
 pub use connector::{PollEvent, SendBehavior, TcpConnector};
+pub use server::{ServerEvent, TcpServer};
 pub use stream::{ConnState, TcpStream, TcpTelemetry};

--- a/crates/flux-network/src/tcp/server.rs
+++ b/crates/flux-network/src/tcp/server.rs
@@ -1,0 +1,409 @@
+use std::net::{Shutdown, SocketAddr};
+
+use flux::spine::{SpineProducerWithDCache, SpineProducers};
+use flux_timing::{Duration, Instant, Nanos};
+use flux_utils::{DCachePtr, safe_panic};
+use mio::{Events, Interest, Poll, Token, event::Event, net::TcpListener};
+use tracing::{error, info, warn};
+
+use crate::tcp::{
+    ConnState, SendBehavior, TcpStream, TcpTelemetry,
+    stream::{
+        DEFAULT_TCP_USER_TIMEOUT_MS, FRAME_HEADER_SIZE, set_socket_buf_size, set_user_timeout,
+        write_frame_header,
+    },
+};
+
+/// Event emitted by [`TcpServer::poll_with`] and
+/// [`TcpServer::poll_with_produce`].
+pub enum ServerEvent<Payload> {
+    /// A listener accepted a new connection.
+    Accept { listener: Token, stream: Token, peer_addr: SocketAddr },
+    /// An accepted connection was closed.
+    Disconnect { token: Token },
+    /// A complete framed message was received.
+    Message { token: Token, payload: Payload, send_ts: Nanos },
+}
+
+struct ServerManager {
+    poll: Poll,
+    listeners: Vec<(Token, TcpListener)>,
+    streams: Vec<(Token, TcpStream)>,
+    on_connect_msg: Option<Vec<u8>>,
+    telemetry: TcpTelemetry,
+    socket_buf_size: Option<usize>,
+    user_timeout_ms: u32,
+    dcache: Option<DCachePtr>,
+    max_backlog: Option<(usize, Duration)>,
+    nodelay: bool,
+    pending_disconnects: Vec<Token>,
+    next_token: usize,
+    bcast_header: [u8; FRAME_HEADER_SIZE],
+    bcast_payload: Vec<u8>,
+}
+
+impl Default for ServerManager {
+    fn default() -> Self {
+        Self {
+            poll: Poll::new().expect("couldn't set up a poll for tcp server"),
+            listeners: Vec::with_capacity(2),
+            streams: Vec::with_capacity(8),
+            on_connect_msg: None,
+            telemetry: TcpTelemetry::Disabled,
+            socket_buf_size: None,
+            user_timeout_ms: DEFAULT_TCP_USER_TIMEOUT_MS,
+            dcache: None,
+            max_backlog: None,
+            nodelay: true,
+            pending_disconnects: Vec::with_capacity(10),
+            next_token: 0,
+            bcast_header: [0; FRAME_HEADER_SIZE],
+            bcast_payload: Vec::with_capacity(TcpStream::SEND_BUF_SIZE),
+        }
+    }
+}
+
+impl ServerManager {
+    fn listen_at(&mut self, addr: SocketAddr) -> Option<Token> {
+        let mut listener = TcpListener::bind(addr)
+            .inspect_err(|err| warn!(?err, %addr, "couldn't start tcp listener"))
+            .ok()?;
+        let token = Token(self.next_token);
+        self.poll
+            .registry()
+            .register(&mut listener, token, Interest::READABLE)
+            .inspect_err(|err| warn!(?err, %addr, "couldn't register tcp listener"))
+            .ok()?;
+        self.next_token += 1;
+        self.listeners.push((token, listener));
+        Some(token)
+    }
+
+    fn accept_connections<F>(&mut self, listener_index: usize, handler: &mut F)
+    where
+        F: for<'a> FnMut(ServerEvent<&'a [u8]>),
+    {
+        let listener_token = self.listeners[listener_index].0;
+        loop {
+            let Ok((mut socket, peer_addr)) = self.listeners[listener_index].1.accept() else {
+                return;
+            };
+            info!(%peer_addr, "tcp server accepted connection");
+            if let Some(size) = self.socket_buf_size {
+                set_socket_buf_size(&socket, size);
+            }
+            let token = Token(self.next_token);
+            if let Err(err) = self.poll.registry().register(&mut socket, token, Interest::READABLE)
+            {
+                error!(?err, %peer_addr, "couldn't register accepted tcp stream");
+                let _ = socket.shutdown(Shutdown::Both);
+                continue;
+            }
+            if self.nodelay &&
+                let Err(err) = socket.set_nodelay(true)
+            {
+                error!(?err, %peer_addr, "couldn't set nodelay on accepted tcp stream");
+                let _ = self.poll.registry().deregister(&mut socket);
+                let _ = socket.shutdown(Shutdown::Both);
+                continue;
+            }
+            set_user_timeout(&socket, self.user_timeout_ms);
+
+            let mut stream = TcpStream::from_stream_with_telemetry(
+                socket,
+                token,
+                peer_addr,
+                self.telemetry,
+                self.dcache.is_some(),
+            );
+            if let Some(message) = &self.on_connect_msg &&
+                stream.write_or_enqueue_with(self.poll.registry(), |buf| {
+                    buf.extend_from_slice(message);
+                }) == ConnState::Disconnected
+            {
+                stream.close(self.poll.registry());
+                continue;
+            }
+
+            self.next_token += 1;
+            handler(ServerEvent::Accept { listener: listener_token, stream: token, peer_addr });
+            self.streams.push((token, stream));
+        }
+    }
+
+    fn handle_event<F>(&mut self, event: &Event, handler: &mut F)
+    where
+        F: for<'a> FnMut(ServerEvent<&'a [u8]>),
+    {
+        let token = event.token();
+        if let Some(index) = self.listeners.iter().position(|(candidate, _)| *candidate == token) {
+            self.accept_connections(index, handler);
+            return;
+        }
+        let Some(index) = self.streams.iter().position(|(candidate, _)| *candidate == token) else {
+            safe_panic!("tcp server got event for unknown token");
+            return;
+        };
+        if self.streams[index].1.poll_with(
+            self.poll.registry(),
+            event,
+            self.dcache.as_deref(),
+            &mut |token, payload, send_ts| {
+                handler(ServerEvent::Message { token, payload, send_ts });
+            },
+        ) == ConnState::Disconnected
+        {
+            handler(ServerEvent::Disconnect { token });
+            self.disconnect_index(index);
+        }
+    }
+
+    fn handle_event_produce<T, P, F>(&mut self, event: &Event, produce: &mut P, handler: &mut F)
+    where
+        T: 'static + Copy,
+        P: SpineProducers + AsRef<SpineProducerWithDCache<T>>,
+        F: for<'a> FnMut(ServerEvent<&'a [u8]>) -> Option<T>,
+    {
+        let token = event.token();
+        if let Some(index) = self.listeners.iter().position(|(candidate, _)| *candidate == token) {
+            self.accept_connections(index, &mut |event| {
+                let _ = handler(event);
+            });
+            return;
+        }
+        let Some(index) = self.streams.iter().position(|(candidate, _)| *candidate == token) else {
+            safe_panic!("tcp server got event for unknown token");
+            return;
+        };
+        let dcache = self.dcache.as_deref().expect("dcache required for poll_with_produce");
+        if self.streams[index].1.poll_with_produce(
+            self.poll.registry(),
+            event,
+            dcache,
+            produce,
+            &mut |token, payload, send_ts| {
+                handler(ServerEvent::Message { token, payload, send_ts })
+            },
+        ) == ConnState::Disconnected
+        {
+            let _ = handler(ServerEvent::Disconnect { token });
+            self.disconnect_index(index);
+        }
+    }
+
+    fn disconnect_index(&mut self, index: usize) {
+        let (_, mut stream) = self.streams.swap_remove(index);
+        stream.close(self.poll.registry());
+    }
+
+    fn disconnect(&mut self, token: Token) {
+        if let Some(index) = self.streams.iter().position(|(candidate, _)| *candidate == token) {
+            self.disconnect_index(index);
+        }
+    }
+
+    fn disconnect_all(&mut self) {
+        while !self.streams.is_empty() {
+            self.disconnect_index(self.streams.len() - 1);
+        }
+    }
+
+    fn remove_listener(&mut self, token: Token) {
+        let Some(index) = self.listeners.iter().position(|(candidate, _)| *candidate == token)
+        else {
+            return;
+        };
+        let (_, mut listener) = self.listeners.swap_remove(index);
+        let _ = self.poll.registry().deregister(&mut listener);
+    }
+
+    fn drain_pending_disconnects<F>(&mut self, handler: &mut F) -> bool
+    where
+        F: for<'a> FnMut(ServerEvent<&'a [u8]>),
+    {
+        let worked = !self.pending_disconnects.is_empty();
+        for token in self.pending_disconnects.drain(..) {
+            handler(ServerEvent::Disconnect { token });
+        }
+        worked
+    }
+
+    fn backlog_exceeded(max_backlog: Option<(usize, Duration)>, stream: &mut TcpStream) -> bool {
+        let Some((max, timeout)) = max_backlog else { return false };
+        if stream.send_backlog.len() <= max {
+            stream.backlog_exceeded_since = None;
+            return false;
+        }
+        let now = Instant::now();
+        let since = stream.backlog_exceeded_since.get_or_insert(now);
+        now.saturating_sub(*since) >= timeout
+    }
+
+    fn broadcast<F>(&mut self, serialise: &F)
+    where
+        F: Fn(&mut Vec<u8>),
+    {
+        self.bcast_payload.clear();
+        serialise(&mut self.bcast_payload);
+        if self.bcast_payload.is_empty() {
+            return;
+        }
+        write_frame_header(&mut self.bcast_header, self.bcast_payload.len(), Nanos::now());
+
+        let mut index = self.streams.len();
+        while index != 0 {
+            index -= 1;
+            let state = self.streams[index].1.write_or_enqueue_shared(
+                self.poll.registry(),
+                &self.bcast_header,
+                &self.bcast_payload,
+            );
+            let backlog_exceeded =
+                Self::backlog_exceeded(self.max_backlog, &mut self.streams[index].1);
+            if state == ConnState::Disconnected || backlog_exceeded {
+                let token = self.streams[index].0;
+                self.disconnect_index(index);
+                self.pending_disconnects.push(token);
+            }
+        }
+    }
+
+    fn write_or_enqueue_with<F>(&mut self, where_to: SendBehavior, serialise: F)
+    where
+        F: Fn(&mut Vec<u8>),
+    {
+        let SendBehavior::Single(token) = where_to else {
+            self.broadcast(&serialise);
+            return;
+        };
+        let Some(index) = self.streams.iter().position(|(candidate, _)| *candidate == token) else {
+            error!(?token, "tcp server send to unknown stream");
+            return;
+        };
+        if self.streams[index].1.write_or_enqueue_with(self.poll.registry(), serialise) ==
+            ConnState::Disconnected ||
+            Self::backlog_exceeded(self.max_backlog, &mut self.streams[index].1)
+        {
+            self.disconnect_index(index);
+            self.pending_disconnects.push(token);
+        }
+    }
+}
+
+/// Non-blocking TCP listener and accepted-connection manager.
+pub struct TcpServer {
+    events: Events,
+    manager: ServerManager,
+}
+
+impl Default for TcpServer {
+    fn default() -> Self {
+        Self { events: Events::with_capacity(128), manager: ServerManager::default() }
+    }
+}
+
+impl TcpServer {
+    pub fn with_on_connect_msg(mut self, msg: Vec<u8>) -> Self {
+        assert!(msg.len() <= TcpStream::SEND_BUF_SIZE, "on_connect_msg exceeds send buffer size");
+        self.manager.on_connect_msg = Some(msg);
+        self
+    }
+
+    pub fn with_dcache(mut self, dcache: DCachePtr) -> Self {
+        self.manager.dcache = Some(dcache);
+        self
+    }
+
+    pub fn with_telemetry(mut self, telemetry: TcpTelemetry) -> Self {
+        self.manager.telemetry = telemetry;
+        self
+    }
+
+    pub fn with_socket_buf_size(mut self, size: usize) -> Self {
+        self.manager.socket_buf_size = Some(size);
+        self
+    }
+
+    pub fn with_user_timeout(mut self, timeout_ms: u32) -> Self {
+        self.manager.user_timeout_ms = timeout_ms;
+        self
+    }
+
+    pub fn with_nodelay(mut self, nodelay: bool) -> Self {
+        self.manager.nodelay = nodelay;
+        self
+    }
+
+    pub fn with_max_backlog(mut self, max: usize, timeout: Duration) -> Self {
+        self.manager.max_backlog = Some((max, timeout));
+        self
+    }
+
+    pub fn listen_at(&mut self, addr: SocketAddr) -> Option<Token> {
+        self.manager.listen_at(addr)
+    }
+
+    pub fn poll_with<F>(&mut self, mut handler: F) -> bool
+    where
+        F: for<'a> FnMut(ServerEvent<&'a [u8]>),
+    {
+        let mut worked = self.manager.drain_pending_disconnects(&mut handler);
+        if let Err(err) = self.manager.poll.poll(&mut self.events, Some(std::time::Duration::ZERO))
+        {
+            safe_panic!("tcp server poll failed: {err}");
+            return false;
+        }
+        for event in &self.events {
+            worked = true;
+            self.manager.handle_event(event, &mut handler);
+        }
+        worked |= self.manager.drain_pending_disconnects(&mut handler);
+        worked
+    }
+
+    pub fn poll_with_produce<T, P, F>(&mut self, produce: &mut P, mut handler: F) -> bool
+    where
+        T: 'static + Copy,
+        P: SpineProducers + AsRef<SpineProducerWithDCache<T>>,
+        F: for<'a> FnMut(ServerEvent<&'a [u8]>) -> Option<T>,
+    {
+        let mut worked = self.manager.drain_pending_disconnects(&mut |event| {
+            let _ = handler(event);
+        });
+        if let Err(err) = self.manager.poll.poll(&mut self.events, Some(std::time::Duration::ZERO))
+        {
+            safe_panic!("tcp server poll failed: {err}");
+            return false;
+        }
+        for event in &self.events {
+            worked = true;
+            self.manager.handle_event_produce(event, produce, &mut handler);
+        }
+        worked |= self.manager.drain_pending_disconnects(&mut |event| {
+            let _ = handler(event);
+        });
+        worked
+    }
+
+    pub fn write_or_enqueue_with<F>(&mut self, where_to: SendBehavior, serialise: F)
+    where
+        F: Fn(&mut Vec<u8>),
+    {
+        self.manager.write_or_enqueue_with(where_to, serialise);
+    }
+
+    /// Permanently closes an accepted connection.
+    pub fn disconnect(&mut self, token: Token) {
+        self.manager.disconnect(token);
+    }
+
+    /// Permanently closes every accepted connection, leaving listeners active.
+    pub fn disconnect_all(&mut self) {
+        self.manager.disconnect_all();
+    }
+
+    /// Stops and removes a listener without affecting accepted connections.
+    pub fn remove_listener(&mut self, token: Token) {
+        self.manager.remove_listener(token);
+    }
+}

--- a/crates/flux-network/src/tcp/stream.rs
+++ b/crates/flux-network/src/tcp/stream.rs
@@ -76,7 +76,7 @@ pub(crate) fn write_frame_header(
 /// Only hit when a socket blocks; the happy path writes `header` and `payload`
 /// as separate `IoSlice`s and never concatenates.
 #[inline]
-fn build_frame_vec(header: &[u8; FRAME_HEADER_SIZE], payload: &[u8]) -> Vec<u8> {
+pub(crate) fn build_frame_vec(header: &[u8; FRAME_HEADER_SIZE], payload: &[u8]) -> Vec<u8> {
     let mut v = Vec::with_capacity(FRAME_HEADER_SIZE + payload.len());
     v.extend_from_slice(header);
     v.extend_from_slice(payload);
@@ -201,6 +201,77 @@ impl TcpStream {
             backlog_exceeded_since: None,
             timers,
         }
+    }
+
+    /// Constructs a client-managed stream with telemetry keyed by its stable
+    /// endpoint token rather than the socket's ephemeral local port.
+    #[inline(never)]
+    pub(crate) fn from_client_stream_with_telemetry(
+        stream: mio::net::TcpStream,
+        token: Token,
+        peer_addr: SocketAddr,
+        telemetry: TcpTelemetry,
+    ) -> Self {
+        let timers = match telemetry {
+            TcpTelemetry::Disabled => None,
+            TcpTelemetry::Enabled { app_name } => {
+                let label = format!("client-{}-{peer_addr}", token.0);
+                Some(TcpTimers::new(app_name, &label))
+            }
+        };
+
+        Self {
+            stream,
+            peer_addr,
+            token,
+            rx_state: RxState::default(),
+            rx_buf: RxBuf::Heap(vec![0; RX_BUF_SIZE]),
+            header_buf: [0; FRAME_HEADER_SIZE],
+            send_buf: vec![0; Self::SEND_BUF_SIZE],
+            send_backlog: VecDeque::with_capacity(64),
+            send_cursor: 0,
+            writable_armed: false,
+            backlog_exceeded_since: None,
+            timers,
+        }
+    }
+
+    /// Installs frames retained by [`TcpClient`](super::TcpClient) while this
+    /// endpoint was disconnected and schedules them after the on-connect
+    /// message.
+    pub(crate) fn install_send_backlog(
+        &mut self,
+        registry: &Registry,
+        backlog: VecDeque<Vec<u8>>,
+        on_connect_msg: Option<&Vec<u8>>,
+    ) -> ConnState {
+        debug_assert!(self.send_backlog.is_empty());
+        self.send_backlog = backlog;
+        if !self.send_backlog.is_empty() {
+            if let Some(message) = on_connect_msg {
+                let already_queued = self.send_backlog.front().is_some_and(|front| {
+                    front.len() >= FRAME_HEADER_SIZE && front[FRAME_HEADER_SIZE..] == **message
+                });
+                if !already_queued {
+                    self.serialise_frame(|bytes| bytes.extend_from_slice(message));
+                    let data = self.alloc_vec(0);
+                    return self.enqueue_front(registry, data);
+                }
+            }
+            self.arm_writable(registry)
+        } else if let Some(message) = on_connect_msg {
+            self.write_or_enqueue_with(registry, |bytes| bytes.extend_from_slice(message))
+        } else {
+            ConnState::Alive
+        }
+    }
+
+    /// Moves queued frames out before a client-managed socket is replaced.
+    pub(crate) fn take_send_backlog(&mut self) -> VecDeque<Vec<u8>> {
+        self.send_cursor = 0;
+        self.writable_armed = false;
+        self.backlog_exceeded_since = None;
+        std::mem::take(&mut self.send_backlog)
     }
 
     #[inline]

--- a/crates/flux-network/tests/tcp_client_server_compat.rs
+++ b/crates/flux-network/tests/tcp_client_server_compat.rs
@@ -1,0 +1,271 @@
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    thread,
+    time::{Duration, Instant},
+};
+
+use flux_network::tcp::{
+    ClientEvent, PollEvent, SendBehavior, ServerEvent, TcpClient, TcpConnector, TcpServer,
+};
+
+const CLIENT_HELLO: &[u8] = b"client-hello";
+const SERVER_HELLO: &[u8] = b"server-hello";
+const REQUEST: &[u8] = b"request-payload";
+const RESPONSE: &[u8] = b"response-payload";
+
+fn unused_addr() -> SocketAddr {
+    let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+    addr
+}
+
+fn contains(messages: &[Vec<u8>], expected: &[u8]) -> bool {
+    messages.iter().any(|message| message == expected)
+}
+
+#[test]
+fn legacy_client_is_wire_compatible_with_new_server() {
+    let addr = unused_addr();
+    let mut server = TcpServer::default().with_on_connect_msg(SERVER_HELLO.to_vec());
+    server.listen_at(addr).expect("new server failed to listen");
+
+    let mut client = TcpConnector::default();
+    let client_token = client.connect(addr).expect("legacy client failed to connect");
+    client.write_or_enqueue_with(SendBehavior::Single(client_token), |buf| {
+        buf.extend_from_slice(REQUEST);
+    });
+
+    let mut server_stream = None;
+    let mut server_messages = Vec::new();
+    let mut client_messages = Vec::new();
+    let mut response_sent = false;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        server.poll_with(|event| match event {
+            ServerEvent::Accept { stream, peer_addr, .. } => {
+                assert_eq!(peer_addr.ip(), addr.ip());
+                server_stream = Some(stream);
+            }
+            ServerEvent::Message { payload, .. } => server_messages.push(payload.to_vec()),
+            ServerEvent::Disconnect { .. } => panic!("new server disconnected unexpectedly"),
+        });
+        client.poll_with(|event| {
+            if let PollEvent::Message { payload, .. } = event {
+                client_messages.push(payload.to_vec());
+            }
+        });
+
+        if !response_sent && contains(&server_messages, REQUEST) {
+            let stream = server_stream.expect("request arrived before accept event");
+            server.write_or_enqueue_with(SendBehavior::Single(stream), |buf| {
+                buf.extend_from_slice(RESPONSE);
+            });
+            response_sent = true;
+        }
+        if contains(&client_messages, SERVER_HELLO) &&
+            contains(&client_messages, RESPONSE) &&
+            contains(&server_messages, REQUEST)
+        {
+            break;
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    assert!(contains(&server_messages, REQUEST));
+    assert!(contains(&client_messages, SERVER_HELLO));
+    assert!(contains(&client_messages, RESPONSE));
+}
+
+#[test]
+fn new_client_is_wire_compatible_with_legacy_server() {
+    let addr = unused_addr();
+    let mut server = TcpConnector::default().with_on_connect_msg(SERVER_HELLO.to_vec());
+    server.listen_at(addr).expect("legacy server failed to listen");
+
+    let mut client = TcpClient::default().with_on_connect_msg(CLIENT_HELLO.to_vec());
+    let client_token = client.connect(addr);
+    // This must be retained behind the on-connect frame until establishment.
+    client.write_or_enqueue_with(SendBehavior::Single(client_token), |buf| {
+        buf.extend_from_slice(REQUEST);
+    });
+
+    let mut server_stream = None;
+    let mut server_messages = Vec::new();
+    let mut client_messages = Vec::new();
+    let mut connected = None;
+    let mut response_sent = false;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        server.poll_with(|event| match event {
+            PollEvent::Accept { stream, .. } => server_stream = Some(stream),
+            PollEvent::Message { payload, .. } => server_messages.push(payload.to_vec()),
+            PollEvent::Disconnect { .. } => panic!("legacy server disconnected unexpectedly"),
+            PollEvent::Reconnect { .. } => panic!("legacy server cannot reconnect inbound streams"),
+        });
+        client.poll_with(|event| match event {
+            ClientEvent::Connected { token, peer_addr } => connected = Some((token, peer_addr)),
+            ClientEvent::Message { payload, .. } => client_messages.push(payload.to_vec()),
+            ClientEvent::Disconnect { .. } => panic!("new client disconnected unexpectedly"),
+        });
+
+        if !response_sent && contains(&server_messages, REQUEST) {
+            let stream = server_stream.expect("request arrived before accept event");
+            server.write_or_enqueue_with(SendBehavior::Single(stream), |buf| {
+                buf.extend_from_slice(RESPONSE);
+            });
+            response_sent = true;
+        }
+        if connected == Some((client_token, addr)) &&
+            server_messages.first().is_some_and(|message| message == CLIENT_HELLO) &&
+            contains(&server_messages, REQUEST) &&
+            contains(&client_messages, SERVER_HELLO) &&
+            contains(&client_messages, RESPONSE)
+        {
+            break;
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    assert_eq!(connected, Some((client_token, addr)));
+    assert_eq!(server_messages.first().map(Vec::as_slice), Some(CLIENT_HELLO));
+    assert!(contains(&server_messages, REQUEST));
+    assert!(contains(&client_messages, SERVER_HELLO));
+    assert!(contains(&client_messages, RESPONSE));
+}
+
+#[test]
+fn new_client_retries_initial_failure_with_the_same_token() {
+    let addr = unused_addr();
+    let mut client =
+        TcpClient::default().with_reconnect_interval(flux_timing::Duration::from_millis(1));
+    let token = client.connect(addr);
+    client.write_or_enqueue_with(SendBehavior::Single(token), |buf| {
+        buf.extend_from_slice(REQUEST);
+    });
+
+    let no_server_deadline = Instant::now() + Duration::from_millis(20);
+    let mut connected_early = false;
+    while Instant::now() < no_server_deadline {
+        client.poll_with(|event| {
+            if let ClientEvent::Connected { .. } = event {
+                connected_early = true;
+            }
+        });
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert!(!connected_early);
+    assert!(client.currently_disconnected().any(|candidate| candidate == token));
+
+    let mut server = TcpServer::default();
+    server.listen_at(addr).expect("new server failed to listen");
+    let mut connected = None;
+    let mut received = None;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline && (connected.is_none() || received.is_none()) {
+        client.poll_with(|event| {
+            if let ClientEvent::Connected { token, peer_addr } = event {
+                connected = Some((token, peer_addr));
+            }
+        });
+        server.poll_with(|event| {
+            if let ServerEvent::Message { payload, .. } = event {
+                received = Some(payload.to_vec());
+            }
+        });
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    assert_eq!(connected, Some((token, addr)));
+    assert_eq!(received.as_deref(), Some(REQUEST));
+    client.disconnect(token);
+    assert!(client.currently_disconnected().any(|candidate| candidate == token));
+    client.remove(token);
+    assert!(!client.currently_disconnected().any(|candidate| candidate == token));
+}
+
+fn receive_after_reconnect(drop_backlog: bool) -> (Option<Vec<u8>>, bool) {
+    let addr = unused_addr();
+    let mut server = TcpServer::default();
+    server.listen_at(addr).expect("new server failed to listen");
+    let mut client = TcpClient::default()
+        .with_reconnect_interval(flux_timing::Duration::from_millis(1))
+        .with_drop_backlog_on_disconnect(drop_backlog);
+    let token = client.connect(addr);
+
+    let mut server_stream = None;
+    let mut initially_connected = false;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline && (server_stream.is_none() || !initially_connected) {
+        server.poll_with(|event| {
+            if let ServerEvent::Accept { stream, .. } = event {
+                server_stream = Some(stream);
+            }
+        });
+        client.poll_with(|event| {
+            if let ClientEvent::Connected { token: event_token, .. } = event {
+                assert_eq!(event_token, token);
+                initially_connected = true;
+            }
+        });
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert!(initially_connected);
+    server.disconnect(server_stream.expect("server did not accept initial connection"));
+
+    let mut disconnected = false;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline && !disconnected {
+        client.poll_with(|event| {
+            if let ClientEvent::Disconnect { token: event_token, .. } = event {
+                assert_eq!(event_token, token);
+                disconnected = true;
+            }
+        });
+        server.poll_with(|_| {});
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert!(disconnected, "client did not observe server disconnect");
+
+    client.write_or_enqueue_with(SendBehavior::Single(token), |buf| {
+        buf.extend_from_slice(REQUEST);
+    });
+    client.force_reconnect();
+
+    let mut received = None;
+    let mut reconnected = false;
+    let mut reconnected_at = None;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        server.poll_with(|event| {
+            if let ServerEvent::Message { payload, .. } = event {
+                received = Some(payload.to_vec());
+            }
+        });
+        client.poll_with(|event| {
+            if let ClientEvent::Connected { token: event_token, peer_addr } = event {
+                assert_eq!(event_token, token);
+                assert_eq!(peer_addr, addr);
+                reconnected = true;
+                reconnected_at = Some(Instant::now());
+            }
+        });
+        if received.is_some() ||
+            reconnected_at.is_some_and(|at| at.elapsed() >= Duration::from_millis(20))
+        {
+            break;
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+    (received, reconnected)
+}
+
+#[test]
+fn new_client_replays_disconnected_backlog_by_default() {
+    assert_eq!(receive_after_reconnect(false), (Some(REQUEST.to_vec()), true));
+}
+
+#[test]
+fn new_client_can_drop_disconnected_backlog() {
+    assert_eq!(receive_after_reconnect(true), (None, true));
+}


### PR DESCRIPTION
# Add dedicated TCP client and server APIs

## Summary

This PR adds role-specific `TcpClient` and `TcpServer` APIs while leaving the
existing `TcpConnector` API and behavior unchanged.

- `TcpClient` manages persistent outbound endpoints with stable tokens.
- `TcpServer` manages listeners and accepted inbound streams.
- Client and server events only expose lifecycle states that are possible for
  their respective roles.
- Both APIs reuse the existing `TcpStream` framing and send paths.

## Client lifecycle

`TcpClient::connect` returns a stable endpoint token immediately. The endpoint
then moves through disconnected, connecting, and connected states as
`poll_with` drives IO.

- Failed initial connections are retried on the configured interval.
- Established connections emit `Connected`, `Disconnect`, and `Message`
  events with the stable endpoint token and peer address where relevant.
- Queued frames are retained across disconnects by default and replayed after
  reconnect.
- Retaining disconnected backlog can be disabled with
  `with_drop_backlog_on_disconnect`.

## Server lifecycle

`TcpServer` separates listener and accepted-stream management from outbound
connection concerns.

- `Accept` reports the listener token, stream token, and peer address.
- `Disconnect` and `Message` only apply to accepted streams.
- Existing on-connect messages, socket options, telemetry, backlog limits,
  broadcast sends, and dcache-backed polling remain available.

## Compatibility

- `TcpConnector` is unchanged and remains the legacy mixed client/server API.
- The TCP frame header, timestamp encoding, payload framing, and on-connect
  message ordering are unchanged.
- Compatibility tests cover a legacy `TcpConnector` client talking to a new
  `TcpServer`, and a new `TcpClient` talking to a legacy `TcpConnector` server.
- Existing users can continue using `TcpConnector` without a lifecycle or wire
  behavior change.

## Testing

- `cargo check`
- `just fmt-check`
- `just clippy`
- `cargo test -p flux-network --tests --no-fail-fast`
- Five new integration tests covering bidirectional legacy compatibility,
  initial connection retry, stable endpoint tokens, retained reconnect
  backlog, and opt-in backlog dropping
