### PR TITLE
fix timers leak

### DIFF
--- a/crates/flux-network/src/tcp/client.rs
+++ b/crates/flux-network/src/tcp/client.rs
@@ -12,8 +12,8 @@ use tracing::{debug, error, warn};
 use crate::tcp::{
     ConnState, SendBehavior, TcpStream, TcpTelemetry,
     stream::{
-        DEFAULT_TCP_USER_TIMEOUT_MS, FRAME_HEADER_SIZE, build_frame_vec, set_socket_buf_size,
-        set_user_timeout, write_frame_header,
+        DEFAULT_TCP_USER_TIMEOUT_MS, FRAME_HEADER_SIZE, TcpTimers, build_frame_vec,
+        set_socket_buf_size, set_user_timeout, write_frame_header,
     },
 };
 
@@ -30,6 +30,7 @@ struct Endpoint {
     token: Token,
     peer_addr: SocketAddr,
     state: EndpointState,
+    timers: Option<TcpTimers>,
     send_backlog: VecDeque<Vec<u8>>,
     backlog_exceeded_since: Option<Instant>,
 }
@@ -87,10 +88,12 @@ impl ClientManager {
     fn connect(&mut self, peer_addr: SocketAddr) -> Token {
         let token = Token(self.next_token);
         self.next_token += 1;
+        let timers = TcpTimers::new_client(self.telemetry, token, peer_addr);
         self.endpoints.push(Endpoint {
             token,
             peer_addr,
             state: EndpointState::Disconnected,
+            timers,
             send_backlog: VecDeque::with_capacity(64),
             backlog_exceeded_since: None,
         });
@@ -187,8 +190,8 @@ impl ClientManager {
             return;
         }
 
-        let mut stream =
-            TcpStream::from_client_stream_with_telemetry(socket, token, peer_addr, self.telemetry);
+        let timers = self.endpoints[index].timers.take();
+        let mut stream = TcpStream::from_client_stream(socket, token, peer_addr, timers);
         let backlog = std::mem::take(&mut self.endpoints[index].send_backlog);
         if stream.install_send_backlog(self.poll.registry(), backlog, self.on_connect_msg.as_ref()) ==
             ConnState::Disconnected
@@ -250,6 +253,7 @@ impl ClientManager {
                 let _ = socket.shutdown(Shutdown::Both);
             }
             EndpointState::Connected(mut stream) => {
+                self.endpoints[index].timers = stream.take_timers();
                 if self.drop_backlog_on_disconnect {
                     self.endpoints[index].send_backlog.clear();
                 } else {

--- a/crates/flux-network/src/tcp/stream.rs
+++ b/crates/flux-network/src/tcp/stream.rs
@@ -35,7 +35,7 @@ pub enum TcpTelemetry {
 
 /// Timers for TCP stream metrics.
 #[derive(Clone, Copy, Debug)]
-struct TcpTimers {
+pub(crate) struct TcpTimers {
     latency: Timer,
     alloc: Timer,
 }
@@ -46,6 +46,16 @@ impl TcpTimers {
             latency: Timer::new(app_name, format!("tcp_latency_{label}")),
             alloc: Timer::new(app_name, format!("tcp_alloc_{label}")),
         }
+    }
+
+    pub(crate) fn new_client(
+        telemetry: TcpTelemetry,
+        token: Token,
+        peer_addr: SocketAddr,
+    ) -> Option<Self> {
+        let TcpTelemetry::Enabled { app_name } = telemetry else { return None };
+        let label = format!("client-{}-{peer_addr}", token.0);
+        Some(Self::new(app_name, &label))
     }
 }
 
@@ -203,23 +213,15 @@ impl TcpStream {
         }
     }
 
-    /// Constructs a client-managed stream with telemetry keyed by its stable
-    /// endpoint token rather than the socket's ephemeral local port.
+    /// Constructs a client-managed stream using timers owned by its persistent
+    /// endpoint and reused across replacement sockets.
     #[inline(never)]
-    pub(crate) fn from_client_stream_with_telemetry(
+    pub(crate) fn from_client_stream(
         stream: mio::net::TcpStream,
         token: Token,
         peer_addr: SocketAddr,
-        telemetry: TcpTelemetry,
+        timers: Option<TcpTimers>,
     ) -> Self {
-        let timers = match telemetry {
-            TcpTelemetry::Disabled => None,
-            TcpTelemetry::Enabled { app_name } => {
-                let label = format!("client-{}-{peer_addr}", token.0);
-                Some(TcpTimers::new(app_name, &label))
-            }
-        };
-
         Self {
             stream,
             peer_addr,
@@ -272,6 +274,12 @@ impl TcpStream {
         self.writable_armed = false;
         self.backlog_exceeded_since = None;
         std::mem::take(&mut self.send_backlog)
+    }
+
+    /// Returns client telemetry to the persistent endpoint before this socket
+    /// is replaced.
+    pub(crate) fn take_timers(&mut self) -> Option<TcpTimers> {
+        self.timers.take()
     }
 
     #[inline]

--- a/crates/flux-network/tests/tcp_client_telemetry.rs
+++ b/crates/flux-network/tests/tcp_client_telemetry.rs
@@ -1,0 +1,84 @@
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    thread,
+    time::{Duration, Instant},
+};
+
+use flux_communication::cleanup_shmem;
+use flux_network::tcp::{ClientEvent, ServerEvent, TcpClient, TcpServer, TcpTelemetry};
+use flux_utils::directories::shmem_dir;
+use mio::Token;
+
+const APP_NAME: &str = "tcp-client-telemetry-reconnect-test";
+
+fn unused_addr() -> SocketAddr {
+    let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+    addr
+}
+
+fn process_mapping_count() -> usize {
+    std::fs::read_to_string("/proc/self/maps").unwrap().lines().count()
+}
+
+fn wait_for_connection(client: &mut TcpClient, server: &mut TcpServer) -> Token {
+    let mut client_connected = false;
+    let mut server_stream = None;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline && (!client_connected || server_stream.is_none()) {
+        client.poll_with(|event| {
+            if let ClientEvent::Connected { .. } = event {
+                client_connected = true;
+            }
+        });
+        server.poll_with(|event| {
+            if let ServerEvent::Accept { stream, .. } = event {
+                server_stream = Some(stream);
+            }
+        });
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert!(client_connected, "client did not connect");
+    server_stream.expect("server did not accept connection")
+}
+
+#[test]
+fn client_reuses_telemetry_mappings_across_reconnects() {
+    let shmem = shmem_dir(APP_NAME);
+    cleanup_shmem(&shmem);
+
+    let addr = unused_addr();
+    let mut server = TcpServer::default();
+    server.listen_at(addr).expect("server failed to listen");
+    let mut client = TcpClient::default()
+        .with_reconnect_interval(flux_timing::Duration::from_millis(1))
+        .with_telemetry(TcpTelemetry::Enabled { app_name: APP_NAME });
+    let _token = client.connect(addr);
+
+    let mut server_stream = wait_for_connection(&mut client, &mut server);
+    let mappings_after_first_connect = process_mapping_count();
+
+    for _ in 0..5 {
+        server.disconnect(server_stream);
+
+        let mut disconnected = false;
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline && !disconnected {
+            client.poll_with(|event| {
+                if let ClientEvent::Disconnect { .. } = event {
+                    disconnected = true;
+                }
+            });
+            server.poll_with(|_| {});
+            thread::sleep(Duration::from_millis(1));
+        }
+        assert!(disconnected, "client did not observe disconnect");
+
+        client.force_reconnect();
+        server_stream = wait_for_connection(&mut client, &mut server);
+    }
+
+    assert_eq!(process_mapping_count(), mappings_after_first_connect);
+    cleanup_shmem(&shmem);
+}


### PR DESCRIPTION
## Summary

- reuse `TcpClient` telemetry timers across reconnects
- keep timer ownership on the persistent client endpoint while disconnected
- add a regression test that verifies reconnects do not add shared-memory mappings

## Problem

Each successful `TcpClient` reconnect created a new pair of telemetry timers. Each
timer opens shared-memory queues whose mappings live for the lifetime of the
process, so repeated reconnects continually increased the client's virtual memory
mappings.

The telemetry sample queues themselves remain bounded and overwrite old samples
when they are not drained; the leak was caused by recreating their mappings.

## Implementation

`TcpTimers` now moves between the persistent client endpoint and its active
`TcpStream`. The endpoint creates the timers once, lends them to each connected
stream, and takes them back before that stream is dropped on disconnect.

This is an internal ownership change. It does not alter the public API, TCP frame
format, connection behavior, or wire compatibility.

## Testing

- added a Linux integration test that forces repeated disconnect/reconnect cycles
  and asserts that `/proc/self/maps` does not grow after the initial connection
- `cargo check --workspace --all-targets`
- `just clippy`
- `cargo test --workspace --all-features --no-run`
- `just fmt-check`
- `git diff --check`
