### PR TITLE
New udp transport

### DIFF
--- a/crates/flux-network/Cargo.toml
+++ b/crates/flux-network/Cargo.toml
@@ -14,7 +14,10 @@ flux-timing.workspace = true
 flux-utils.workspace = true
 libc.workspace = true
 mio.workspace = true
+rand.workspace = true
+rustc-hash.workspace = true
 serde.workspace = true
+thiserror.workspace = true
 tracing.workspace = true
 wincode = { workspace = true, optional = true }
 

--- a/crates/flux-network/src/lib.rs
+++ b/crates/flux-network/src/lib.rs
@@ -1,2 +1,4 @@
 pub mod tcp;
+#[cfg(target_os = "linux")]
+pub mod udp;
 pub use mio::Token;

--- a/crates/flux-network/src/tcp/mod.rs
+++ b/crates/flux-network/src/tcp/mod.rs
@@ -6,4 +6,5 @@ mod stream;
 pub use client::{ClientEvent, TcpClient};
 pub use connector::{PollEvent, SendBehavior, TcpConnector};
 pub use server::{ServerEvent, TcpServer};
+pub(crate) use stream::set_socket_buf_size;
 pub use stream::{ConnState, TcpStream, TcpTelemetry};

--- a/crates/flux-network/src/tcp/server.rs
+++ b/crates/flux-network/src/tcp/server.rs
@@ -1,4 +1,7 @@
-use std::net::{Shutdown, SocketAddr};
+use std::{
+    io,
+    net::{Shutdown, SocketAddr},
+};
 
 use flux::spine::{SpineProducerWithDCache, SpineProducers};
 use flux_timing::{Duration, Instant, Nanos};
@@ -35,6 +38,7 @@ struct ServerManager {
     user_timeout_ms: u32,
     dcache: Option<DCachePtr>,
     max_backlog: Option<(usize, Duration)>,
+    drop_backlog_on_disconnect: bool,
     nodelay: bool,
     pending_disconnects: Vec<Token>,
     next_token: usize,
@@ -54,6 +58,7 @@ impl Default for ServerManager {
             user_timeout_ms: DEFAULT_TCP_USER_TIMEOUT_MS,
             dcache: None,
             max_backlog: None,
+            drop_backlog_on_disconnect: false,
             nodelay: true,
             pending_disconnects: Vec::with_capacity(10),
             next_token: 0,
@@ -64,19 +69,26 @@ impl Default for ServerManager {
 }
 
 impl ServerManager {
-    fn listen_at(&mut self, addr: SocketAddr) -> Option<Token> {
-        let mut listener = TcpListener::bind(addr)
-            .inspect_err(|err| warn!(?err, %addr, "couldn't start tcp listener"))
-            .ok()?;
+    fn try_listen_at(&mut self, addr: SocketAddr) -> io::Result<Token> {
+        let listener = TcpListener::bind(addr)?;
+        self.register_listener(listener)
+    }
+
+    fn register_listener(&mut self, mut listener: TcpListener) -> io::Result<Token> {
         let token = Token(self.next_token);
-        self.poll
-            .registry()
-            .register(&mut listener, token, Interest::READABLE)
-            .inspect_err(|err| warn!(?err, %addr, "couldn't register tcp listener"))
-            .ok()?;
+        self.poll.registry().register(&mut listener, token, Interest::READABLE)?;
         self.next_token += 1;
         self.listeners.push((token, listener));
-        Some(token)
+        Ok(token)
+    }
+
+    fn listen_at(&mut self, addr: SocketAddr) -> Option<Token> {
+        let listener = TcpListener::bind(addr)
+            .inspect_err(|err| warn!(?err, %addr, "couldn't start tcp listener"))
+            .ok()?;
+        self.register_listener(listener)
+            .inspect_err(|err| warn!(?err, %addr, "couldn't register tcp listener"))
+            .ok()
     }
 
     fn accept_connections<F>(&mut self, listener_index: usize, handler: &mut F)
@@ -193,6 +205,9 @@ impl ServerManager {
 
     fn disconnect_index(&mut self, index: usize) {
         let (_, mut stream) = self.streams.swap_remove(index);
+        if self.drop_backlog_on_disconnect {
+            stream.clear_send_backlog();
+        }
         stream.close(self.poll.registry());
     }
 
@@ -339,8 +354,17 @@ impl TcpServer {
         self
     }
 
+    pub fn with_drop_backlog_on_disconnect(mut self, enabled: bool) -> Self {
+        self.manager.drop_backlog_on_disconnect = enabled;
+        self
+    }
+
     pub fn listen_at(&mut self, addr: SocketAddr) -> Option<Token> {
         self.manager.listen_at(addr)
+    }
+
+    pub(crate) fn try_listen_at(&mut self, addr: SocketAddr) -> io::Result<Token> {
+        self.manager.try_listen_at(addr)
     }
 
     pub fn poll_with<F>(&mut self, mut handler: F) -> bool

--- a/crates/flux-network/src/tcp/stream.rs
+++ b/crates/flux-network/src/tcp/stream.rs
@@ -810,23 +810,43 @@ pub(crate) fn set_user_timeout(_stream: &mio::net::TcpStream, _timeout_ms: u32) 
 }
 
 /// Set kernel `SO_SNDBUF` and `SO_RCVBUF` on a socket.
+///
+/// The kernel silently clamps requests to `net.core.wmem_max` /
+/// `net.core.rmem_max`; a warning is logged when that happens because an
+/// undersized buffer shows up as packet loss rather than an error.
 pub(crate) fn set_socket_buf_size(socket: &impl std::os::fd::AsRawFd, size: usize) {
     let fd = socket.as_raw_fd();
-    let size = size as libc::c_int;
-    unsafe {
-        libc::setsockopt(
-            fd,
-            libc::SOL_SOCKET,
-            libc::SO_SNDBUF,
-            ptr::from_ref(&size).cast::<libc::c_void>(),
-            core::mem::size_of::<libc::c_int>() as libc::socklen_t,
-        );
-        libc::setsockopt(
-            fd,
-            libc::SOL_SOCKET,
-            libc::SO_RCVBUF,
-            ptr::from_ref(&size).cast::<libc::c_void>(),
-            core::mem::size_of::<libc::c_int>() as libc::socklen_t,
-        );
+    let requested = size as libc::c_int;
+    for (option, name, limit) in [
+        (libc::SO_SNDBUF, "SO_SNDBUF", "net.core.wmem_max"),
+        (libc::SO_RCVBUF, "SO_RCVBUF", "net.core.rmem_max"),
+    ] {
+        unsafe {
+            libc::setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                option,
+                ptr::from_ref(&requested).cast::<libc::c_void>(),
+                core::mem::size_of::<libc::c_int>() as libc::socklen_t,
+            );
+        }
+
+        let mut granted: libc::c_int = 0;
+        let mut granted_length = core::mem::size_of::<libc::c_int>() as libc::socklen_t;
+        let result = unsafe {
+            libc::getsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                option,
+                ptr::from_mut(&mut granted).cast::<libc::c_void>(),
+                ptr::from_mut(&mut granted_length),
+            )
+        };
+        // The kernel stores and reports double the granted value to account
+        // for bookkeeping overhead, so an unclamped request reads back as
+        // exactly `2 * size`.
+        if result == 0 && i64::from(granted) < 2 * size as i64 {
+            warn!(requested = size, granted, "kernel clamped {name}; raise {limit}");
+        }
     }
 }

--- a/crates/flux-network/src/tcp/stream.rs
+++ b/crates/flux-network/src/tcp/stream.rs
@@ -809,10 +809,9 @@ pub(crate) fn set_user_timeout(_stream: &mio::net::TcpStream, _timeout_ms: u32) 
     // TCP_USER_TIMEOUT is not supported on non-Linux platforms.
 }
 
-/// Set kernel `SO_SNDBUF` and `SO_RCVBUF` on a mio `TcpStream`.
-pub(crate) fn set_socket_buf_size(stream: &mio::net::TcpStream, size: usize) {
-    use std::os::fd::AsRawFd;
-    let fd = stream.as_raw_fd();
+/// Set kernel `SO_SNDBUF` and `SO_RCVBUF` on a socket.
+pub(crate) fn set_socket_buf_size(socket: &impl std::os::fd::AsRawFd, size: usize) {
+    let fd = socket.as_raw_fd();
     let size = size as libc::c_int;
     unsafe {
         libc::setsockopt(

--- a/crates/flux-network/src/udp/control.rs
+++ b/crates/flux-network/src/udp/control.rs
@@ -1,0 +1,246 @@
+use thiserror::Error;
+
+const CONTROL_VERSION: u8 = 1;
+const CONTROL_PREFIX_SIZE: usize = 2; // version + message
+
+const SUBSCRIBE: u8 = 1;
+const STATE: u8 = 2;
+const REPAIR_REQUEST: u8 = 3;
+const REPAIR_DATA: u8 = 4;
+const UNAVAILABLE: u8 = 5;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum SubscriberMessage {
+    Subscribe { udp_port: u16 },
+    Repair { session_id: u32, sequence: u64 },
+}
+
+impl SubscriberMessage {
+    pub(crate) fn encode(&self, output: &mut Vec<u8>) {
+        match self {
+            Self::Subscribe { udp_port } => {
+                begin_message(output, SUBSCRIBE);
+                output.extend_from_slice(&udp_port.to_le_bytes());
+            }
+            Self::Repair { session_id, sequence } => {
+                begin_message(output, REPAIR_REQUEST);
+                output.extend_from_slice(&session_id.to_le_bytes());
+                output.extend_from_slice(&sequence.to_le_bytes());
+            }
+        }
+    }
+
+    pub(crate) fn decode(bytes: &[u8]) -> Result<Self, ControlError> {
+        let (kind, mut reader) = begin_decode(bytes)?;
+        let message = match kind {
+            SUBSCRIBE => Self::Subscribe { udp_port: reader.u16()? },
+            REPAIR_REQUEST => Self::Repair { session_id: reader.u32()?, sequence: reader.u64()? },
+            other => return Err(ControlError::UnsupportedMessage(other)),
+        };
+        finish_decode(&reader)?;
+        validate_subscriber(&message)?;
+        Ok(message)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum PublisherMessage<'a> {
+    State { session_id: u32, next_sequence: u64 },
+    RepairData { session_id: u32, sequence: u64, payload: &'a [u8] },
+    Unavailable { session_id: u32, sequence: u64 },
+}
+
+impl<'a> PublisherMessage<'a> {
+    pub(crate) fn encode(&self, output: &mut Vec<u8>) {
+        match self {
+            Self::State { session_id, next_sequence } => {
+                begin_message(output, STATE);
+                output.extend_from_slice(&session_id.to_le_bytes());
+                output.extend_from_slice(&next_sequence.to_le_bytes());
+            }
+            Self::RepairData { session_id, sequence, payload } => {
+                begin_message(output, REPAIR_DATA);
+                output.extend_from_slice(&session_id.to_le_bytes());
+                output.extend_from_slice(&sequence.to_le_bytes());
+                output.extend_from_slice(payload);
+            }
+            Self::Unavailable { session_id, sequence } => {
+                begin_message(output, UNAVAILABLE);
+                output.extend_from_slice(&session_id.to_le_bytes());
+                output.extend_from_slice(&sequence.to_le_bytes());
+            }
+        }
+    }
+
+    pub(crate) fn decode(bytes: &'a [u8]) -> Result<Self, ControlError> {
+        let (kind, mut reader) = begin_decode(bytes)?;
+        let message = match kind {
+            STATE => Self::State { session_id: reader.u32()?, next_sequence: reader.u64()? },
+            REPAIR_DATA => {
+                let session_id = reader.u32()?;
+                let sequence = reader.u64()?;
+                let payload = reader.remaining();
+                Self::RepairData { session_id, sequence, payload }
+            }
+            UNAVAILABLE => Self::Unavailable { session_id: reader.u32()?, sequence: reader.u64()? },
+            other => return Err(ControlError::UnsupportedMessage(other)),
+        };
+        finish_decode(&reader)?;
+        Ok(message)
+    }
+}
+
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub(crate) enum ControlError {
+    #[error("truncated UDP control message")]
+    Truncated,
+    #[error("unsupported UDP control version {0}")]
+    UnsupportedVersion(u8),
+    #[error("unsupported UDP control message kind {0}")]
+    UnsupportedMessage(u8),
+    #[error("trailing bytes in UDP control message")]
+    TrailingBytes,
+    #[error("subscription UDP port must be nonzero")]
+    InvalidUdpPort,
+}
+
+fn begin_message(output: &mut Vec<u8>, kind: u8) {
+    output.clear();
+    output.push(CONTROL_VERSION);
+    output.push(kind);
+}
+
+fn begin_decode(bytes: &[u8]) -> Result<(u8, Reader<'_>), ControlError> {
+    if bytes.len() < CONTROL_PREFIX_SIZE {
+        return Err(ControlError::Truncated);
+    }
+    if bytes[0] != CONTROL_VERSION {
+        return Err(ControlError::UnsupportedVersion(bytes[0]));
+    }
+    Ok((bytes[1], Reader::new(&bytes[CONTROL_PREFIX_SIZE..])))
+}
+
+fn finish_decode(reader: &Reader<'_>) -> Result<(), ControlError> {
+    if reader.is_empty() { Ok(()) } else { Err(ControlError::TrailingBytes) }
+}
+
+fn validate_subscriber(message: &SubscriberMessage) -> Result<(), ControlError> {
+    match message {
+        SubscriberMessage::Subscribe { udp_port: 0 } => Err(ControlError::InvalidUdpPort),
+        SubscriberMessage::Subscribe { .. } | SubscriberMessage::Repair { .. } => Ok(()),
+    }
+}
+
+struct Reader<'a> {
+    bytes: &'a [u8],
+    cursor: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, cursor: 0 }
+    }
+
+    fn take(&mut self, length: usize) -> Result<&'a [u8], ControlError> {
+        let end = self.cursor.checked_add(length).ok_or(ControlError::Truncated)?;
+        let bytes = self.bytes.get(self.cursor..end).ok_or(ControlError::Truncated)?;
+        self.cursor = end;
+        Ok(bytes)
+    }
+
+    fn u16(&mut self) -> Result<u16, ControlError> {
+        Ok(u16::from_le_bytes(self.take(2)?.try_into().unwrap()))
+    }
+
+    fn u32(&mut self) -> Result<u32, ControlError> {
+        Ok(u32::from_le_bytes(self.take(4)?.try_into().unwrap()))
+    }
+
+    fn u64(&mut self) -> Result<u64, ControlError> {
+        Ok(u64::from_le_bytes(self.take(8)?.try_into().unwrap()))
+    }
+
+    fn remaining(&mut self) -> &'a [u8] {
+        let remaining = &self.bytes[self.cursor..];
+        self.cursor = self.bytes.len();
+        remaining
+    }
+
+    fn is_empty(&self) -> bool {
+        self.cursor == self.bytes.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subscriber_message_roundtrip() {
+        let mut buf = Vec::new();
+        for message in [
+            SubscriberMessage::Subscribe { udp_port: 4567 },
+            SubscriberMessage::Repair { session_id: 0xdead_beef, sequence: u64::MAX },
+        ] {
+            message.encode(&mut buf);
+            assert_eq!(SubscriberMessage::decode(&buf), Ok(message));
+        }
+    }
+
+    #[test]
+    fn publisher_message_roundtrip() {
+        let mut buf = Vec::new();
+        for message in [
+            PublisherMessage::State { session_id: 1, next_sequence: 2 },
+            PublisherMessage::RepairData { session_id: 3, sequence: 4, payload: b"repair bytes" },
+            PublisherMessage::RepairData { session_id: 3, sequence: 4, payload: b"" },
+            PublisherMessage::Unavailable { session_id: 5, sequence: 6 },
+        ] {
+            message.encode(&mut buf);
+            assert_eq!(PublisherMessage::decode(&buf), Ok(message));
+        }
+    }
+
+    #[test]
+    fn decode_rejects_invalid_messages() {
+        let mut subscribe = Vec::new();
+        SubscriberMessage::Subscribe { udp_port: 4567 }.encode(&mut subscribe);
+
+        assert_eq!(SubscriberMessage::decode(&subscribe[..1]), Err(ControlError::Truncated));
+        assert_eq!(
+            SubscriberMessage::decode(&subscribe[..subscribe.len() - 1]),
+            Err(ControlError::Truncated)
+        );
+
+        let mut bad_version = subscribe.clone();
+        bad_version[0] = CONTROL_VERSION + 1;
+        assert_eq!(
+            SubscriberMessage::decode(&bad_version),
+            Err(ControlError::UnsupportedVersion(CONTROL_VERSION + 1))
+        );
+
+        let mut bad_kind = subscribe.clone();
+        bad_kind[1] = 0xff;
+        assert_eq!(
+            SubscriberMessage::decode(&bad_kind),
+            Err(ControlError::UnsupportedMessage(0xff))
+        );
+
+        let mut trailing = subscribe.clone();
+        trailing.push(0);
+        assert_eq!(SubscriberMessage::decode(&trailing), Err(ControlError::TrailingBytes));
+
+        let mut zero_port = Vec::new();
+        SubscriberMessage::Subscribe { udp_port: 0 }.encode(&mut zero_port);
+        assert_eq!(SubscriberMessage::decode(&zero_port), Err(ControlError::InvalidUdpPort));
+
+        // messages must not decode as the opposite direction
+        let mut state = Vec::new();
+        PublisherMessage::State { session_id: 1, next_sequence: 2 }.encode(&mut state);
+        assert_eq!(SubscriberMessage::decode(&state), Err(ControlError::UnsupportedMessage(STATE)));
+        assert_eq!(
+            PublisherMessage::decode(&subscribe),
+            Err(ControlError::UnsupportedMessage(SUBSCRIBE))
+        );
+    }
+}

--- a/crates/flux-network/src/udp/control.rs
+++ b/crates/flux-network/src/udp/control.rs
@@ -178,10 +178,12 @@ mod tests {
     #[test]
     fn subscriber_message_roundtrip() {
         let mut buf = Vec::new();
-        for message in [
-            SubscriberMessage::Subscribe { udp_port: 4567 },
-            SubscriberMessage::Repair { session_id: 0xdead_beef, sequence: u64::MAX },
-        ] {
+        for message in
+            [SubscriberMessage::Subscribe { udp_port: 4567 }, SubscriberMessage::Repair {
+                session_id: 0xdead_beef,
+                sequence: u64::MAX,
+            }]
+        {
             message.encode(&mut buf);
             assert_eq!(SubscriberMessage::decode(&buf), Ok(message));
         }

--- a/crates/flux-network/src/udp/mod.rs
+++ b/crates/flux-network/src/udp/mod.rs
@@ -8,7 +8,6 @@ mod wire;
 pub use publisher::{PublisherEvent, UdpPublisher};
 pub use subscriber::{SubscriberEvent, UdpSubscriber};
 pub use wire::{DEFAULT_IPV4_MAX_DATAGRAM_SIZE, DEFAULT_IPV6_MAX_DATAGRAM_SIZE};
-
 use wire::{MAX_DATAGRAM_SIZE, UDP_HEADER_SIZE, default_max_datagram_size_for};
 
 const DEFAULT_MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024;

--- a/crates/flux-network/src/udp/mod.rs
+++ b/crates/flux-network/src/udp/mod.rs
@@ -11,6 +11,8 @@ pub use wire::{DEFAULT_IPV4_MAX_DATAGRAM_SIZE, DEFAULT_IPV6_MAX_DATAGRAM_SIZE};
 
 use wire::{MAX_DATAGRAM_SIZE, UDP_HEADER_SIZE, default_max_datagram_size_for};
 
+const DEFAULT_MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
+
 pub(crate) struct NativeSocketAddr {
     pub(crate) address: libc::sockaddr_storage,
     pub(crate) address_length: libc::socklen_t,
@@ -62,6 +64,9 @@ pub struct UdpConfig {
     /// across the publisher and all subscribers because it defines the
     /// fragment stride.
     pub max_datagram_size: usize,
+    /// Largest complete application message accepted by either endpoint.
+    /// This bounds subscriber reassembly allocations.
+    pub max_message_size: usize,
     /// Number of recent message sequences retained by the publisher and
     /// tracked by subscribers. Must be a power of two.
     pub sequence_window: usize,
@@ -70,6 +75,9 @@ pub struct UdpConfig {
     pub socket_buf_size: Option<usize>,
     /// How often the publisher broadcasts its next sequence number.
     pub progress_interval: Duration,
+    /// Minimum time a missing or partially assembled message remains pending
+    /// before the subscriber requests full-message repair.
+    pub repair_delay: Duration,
     /// Maximum message sequences with an outstanding repair request per
     /// subscriber.
     pub max_inflight_repair_requests: usize,
@@ -81,9 +89,11 @@ impl UdpConfig {
     pub fn default_for_addr(publisher_addr: SocketAddr) -> Self {
         Self {
             max_datagram_size: default_max_datagram_size_for(publisher_addr),
+            max_message_size: DEFAULT_MAX_MESSAGE_SIZE,
             sequence_window: 65_536,
             socket_buf_size: Some(64 * 1024 * 1024),
             progress_interval: Duration::from_millis(100),
+            repair_delay: Duration::from_millis(1),
             max_inflight_repair_requests: 64,
             reconnect_interval: Duration::from_secs(1),
         }
@@ -104,6 +114,24 @@ impl UdpConfig {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "UDP progress interval must be nonzero",
+            ));
+        }
+
+        if self.max_message_size == 0 || self.max_message_size >= u32::MAX as usize {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "maximum UDP message size {} must be between 1 and {} bytes",
+                    self.max_message_size,
+                    u32::MAX as usize - 1,
+                ),
+            ));
+        }
+
+        if self.repair_delay.as_nanos() > u64::MAX as u128 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "UDP repair delay is too large",
             ));
         }
 

--- a/crates/flux-network/src/udp/mod.rs
+++ b/crates/flux-network/src/udp/mod.rs
@@ -1,0 +1,140 @@
+use std::{io, net::SocketAddr, time::Duration};
+
+mod control;
+mod publisher;
+mod subscriber;
+mod wire;
+
+pub use publisher::{PublisherEvent, UdpPublisher};
+pub use subscriber::{SubscriberEvent, UdpSubscriber};
+pub use wire::{DEFAULT_IPV4_MAX_DATAGRAM_SIZE, DEFAULT_IPV6_MAX_DATAGRAM_SIZE};
+
+use wire::{MAX_DATAGRAM_SIZE, UDP_HEADER_SIZE, default_max_datagram_size_for};
+
+pub(crate) struct NativeSocketAddr {
+    pub(crate) address: libc::sockaddr_storage,
+    pub(crate) address_length: libc::socklen_t,
+}
+
+impl NativeSocketAddr {
+    pub(crate) fn encode(address: SocketAddr) -> Self {
+        let mut storage: libc::sockaddr_storage = unsafe { core::mem::zeroed() };
+        let address_length = match address {
+            SocketAddr::V4(address) => {
+                let encoded = libc::sockaddr_in {
+                    sin_family: libc::AF_INET as libc::sa_family_t,
+                    sin_port: address.port().to_be(),
+                    sin_addr: libc::in_addr { s_addr: u32::from_ne_bytes(address.ip().octets()) },
+                    sin_zero: [0; 8],
+                };
+                unsafe {
+                    core::ptr::write(
+                        core::ptr::from_mut(&mut storage).cast::<libc::sockaddr_in>(),
+                        encoded,
+                    );
+                }
+                core::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t
+            }
+            SocketAddr::V6(address) => {
+                let encoded = libc::sockaddr_in6 {
+                    sin6_family: libc::AF_INET6 as libc::sa_family_t,
+                    sin6_port: address.port().to_be(),
+                    sin6_flowinfo: address.flowinfo().to_be(),
+                    sin6_addr: libc::in6_addr { s6_addr: address.ip().octets() },
+                    sin6_scope_id: address.scope_id(),
+                };
+                unsafe {
+                    core::ptr::write(
+                        core::ptr::from_mut(&mut storage).cast::<libc::sockaddr_in6>(),
+                        encoded,
+                    );
+                }
+                core::mem::size_of::<libc::sockaddr_in6>() as libc::socklen_t
+            }
+        };
+        Self { address: storage, address_length }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct UdpConfig {
+    /// Largest UDP datagram, including the Flux UDP header. This must match
+    /// across the publisher and all subscribers because it defines the
+    /// fragment stride.
+    pub max_datagram_size: usize,
+    /// Number of recent message sequences retained by the publisher and
+    /// tracked by subscribers. Must be a power of two.
+    pub sequence_window: usize,
+    /// Optional kernel send and receive buffer size for UDP and TCP repair
+    /// sockets.
+    pub socket_buf_size: Option<usize>,
+    /// How often the publisher broadcasts its next sequence number.
+    pub progress_interval: Duration,
+    /// Maximum message sequences with an outstanding repair request per
+    /// subscriber.
+    pub max_inflight_repair_requests: usize,
+    /// Delay between subscriber TCP repair reconnection attempts.
+    pub reconnect_interval: Duration,
+}
+
+impl UdpConfig {
+    pub fn default_for_addr(publisher_addr: SocketAddr) -> Self {
+        Self {
+            max_datagram_size: default_max_datagram_size_for(publisher_addr),
+            sequence_window: 65_536,
+            socket_buf_size: Some(64 * 1024 * 1024),
+            progress_interval: Duration::from_millis(100),
+            max_inflight_repair_requests: 64,
+            reconnect_interval: Duration::from_secs(1),
+        }
+    }
+
+    fn validate(&self) -> io::Result<()> {
+        if !self.sequence_window.is_power_of_two() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "UDP sequence window {} must be a nonzero power of two",
+                    self.sequence_window
+                ),
+            ));
+        }
+
+        if self.progress_interval.is_zero() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "UDP progress interval must be nonzero",
+            ));
+        }
+
+        if self.max_inflight_repair_requests == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "maximum inflight UDP repair requests must be nonzero",
+            ));
+        }
+
+        if self.max_datagram_size <= UDP_HEADER_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "maximum UDP datagram size {} is smaller than required minimum: {}",
+                    self.max_datagram_size,
+                    UDP_HEADER_SIZE + 1
+                ),
+            ));
+        }
+
+        if self.max_datagram_size > MAX_DATAGRAM_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "maximum UDP datagram size {} exceeds UDP payload maximum: {MAX_DATAGRAM_SIZE}",
+                    self.max_datagram_size,
+                ),
+            ));
+        }
+
+        Ok(())
+    }
+}

--- a/crates/flux-network/src/udp/publisher.rs
+++ b/crates/flux-network/src/udp/publisher.rs
@@ -1,0 +1,430 @@
+use std::os::fd::AsRawFd;
+use std::{io, net::SocketAddr};
+
+use flux_timing::Repeater;
+use mio::Token;
+use tracing::warn;
+
+use super::{
+    NativeSocketAddr, UdpConfig,
+    control::{self, PublisherMessage, SubscriberMessage},
+    wire::{FragmentHeader, UDP_HEADER_SIZE, encode_fragments},
+};
+use crate::tcp::{SendBehavior, ServerEvent, TcpServer, set_socket_buf_size};
+
+pub enum PublisherEvent {
+    // not necessarily subscribed yet
+    Connected { addr: SocketAddr },
+    Disconnect { addr: SocketAddr },
+}
+
+/// Non-blocking directional publisher for reliable, unordered UDP messages.
+pub struct UdpPublisher {
+    config: UdpConfig,
+    udp_socket: mio::net::UdpSocket,
+    session_id: u32,
+    history: Vec<Vec<u8>>,
+    history_mask: u64,
+    next_sequence: u64,
+    progress_repeater: Repeater,
+
+    // TODO: remove this with new poll_with api
+    pending_control: Vec<(Token, Result<SubscriberMessage, control::ControlError>)>,
+    repair: TcpServer,
+    subscribers: Subscribers,
+    to_disconnect: Vec<Token>,
+}
+
+impl UdpPublisher {
+    /// Make sure the same config is used for the subscriber
+    pub fn new_with_config(addr: SocketAddr, config: UdpConfig) -> io::Result<Self> {
+        config.validate()?;
+
+        let socket = mio::net::UdpSocket::bind(addr)?;
+        if let Some(size) = config.socket_buf_size {
+            set_socket_buf_size(&socket, size);
+        }
+        let mut repair =
+            TcpServer::default().with_nodelay(true).with_drop_backlog_on_disconnect(true);
+        if let Some(size) = config.socket_buf_size {
+            repair = repair.with_socket_buf_size(size);
+        }
+        repair.try_listen_at(addr)?;
+
+        let mut history = Vec::with_capacity(config.sequence_window);
+        history.resize_with(config.sequence_window, Vec::new);
+        let mut progress_repeater = Repeater::every(config.progress_interval.into());
+        progress_repeater.reset();
+
+        Ok(Self {
+            config,
+            udp_socket: socket,
+            repair,
+            session_id: rand::random(),
+            history,
+            history_mask: config.sequence_window as u64 - 1,
+            next_sequence: 0,
+            progress_repeater,
+            to_disconnect: Vec::with_capacity(64),
+            pending_control: Vec::with_capacity(64),
+            subscribers: Subscribers::new(),
+        })
+    }
+
+    pub fn active_subscribers(&self) -> usize {
+        self.subscribers.len()
+    }
+
+    pub fn publish_with<F, G>(&mut self, handler: F, serialise: G)
+    where
+        F: FnMut(PublisherEvent),
+        G: FnOnce(&mut Vec<u8>),
+    {
+        let sequence = self.next_sequence;
+        let index = (sequence & self.history_mask) as usize;
+        let payload = &mut self.history[index];
+        payload.clear();
+        serialise(payload);
+        assert!(payload.len() < u32::MAX as usize, "payload too big");
+
+        self.next_sequence += 1;
+        if self.subscribers.is_empty() {
+            return;
+        }
+
+        self.subscribers.broadcast(
+            &self.udp_socket,
+            self.config.max_datagram_size,
+            self.session_id,
+            sequence,
+            payload,
+            &mut self.to_disconnect,
+        );
+
+        self.disconnect_pending(handler);
+    }
+
+    pub fn poll_with<F>(&mut self, mut handler: F)
+    where
+        F: FnMut(PublisherEvent),
+    {
+        // TODO: owned api in poll_with so we can send immediately
+        self.repair.poll_with(|event| match event {
+            ServerEvent::Accept { stream, peer_addr, .. } => {
+                self.subscribers.add_pending(stream, peer_addr);
+                handler(PublisherEvent::Connected { addr: peer_addr });
+            }
+            ServerEvent::Disconnect { token } => {
+                if let Some(addr) = self.subscribers.remove(token) {
+                    handler(PublisherEvent::Disconnect { addr });
+                }
+            }
+            ServerEvent::Message { token, payload, .. } => {
+                self.pending_control.push((token, SubscriberMessage::decode(payload)));
+            }
+        });
+
+        for (token, msg) in self.pending_control.drain(..) {
+            match msg {
+                Ok(msg) => match msg {
+                    SubscriberMessage::Subscribe { udp_port } => {
+                        if !self.subscribers.set_udp_port(token, udp_port) {
+                            continue;
+                        }
+                        self.repair.write_or_enqueue_with(SendBehavior::Single(token), |buf| {
+                            PublisherMessage::State {
+                                session_id: self.session_id,
+                                next_sequence: self.next_sequence,
+                            }
+                            .encode(buf);
+                        });
+                    }
+                    SubscriberMessage::Repair { session_id, sequence } => {
+                        if self.session_id != session_id {
+                            push_unique(&mut self.to_disconnect, token);
+                            continue;
+                        }
+
+                        let distance = self.next_sequence.saturating_sub(sequence);
+                        if distance == 0 || distance as usize > self.history.len() {
+                            self.repair.write_or_enqueue_with(SendBehavior::Single(token), |buf| {
+                                PublisherMessage::Unavailable {
+                                    session_id: self.session_id,
+                                    sequence,
+                                }
+                                .encode(buf);
+                            });
+                            continue;
+                        }
+
+                        let index = (sequence & self.history_mask) as usize;
+                        let payload = self.history[index].as_slice();
+
+                        self.repair.write_or_enqueue_with(SendBehavior::Single(token), |buf| {
+                            PublisherMessage::RepairData { session_id, sequence, payload }
+                                .encode(buf);
+                        });
+                    }
+                },
+                Err(err) => {
+                    warn!(?err, "udp protocol error");
+                    push_unique(&mut self.to_disconnect, token);
+                }
+            }
+        }
+
+        if self.progress_repeater.fired() {
+            self.repair.write_or_enqueue_with(SendBehavior::Broadcast, |buf| {
+                PublisherMessage::State {
+                    session_id: self.session_id,
+                    next_sequence: self.next_sequence,
+                }
+                .encode(buf);
+            });
+        }
+
+        self.disconnect_pending(handler);
+    }
+
+    fn disconnect_pending<F>(&mut self, mut handler: F)
+    where
+        F: FnMut(PublisherEvent),
+    {
+        if self.to_disconnect.is_empty() {
+            return;
+        }
+        for token in self.to_disconnect.drain(..) {
+            self.repair.disconnect(token);
+            if let Some(addr) = self.subscribers.remove(token) {
+                handler(PublisherEvent::Disconnect { addr });
+            }
+        }
+    }
+}
+
+struct Subscriber {
+    token: Token,
+    peer_addr: SocketAddr,
+    udp_destination: Option<NativeSocketAddr>,
+}
+
+impl Subscriber {
+    fn new(token: Token, peer_addr: SocketAddr) -> Self {
+        Self { token, peer_addr, udp_destination: None }
+    }
+
+    fn update_udp_port(&mut self, udp_port: u16) {
+        let udp_addr = SocketAddr::new(self.peer_addr.ip(), udp_port);
+        self.udp_destination = Some(NativeSocketAddr::encode(udp_addr));
+    }
+}
+
+const SEND_BATCH_SIZE: usize = 64;
+
+struct Subscribers {
+    subs: Vec<Subscriber>,
+    active_count: usize,
+    headers: [[u8; UDP_HEADER_SIZE]; SEND_BATCH_SIZE],
+    iovecs: [[libc::iovec; 2]; SEND_BATCH_SIZE],
+    messages: Vec<libc::mmsghdr>,
+    message_tokens: [Token; SEND_BATCH_SIZE],
+    expected_lengths: [usize; SEND_BATCH_SIZE],
+    fragment_count: usize,
+}
+
+impl Subscribers {
+    fn new() -> Self {
+        Self {
+            subs: Vec::with_capacity(64),
+            active_count: 0,
+            headers: [[0; UDP_HEADER_SIZE]; SEND_BATCH_SIZE],
+            iovecs: core::array::from_fn(|_| {
+                core::array::from_fn(|_| libc::iovec {
+                    iov_base: core::ptr::null_mut(),
+                    iov_len: 0,
+                })
+            }),
+            messages: Vec::with_capacity(SEND_BATCH_SIZE),
+            message_tokens: [Token(0); SEND_BATCH_SIZE],
+            expected_lengths: [0; SEND_BATCH_SIZE],
+            fragment_count: 0,
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.active_count
+    }
+
+    fn is_empty(&self) -> bool {
+        self.active_count == 0
+    }
+
+    fn add_pending(&mut self, token: Token, peer_addr: SocketAddr) {
+        self.subs.push(Subscriber::new(token, peer_addr));
+    }
+
+    fn set_udp_port(&mut self, token: Token, udp_port: u16) -> bool {
+        let Some(sub) = self.subs.iter_mut().find(|sub| sub.token == token) else {
+            return false;
+        };
+        let was_pending = sub.udp_destination.is_none();
+        sub.update_udp_port(udp_port);
+        self.active_count += usize::from(was_pending);
+        true
+    }
+
+    fn remove(&mut self, token: Token) -> Option<SocketAddr> {
+        let index = self.subs.iter().position(|sub| sub.token == token)?;
+        let sub = self.subs.swap_remove(index);
+        self.active_count -= usize::from(sub.udp_destination.is_some());
+        Some(sub.peer_addr)
+    }
+
+    /// Batches up to 64 UDP datagrams across fragments and subscribers per `sendmmsg`.
+    /// Payloads are not copied; the fixed batch stores one `mmsghdr`, token, and
+    /// expected length per datagram, plus one shared header/iovec pair per fragment.
+    fn broadcast(
+        &mut self,
+        socket: &mio::net::UdpSocket,
+        max_datagram_size: usize,
+        session_id: u32,
+        sequence: u64,
+        message: &[u8],
+        failed_tokens: &mut Vec<Token>,
+    ) {
+        self.messages.clear();
+        self.fragment_count = 0;
+
+        let encoded_all = encode_fragments(
+            max_datagram_size,
+            session_id,
+            sequence,
+            message,
+            |header, fragment| self.enqueue_fragment(socket, header, fragment, failed_tokens),
+        );
+        if encoded_all {
+            let _ = self.flush(socket, failed_tokens);
+        }
+    }
+
+    fn enqueue_fragment(
+        &mut self,
+        socket: &mio::net::UdpSocket,
+        header: FragmentHeader,
+        payload: &[u8],
+        failed_tokens: &mut Vec<Token>,
+    ) -> bool {
+        let mut fragment_slot = None;
+        for subscriber_index in 0..self.subs.len() {
+            let token = self.subs[subscriber_index].token;
+            if self.subs[subscriber_index].udp_destination.is_none() {
+                continue;
+            }
+            if failed_tokens.contains(&token) {
+                continue;
+            }
+
+            if self.messages.len() == SEND_BATCH_SIZE {
+                if !self.flush(socket, failed_tokens) {
+                    return false;
+                }
+                fragment_slot = None;
+            }
+
+            let iovec_index = *fragment_slot.get_or_insert_with(|| {
+                let index = self.fragment_count;
+                header.encode(&mut self.headers[index]);
+                self.iovecs[index][0] = libc::iovec {
+                    iov_base: self.headers[index].as_mut_ptr().cast::<libc::c_void>(),
+                    iov_len: UDP_HEADER_SIZE,
+                };
+                self.iovecs[index][1] = libc::iovec {
+                    iov_base: payload.as_ptr().cast_mut().cast::<libc::c_void>(),
+                    iov_len: payload.len(),
+                };
+                self.fragment_count += 1;
+                index
+            });
+
+            let sub = &self.subs[subscriber_index];
+            let destination =
+                sub.udp_destination.as_ref().expect("subscribed subscriber has a UDP destination");
+            let mut msg: libc::mmsghdr = unsafe { core::mem::zeroed() };
+            msg.msg_hdr.msg_name =
+                core::ptr::from_ref(&destination.address).cast_mut().cast::<libc::c_void>();
+            msg.msg_hdr.msg_namelen = destination.address_length;
+            msg.msg_hdr.msg_iov = self.iovecs[iovec_index].as_mut_ptr();
+            msg.msg_hdr.msg_iovlen = self.iovecs[iovec_index].len();
+
+            let message_index = self.messages.len();
+            self.message_tokens[message_index] = token;
+            self.expected_lengths[message_index] = UDP_HEADER_SIZE + payload.len();
+            self.messages.push(msg);
+        }
+        true
+    }
+
+    fn flush(&mut self, socket: &mio::net::UdpSocket, failed_tokens: &mut Vec<Token>) -> bool {
+        let message_count = self.messages.len();
+        let mut cursor = 0;
+        while cursor < message_count {
+            if failed_tokens.contains(&self.message_tokens[cursor]) {
+                cursor += 1;
+                continue;
+            }
+
+            let mut run_end = cursor + 1;
+            while run_end < message_count && !failed_tokens.contains(&self.message_tokens[run_end])
+            {
+                run_end += 1;
+            }
+
+            let sent = unsafe {
+                libc::sendmmsg(
+                    socket.as_raw_fd(),
+                    self.messages.as_mut_ptr().add(cursor),
+                    (run_end - cursor) as libc::c_uint,
+                    libc::MSG_DONTWAIT,
+                )
+            };
+
+            if sent > 0 {
+                let sent = sent as usize;
+                for index in cursor..cursor + sent {
+                    let written = self.messages[index].msg_len as usize;
+                    if written != self.expected_lengths[index] {
+                        push_unique(failed_tokens, self.message_tokens[index]);
+                    }
+                }
+                cursor += sent;
+                continue;
+            }
+
+            let error = if sent == 0 {
+                io::Error::new(io::ErrorKind::WriteZero, "sendmmsg sent no datagrams")
+            } else {
+                io::Error::last_os_error()
+            };
+            if error.kind() == io::ErrorKind::WouldBlock {
+                self.clear_batch();
+                return false;
+            }
+            push_unique(failed_tokens, self.message_tokens[cursor]);
+            cursor += 1;
+        }
+
+        self.clear_batch();
+        true
+    }
+
+    fn clear_batch(&mut self) {
+        self.messages.clear();
+        self.fragment_count = 0;
+    }
+}
+
+fn push_unique(tokens: &mut Vec<Token>, token: Token) {
+    if !tokens.contains(&token) {
+        tokens.push(token);
+    }
+}

--- a/crates/flux-network/src/udp/publisher.rs
+++ b/crates/flux-network/src/udp/publisher.rs
@@ -85,7 +85,10 @@ impl UdpPublisher {
         let payload = &mut self.history[index];
         payload.clear();
         serialise(payload);
-        assert!(payload.len() < u32::MAX as usize, "payload too big");
+        assert!(
+            payload.len() <= self.config.max_message_size,
+            "payload exceeds configured maximum UDP message size"
+        );
 
         self.next_sequence += 1;
         if self.subscribers.is_empty() {

--- a/crates/flux-network/src/udp/publisher.rs
+++ b/crates/flux-network/src/udp/publisher.rs
@@ -1,5 +1,4 @@
-use std::os::fd::AsRawFd;
-use std::{io, net::SocketAddr};
+use std::{io, net::SocketAddr, os::fd::AsRawFd};
 
 use flux_timing::Repeater;
 use mio::Token;
@@ -283,9 +282,10 @@ impl Subscribers {
         Some(sub.peer_addr)
     }
 
-    /// Batches up to 64 UDP datagrams across fragments and subscribers per `sendmmsg`.
-    /// Payloads are not copied; the fixed batch stores one `mmsghdr`, token, and
-    /// expected length per datagram, plus one shared header/iovec pair per fragment.
+    /// Batches up to 64 UDP datagrams across fragments and subscribers per
+    /// `sendmmsg`. Payloads are not copied; the fixed batch stores one
+    /// `mmsghdr`, token, and expected length per datagram, plus one shared
+    /// header/iovec pair per fragment.
     fn broadcast(
         &mut self,
         socket: &mio::net::UdpSocket,

--- a/crates/flux-network/src/udp/subscriber.rs
+++ b/crates/flux-network/src/udp/subscriber.rs
@@ -1,0 +1,730 @@
+use std::{io, net::SocketAddr, os::fd::AsRawFd};
+
+use flux_timing::Nanos;
+use flux_utils::{safe_assert, safe_assert_eq};
+use mio::Token;
+use tracing::{debug, warn};
+
+use super::{
+    NativeSocketAddr, UdpConfig,
+    control::{PublisherMessage, SubscriberMessage},
+    wire::{DatagramError, Fragment, UDP_HEADER_SIZE},
+};
+use crate::tcp::{ClientEvent, SendBehavior, TcpClient, set_socket_buf_size};
+
+/// Result of inserting fragment bytes into a reassembly buffer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum InsertStatus {
+    Duplicate,
+    Incomplete,
+    Complete,
+}
+
+/// Fixed-stride fragment reassembly for one UDP message sequence.
+#[derive(Default)]
+struct ReassemblyBuffer {
+    bytes: Vec<u8>,
+    received: Vec<u64>,
+    fragment_count: usize,
+    received_count: usize,
+}
+
+impl ReassemblyBuffer {
+    fn reset(&mut self, message_length: u32, fragment_payload_size: usize) {
+        safe_assert!(message_length != 0);
+        safe_assert!(fragment_payload_size != 0);
+        self.bytes.resize(message_length as usize, 0);
+        self.fragment_count = self.bytes.len().div_ceil(fragment_payload_size);
+        self.received.resize(self.fragment_count.div_ceil(u64::BITS as usize), 0);
+        self.received.fill(0);
+        self.received_count = 0;
+    }
+
+    fn clear(&mut self) {
+        self.bytes.clear();
+        self.received.clear();
+        self.fragment_count = 0;
+        self.received_count = 0;
+    }
+
+    fn is_initialized(&self) -> bool {
+        self.fragment_count != 0
+    }
+
+    fn message_length(&self) -> u32 {
+        self.bytes.len() as u32
+    }
+
+    fn is_complete(&self) -> bool {
+        self.is_initialized() && self.received_count == self.fragment_count
+    }
+
+    fn payload(&self) -> Option<&[u8]> {
+        self.is_complete().then_some(&self.bytes)
+    }
+
+    fn insert(&mut self, fragment_index: usize, offset: u32, payload: &[u8]) -> InsertStatus {
+        safe_assert!(self.is_initialized());
+        safe_assert!(fragment_index < self.fragment_count);
+        safe_assert!(!payload.is_empty());
+        let word = fragment_index / u64::BITS as usize;
+        let bit = 1_u64 << (fragment_index % u64::BITS as usize);
+        if self.received[word] & bit != 0 {
+            return InsertStatus::Duplicate;
+        }
+
+        let start = offset as usize;
+        let end = start + payload.len();
+        safe_assert!(end <= self.bytes.len());
+        self.bytes[start..end].copy_from_slice(payload);
+        self.received[word] |= bit;
+        self.received_count += 1;
+
+        if self.is_complete() { InsertStatus::Complete } else { InsertStatus::Incomplete }
+    }
+}
+
+const RECV_BATCH_SIZE: usize = 64;
+
+struct RecvMetadata {
+    sources: [libc::sockaddr_storage; RECV_BATCH_SIZE],
+    iovecs: [libc::iovec; RECV_BATCH_SIZE],
+    messages: [libc::mmsghdr; RECV_BATCH_SIZE],
+}
+
+/// Reusable `recvmmsg` storage for up to 64 already-queued datagrams per syscall.
+/// `MSG_DONTWAIT` adds no batching delay. The payload and metadata are heap-backed
+/// because the prewired message headers contain pointers into both allocations,
+/// which must remain stable when the subscriber moves.
+struct RecvBatch {
+    buffer: Box<[u8]>,
+    metadata: Box<RecvMetadata>,
+    stride: usize,
+    used: usize,
+}
+
+impl RecvBatch {
+    fn new(stride: usize) -> Self {
+        let mut buffer = vec![0; RECV_BATCH_SIZE * stride].into_boxed_slice();
+        let mut metadata: Box<RecvMetadata> = Box::new(unsafe { core::mem::zeroed() });
+
+        for index in 0..RECV_BATCH_SIZE {
+            let start = index * stride;
+            metadata.iovecs[index] = libc::iovec {
+                iov_base: buffer[start..].as_mut_ptr().cast::<libc::c_void>(),
+                iov_len: stride,
+            };
+            metadata.messages[index].msg_hdr.msg_name =
+                core::ptr::from_mut(&mut metadata.sources[index]).cast::<libc::c_void>();
+            metadata.messages[index].msg_hdr.msg_namelen =
+                core::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+            metadata.messages[index].msg_hdr.msg_iov =
+                core::ptr::from_mut(&mut metadata.iovecs[index]);
+            metadata.messages[index].msg_hdr.msg_iovlen = 1;
+        }
+
+        Self { buffer, metadata, stride, used: 0 }
+    }
+
+    fn receive(&mut self, socket: &mio::net::UdpSocket) -> io::Result<usize> {
+        for message in &mut self.metadata.messages[..self.used] {
+            message.msg_hdr.msg_namelen =
+                core::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+        }
+        self.used = 0;
+
+        let received = unsafe {
+            libc::recvmmsg(
+                socket.as_raw_fd(),
+                self.metadata.messages.as_mut_ptr(),
+                RECV_BATCH_SIZE as libc::c_uint,
+                libc::MSG_DONTWAIT,
+                core::ptr::null_mut(),
+            )
+        };
+        if received < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            self.used = received as usize;
+            Ok(self.used)
+        }
+    }
+
+    fn source_matches(&self, index: usize, expected: &NativeSocketAddr) -> bool {
+        if self.metadata.messages[index].msg_hdr.msg_namelen != expected.address_length {
+            return false;
+        }
+
+        unsafe {
+            libc::memcmp(
+                core::ptr::from_ref(&self.metadata.sources[index]).cast::<libc::c_void>(),
+                core::ptr::from_ref(&expected.address).cast::<libc::c_void>(),
+                expected.address_length as usize,
+            ) == 0
+        }
+    }
+
+    fn is_truncated(&self, index: usize) -> bool {
+        self.metadata.messages[index].msg_hdr.msg_flags & libc::MSG_TRUNC != 0
+    }
+
+    fn datagram(&self, index: usize) -> &[u8] {
+        let length = self.metadata.messages[index].msg_len as usize;
+        safe_assert!(length <= self.stride);
+        let start = index * self.stride;
+        &self.buffer[start..start + length]
+    }
+}
+
+pub enum SubscriberEvent<'a> {
+    Connected {
+        peer_addr: SocketAddr,
+    },
+    Disconnect {
+        peer_addr: SocketAddr,
+    },
+    /// `ingest_ts` is when the first UDP fragment arrived, or when repair was
+    /// first requested if the message was completely missed on UDP.
+    Message {
+        payload: &'a [u8],
+        ingest_ts: Nanos,
+    },
+}
+
+#[derive(Clone, Copy)]
+enum SlotState {
+    Empty,
+    Pending { ingest_ts: Option<Nanos>, repair_requested: bool },
+    Done,
+}
+
+struct SequenceSlot {
+    sequence: u64,
+    state: SlotState,
+    buffer: ReassemblyBuffer,
+}
+
+impl SequenceSlot {
+    fn new() -> Self {
+        Self { sequence: 0, state: SlotState::Empty, buffer: ReassemblyBuffer::default() }
+    }
+
+    fn reset_pending(&mut self, sequence: u64) {
+        self.sequence = sequence;
+        self.state = SlotState::Pending { ingest_ts: None, repair_requested: false };
+        self.buffer.clear();
+    }
+
+    fn clear(&mut self) {
+        self.state = SlotState::Empty;
+        self.buffer.clear();
+    }
+}
+
+struct SessionState {
+    session_id: u32,
+    fragment_payload_size: usize,
+    window_start: u64,
+    watermark: u64,
+    slots: Vec<SequenceSlot>,
+    window_mask: u64,
+    repair_cursor: usize,
+    pending_count: usize,
+    requested_count: usize,
+}
+
+impl SessionState {
+    fn new(
+        session_id: u32,
+        next_sequence: u64,
+        sequence_window: usize,
+        fragment_payload_size: usize,
+    ) -> Self {
+        Self {
+            session_id,
+            fragment_payload_size,
+            window_start: next_sequence,
+            watermark: next_sequence,
+            slots: (0..sequence_window).map(|_| SequenceSlot::new()).collect(),
+            window_mask: sequence_window as u64 - 1,
+            repair_cursor: 0,
+            pending_count: 0,
+            requested_count: 0,
+        }
+    }
+
+    fn reset(&mut self, session_id: u32, next_sequence: u64) {
+        for slot in &mut self.slots {
+            slot.clear();
+        }
+        self.session_id = session_id;
+        self.window_start = next_sequence;
+        self.watermark = next_sequence;
+        self.repair_cursor = 0;
+        self.pending_count = 0;
+        self.requested_count = 0;
+    }
+
+    fn slot_index(&self, sequence: u64) -> usize {
+        (sequence & self.window_mask) as usize
+    }
+
+    fn is_done(&self, sequence: u64) -> bool {
+        if sequence < self.window_start {
+            return true;
+        }
+        let slot = &self.slots[self.slot_index(sequence)];
+        slot.sequence == sequence && matches!(slot.state, SlotState::Done)
+    }
+
+    fn clear_slot(&mut self, index: usize) -> Option<Nanos> {
+        let slot = &mut self.slots[index];
+        let state = core::mem::replace(&mut slot.state, SlotState::Empty);
+        let ingest_ts = match state {
+            SlotState::Empty => return None,
+            SlotState::Done => None,
+            SlotState::Pending { ingest_ts, repair_requested } => {
+                self.pending_count -= 1;
+                if repair_requested {
+                    self.requested_count -= 1;
+                }
+                ingest_ts
+            }
+        };
+        slot.clear();
+        ingest_ts
+    }
+
+    fn ensure_pending(&mut self, sequence: u64) -> usize {
+        safe_assert!(sequence >= self.window_start);
+        let index = self.slot_index(sequence);
+        if self.slots[index].sequence == sequence {
+            match self.slots[index].state {
+                SlotState::Pending { .. } => return index,
+                SlotState::Done => panic!("completed sequence cannot become pending"),
+                SlotState::Empty => {}
+            }
+        }
+
+        let _ = self.clear_slot(index);
+        if self.pending_count == self.requested_count {
+            self.repair_cursor = index;
+        }
+        self.slots[index].reset_pending(sequence);
+        self.pending_count += 1;
+        index
+    }
+
+    fn pending_mut(&mut self, sequence: u64) -> &mut SequenceSlot {
+        let index = self.ensure_pending(sequence);
+        &mut self.slots[index]
+    }
+
+    fn finish(&mut self, sequence: u64) -> Option<Nanos> {
+        safe_assert!(sequence >= self.window_start);
+        let index = self.slot_index(sequence);
+        let ingest_ts = if self.slots[index].sequence == sequence {
+            self.clear_slot(index)
+        } else {
+            let _ = self.clear_slot(index);
+            None
+        };
+        self.slots[index].sequence = sequence;
+        self.slots[index].state = SlotState::Done;
+        ingest_ts
+    }
+
+    fn mark_requested(&mut self, sequence: u64, request_ts: Nanos) {
+        let index = self.slot_index(sequence);
+        let slot = &mut self.slots[index];
+        assert_eq!(slot.sequence, sequence, "repair slot changed before request was recorded");
+        let SlotState::Pending { ingest_ts, repair_requested } = &mut slot.state else {
+            panic!("repair slot is not pending");
+        };
+        assert!(!*repair_requested, "repair was already requested");
+        *repair_requested = true;
+        ingest_ts.get_or_insert(request_ts);
+        self.requested_count += 1;
+    }
+
+    fn reset_repair_requests(&mut self) {
+        if self.requested_count == 0 {
+            return;
+        }
+        for slot in &mut self.slots {
+            if let SlotState::Pending { repair_requested, .. } = &mut slot.state {
+                *repair_requested = false;
+            }
+        }
+        self.requested_count = 0;
+    }
+
+    fn next_repair(&mut self) -> Option<u64> {
+        if self.pending_count == self.requested_count {
+            return None;
+        }
+
+        for _ in 0..self.slots.len() {
+            let index = self.repair_cursor;
+            self.repair_cursor += 1;
+            if self.repair_cursor == self.slots.len() {
+                self.repair_cursor = 0;
+            }
+            let slot = &self.slots[index];
+            if matches!(slot.state, SlotState::Pending { repair_requested: false, .. }) {
+                return Some(slot.sequence);
+            }
+        }
+        unreachable!("pending repair counts disagree with sequence slots")
+    }
+
+    fn advance_window(&mut self, new_start: u64) {
+        if new_start <= self.window_start {
+            return;
+        }
+
+        let window = self.slots.len() as u64;
+        if new_start - self.window_start >= window {
+            for index in 0..self.slots.len() {
+                let _ = self.clear_slot(index);
+            }
+        } else {
+            for sequence in self.window_start..new_start {
+                let index = self.slot_index(sequence);
+                if self.slots[index].sequence == sequence {
+                    let _ = self.clear_slot(index);
+                }
+            }
+        }
+        self.window_start = new_start;
+        self.watermark = self.watermark.max(new_start);
+    }
+
+    fn maybe_advance_window(&mut self, next_sequence: u64) {
+        let new_start = next_sequence.saturating_sub(self.slots.len() as u64);
+        self.advance_window(new_start);
+    }
+
+    fn observe_watermark(&mut self, next_sequence: u64) {
+        if next_sequence <= self.watermark {
+            return;
+        }
+
+        self.maybe_advance_window(next_sequence);
+        for sequence in self.watermark..next_sequence {
+            if !self.is_done(sequence) {
+                self.ensure_pending(sequence);
+            }
+        }
+        self.watermark = next_sequence;
+    }
+
+    fn insert_fragment<F>(
+        &mut self,
+        fragment: Fragment<'_>,
+        recv_ts: Nanos,
+        handler: &mut F,
+    ) -> Result<(), String>
+    where
+        F: for<'a> FnMut(SubscriberEvent<'a>),
+    {
+        let sequence = fragment.header.seq;
+
+        self.maybe_advance_window(sequence + 1);
+        if self.is_done(sequence) {
+            return Ok(());
+        }
+
+        if fragment.header.offset == 0 && fragment.payload.len() == fragment.header.len as usize {
+            // fast path no reassembly
+            let ingest_ts = self.finish(sequence).unwrap_or(recv_ts);
+            handler(SubscriberEvent::Message { payload: fragment.payload, ingest_ts });
+            return Ok(());
+        }
+
+        let fragment_payload_size = self.fragment_payload_size;
+        let pending = self.pending_mut(sequence);
+        let SlotState::Pending { ingest_ts, .. } = &mut pending.state else {
+            unreachable!("ensured sequence slot is not pending")
+        };
+        ingest_ts.get_or_insert(recv_ts);
+        if pending.buffer.is_initialized() && pending.buffer.message_length() != fragment.header.len
+        {
+            return Err(format!("inconsistent message length for sequence {sequence}"));
+        }
+        if !pending.buffer.is_initialized() {
+            pending.buffer.reset(fragment.header.len, fragment_payload_size);
+        }
+
+        match pending.buffer.insert(fragment.index, fragment.header.offset, fragment.payload) {
+            InsertStatus::Complete => {
+                let index = self.slot_index(sequence);
+                let slot = &self.slots[index];
+                safe_assert_eq!(slot.sequence, sequence);
+                let SlotState::Pending { ingest_ts: Some(ingest_ts), .. } = slot.state else {
+                    unreachable!("complete sequence slot has no ingest timestamp")
+                };
+                let payload = slot.buffer.payload().expect("complete payload is available");
+                handler(SubscriberEvent::Message { payload, ingest_ts });
+                self.finish(sequence);
+                Ok(())
+            }
+            InsertStatus::Duplicate | InsertStatus::Incomplete => Ok(()),
+        }
+    }
+}
+
+pub struct UdpSubscriber {
+    config: UdpConfig,
+    publisher_addr: SocketAddr,
+    publisher_native_addr: NativeSocketAddr,
+    udp_socket: mio::net::UdpSocket,
+    receive_batch: RecvBatch,
+    repair: TcpClient,
+    repair_token: Token,
+    repair_ready: bool,
+    session: Option<SessionState>,
+}
+
+impl UdpSubscriber {
+    /// Make sure the same config is used for the publisher
+    pub fn new_with_config(
+        publisher_addr: SocketAddr,
+        udp_bind_addr: SocketAddr,
+        config: UdpConfig,
+    ) -> io::Result<Self> {
+        config.validate()?;
+
+        let udp_socket = mio::net::UdpSocket::bind(udp_bind_addr)?;
+        if let Some(size) = config.socket_buf_size {
+            set_socket_buf_size(&udp_socket, size);
+        }
+        let udp_addr = udp_socket.local_addr()?;
+        if udp_addr.port() == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::AddrNotAvailable,
+                "subscriber UDP socket did not receive a port",
+            ));
+        }
+        let mut subscribe = Vec::new();
+        SubscriberMessage::Subscribe { udp_port: udp_addr.port() }.encode(&mut subscribe);
+        let mut repair = TcpClient::default()
+            .with_reconnect_interval(config.reconnect_interval.into())
+            .with_on_connect_msg(subscribe)
+            .with_drop_backlog_on_disconnect(true);
+        if let Some(size) = config.socket_buf_size {
+            repair = repair.with_socket_buf_size(size);
+        }
+        let repair_token = repair.connect(publisher_addr);
+
+        Ok(Self {
+            receive_batch: RecvBatch::new(config.max_datagram_size),
+            config,
+            publisher_addr,
+            publisher_native_addr: NativeSocketAddr::encode(publisher_addr),
+            udp_socket,
+            repair,
+            repair_token,
+            repair_ready: false,
+            session: None,
+        })
+    }
+
+    pub fn poll_with<F>(&mut self, mut handler: F)
+    where
+        F: for<'a> FnMut(SubscriberEvent<'a>),
+    {
+        let can_repair = &mut self.repair_ready;
+        let session = &mut self.session;
+        let mut protocol_error = None;
+
+        self.repair.poll_with(|event| {
+            if protocol_error.is_some() {
+                return;
+            }
+
+            match event {
+                ClientEvent::Connected { token: _, peer_addr } => {
+                    *can_repair = false;
+                    if let Some(session) = session.as_mut() {
+                        session.reset_repair_requests();
+                    }
+                    handler(SubscriberEvent::Connected { peer_addr });
+                }
+                ClientEvent::Disconnect { token: _, peer_addr } => {
+                    *can_repair = false;
+                    if let Some(session) = session.as_mut() {
+                        session.reset_repair_requests();
+                    }
+                    handler(SubscriberEvent::Disconnect { peer_addr });
+                }
+                ClientEvent::Message { token: _, payload, .. } => {
+                    let recv_ts = Nanos::now();
+                    match PublisherMessage::decode(payload) {
+                        Ok(PublisherMessage::State { session_id, next_sequence }) => {
+                            match session {
+                                Some(current) if current.session_id == session_id => {
+                                    current.observe_watermark(next_sequence);
+                                }
+                                Some(current) => {
+                                    current.reset(session_id, next_sequence);
+                                }
+                                None => {
+                                    *session = Some(SessionState::new(
+                                        session_id,
+                                        next_sequence,
+                                        self.config.sequence_window,
+                                        self.config.max_datagram_size - UDP_HEADER_SIZE,
+                                    ));
+                                }
+                            }
+                            *can_repair = true;
+                        }
+                        Ok(PublisherMessage::RepairData { session_id, sequence, payload }) => {
+                            let Some(current) = session.as_mut() else { return };
+                            if !*can_repair || current.session_id != session_id {
+                                return;
+                            }
+
+                            if current.is_done(sequence) {
+                                return;
+                            }
+
+                            let ingest_ts = current.finish(sequence).unwrap_or(recv_ts);
+                            handler(SubscriberEvent::Message { payload, ingest_ts });
+                        }
+                        Ok(PublisherMessage::Unavailable { session_id, sequence }) => {
+                            let Some(current) = session.as_mut() else { return };
+                            if !*can_repair || current.session_id != session_id {
+                                return;
+                            }
+
+                            if current.is_done(sequence) {
+                                return;
+                            }
+
+                            current.finish(sequence);
+                            debug!(session_id, sequence, "lost message");
+                        }
+
+                        Err(error) => protocol_error = Some(error.to_string()),
+                    }
+                }
+            }
+        });
+
+        if let Some(error) = protocol_error {
+            self.protocol_error(&error, &mut handler);
+            return;
+        }
+
+        if let Some(error) = self.receive_datagrams(&mut handler) {
+            self.protocol_error(&error, &mut handler);
+            return;
+        }
+
+        self.request_repairs();
+    }
+
+    fn receive_datagrams<F>(&mut self, handler: &mut F) -> Option<String>
+    where
+        F: for<'a> FnMut(SubscriberEvent<'a>),
+    {
+        let mut protocol_error = None;
+        let fragment_payload_size = self.config.max_datagram_size - UDP_HEADER_SIZE;
+
+        loop {
+            let received = match self.receive_batch.receive(&self.udp_socket) {
+                Ok(0) => break,
+                Ok(received) => received,
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => break,
+                Err(error) => {
+                    warn!(%error, "UDP subscriber receive failed");
+                    break;
+                }
+            };
+            let recv_ts = Nanos::now();
+
+            for index in 0..received {
+                if !self.receive_batch.source_matches(index, &self.publisher_native_addr) {
+                    continue;
+                }
+                let Some(session_id) = self.session.as_ref().map(|session| session.session_id)
+                else {
+                    continue;
+                };
+                if self.receive_batch.is_truncated(index) {
+                    protocol_error =
+                        Some("UDP datagram exceeds the configured maximum size".into());
+                    break;
+                }
+
+                let datagram = self.receive_batch.datagram(index);
+                let fragment = match Fragment::decode(datagram, session_id, fragment_payload_size) {
+                    Ok(fragment) => fragment,
+                    Err(DatagramError::UnexpectedSession { .. }) => continue,
+                    Err(error) => {
+                        protocol_error = Some(error.to_string());
+                        break;
+                    }
+                };
+                if let Err(error) = self
+                    .session
+                    .as_mut()
+                    .expect("current session exists")
+                    .insert_fragment(fragment, recv_ts, handler)
+                {
+                    warn!(%error, "UDP subscriber received invalid fragment");
+                }
+            }
+
+            if protocol_error.is_some() {
+                break;
+            }
+        }
+
+        protocol_error
+    }
+
+    fn request_repairs(&mut self) {
+        if !self.repair_ready {
+            return;
+        }
+
+        loop {
+            let Some(session) = self.session.as_mut() else {
+                return;
+            };
+            if session.requested_count >= self.config.max_inflight_repair_requests {
+                return;
+            }
+            let Some(sequence) = session.next_repair() else {
+                return;
+            };
+            let session_id = session.session_id;
+
+            let request_ts = Nanos::now();
+            let request = SubscriberMessage::Repair { session_id, sequence };
+            self.repair.write_or_enqueue_with(SendBehavior::Single(self.repair_token), |output| {
+                request.encode(output);
+            });
+            self.session
+                .as_mut()
+                .expect("repair request requires a session")
+                .mark_requested(sequence, request_ts);
+        }
+    }
+
+    fn protocol_error<F>(&mut self, error: &str, handler: &mut F)
+    where
+        F: for<'a> FnMut(SubscriberEvent<'a>),
+    {
+        warn!(%error, "UDP subscriber protocol error");
+        self.repair_ready = false;
+        if let Some(session) = &mut self.session {
+            session.reset_repair_requests();
+        }
+        self.repair.disconnect(self.repair_token);
+        handler(SubscriberEvent::Disconnect { peer_addr: self.publisher_addr });
+    }
+}

--- a/crates/flux-network/src/udp/subscriber.rs
+++ b/crates/flux-network/src/udp/subscriber.rs
@@ -3,6 +3,7 @@ use std::{io, net::SocketAddr, os::fd::AsRawFd};
 use flux_timing::Nanos;
 use flux_utils::{safe_assert, safe_assert_eq};
 use mio::Token;
+use thiserror::Error;
 use tracing::{debug, warn};
 
 use super::{
@@ -18,6 +19,16 @@ enum InsertStatus {
     Duplicate,
     Incomplete,
     Complete,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+enum InsertFragmentError {
+    #[error("message length {message_length} exceeds configured maximum {maximum}")]
+    MessageTooLarge { message_length: u32, maximum: usize },
+    #[error(
+        "inconsistent message length for sequence {sequence}: expected {expected}, got {actual}"
+    )]
+    InconsistentMessageLength { sequence: u64, expected: u32, actual: u32 },
 }
 
 /// Fixed-stride fragment reassembly for one UDP message sequence.
@@ -194,7 +205,7 @@ pub enum SubscriberEvent<'a> {
 #[derive(Clone, Copy)]
 enum SlotState {
     Empty,
-    Pending { ingest_ts: Option<Nanos>, repair_requested: bool },
+    Pending { ingest_ts: Option<Nanos>, repair_after: Nanos, repair_requested: bool },
     Done,
 }
 
@@ -209,9 +220,9 @@ impl SequenceSlot {
         Self { sequence: 0, state: SlotState::Empty, buffer: ReassemblyBuffer::default() }
     }
 
-    fn reset_pending(&mut self, sequence: u64) {
+    fn reset_pending(&mut self, sequence: u64, repair_after: Nanos) {
         self.sequence = sequence;
-        self.state = SlotState::Pending { ingest_ts: None, repair_requested: false };
+        self.state = SlotState::Pending { ingest_ts: None, repair_after, repair_requested: false };
         self.buffer.clear();
     }
 
@@ -224,6 +235,7 @@ impl SequenceSlot {
 struct SessionState {
     session_id: u32,
     fragment_payload_size: usize,
+    max_message_size: usize,
     window_start: u64,
     watermark: u64,
     slots: Vec<SequenceSlot>,
@@ -231,6 +243,8 @@ struct SessionState {
     repair_cursor: usize,
     pending_count: usize,
     requested_count: usize,
+    repair_delay: Nanos,
+    next_repair_at: Option<Nanos>,
 }
 
 impl SessionState {
@@ -239,10 +253,13 @@ impl SessionState {
         next_sequence: u64,
         sequence_window: usize,
         fragment_payload_size: usize,
+        max_message_size: usize,
+        repair_delay: Nanos,
     ) -> Self {
         Self {
             session_id,
             fragment_payload_size,
+            max_message_size,
             window_start: next_sequence,
             watermark: next_sequence,
             slots: (0..sequence_window).map(|_| SequenceSlot::new()).collect(),
@@ -250,6 +267,8 @@ impl SessionState {
             repair_cursor: 0,
             pending_count: 0,
             requested_count: 0,
+            repair_delay,
+            next_repair_at: None,
         }
     }
 
@@ -263,6 +282,7 @@ impl SessionState {
         self.repair_cursor = 0;
         self.pending_count = 0;
         self.requested_count = 0;
+        self.next_repair_at = None;
     }
 
     fn slot_index(&self, sequence: u64) -> usize {
@@ -283,7 +303,7 @@ impl SessionState {
         let ingest_ts = match state {
             SlotState::Empty => return None,
             SlotState::Done => None,
-            SlotState::Pending { ingest_ts, repair_requested } => {
+            SlotState::Pending { ingest_ts, repair_requested, .. } => {
                 self.pending_count -= 1;
                 if repair_requested {
                     self.requested_count -= 1;
@@ -295,7 +315,7 @@ impl SessionState {
         ingest_ts
     }
 
-    fn ensure_pending(&mut self, sequence: u64) -> usize {
+    fn ensure_pending(&mut self, sequence: u64, observed_at: Nanos) -> usize {
         safe_assert!(sequence >= self.window_start);
         let index = self.slot_index(sequence);
         if self.slots[index].sequence == sequence {
@@ -310,13 +330,16 @@ impl SessionState {
         if self.pending_count == self.requested_count {
             self.repair_cursor = index;
         }
-        self.slots[index].reset_pending(sequence);
+        let repair_after = Nanos(observed_at.0.saturating_add(self.repair_delay.0));
+        self.slots[index].reset_pending(sequence, repair_after);
         self.pending_count += 1;
+        self.next_repair_at =
+            Some(self.next_repair_at.map_or(repair_after, |current| current.min(repair_after)));
         index
     }
 
-    fn pending_mut(&mut self, sequence: u64) -> &mut SequenceSlot {
-        let index = self.ensure_pending(sequence);
+    fn pending_mut(&mut self, sequence: u64, observed_at: Nanos) -> &mut SequenceSlot {
+        let index = self.ensure_pending(sequence, observed_at);
         &mut self.slots[index]
     }
 
@@ -338,7 +361,7 @@ impl SessionState {
         let index = self.slot_index(sequence);
         let slot = &mut self.slots[index];
         assert_eq!(slot.sequence, sequence, "repair slot changed before request was recorded");
-        let SlotState::Pending { ingest_ts, repair_requested } = &mut slot.state else {
+        let SlotState::Pending { ingest_ts, repair_requested, .. } = &mut slot.state else {
             panic!("repair slot is not pending");
         };
         assert!(!*repair_requested, "repair was already requested");
@@ -351,19 +374,30 @@ impl SessionState {
         if self.requested_count == 0 {
             return;
         }
+        let mut next_repair_at = None;
         for slot in &mut self.slots {
-            if let SlotState::Pending { repair_requested, .. } = &mut slot.state {
+            if let SlotState::Pending { repair_after, repair_requested, .. } = &mut slot.state {
                 *repair_requested = false;
+                next_repair_at = Some(
+                    next_repair_at
+                        .map_or(*repair_after, |current: Nanos| current.min(*repair_after)),
+                );
             }
         }
         self.requested_count = 0;
+        self.next_repair_at = next_repair_at;
     }
 
-    fn next_repair(&mut self) -> Option<u64> {
+    fn next_repair(&mut self, now: Nanos) -> Option<u64> {
         if self.pending_count == self.requested_count {
+            self.next_repair_at = None;
+            return None;
+        }
+        if self.next_repair_at.is_some_and(|next| now < next) {
             return None;
         }
 
+        let mut next_repair_at = None;
         for _ in 0..self.slots.len() {
             let index = self.repair_cursor;
             self.repair_cursor += 1;
@@ -371,11 +405,17 @@ impl SessionState {
                 self.repair_cursor = 0;
             }
             let slot = &self.slots[index];
-            if matches!(slot.state, SlotState::Pending { repair_requested: false, .. }) {
-                return Some(slot.sequence);
+            if let SlotState::Pending { repair_after, repair_requested: false, .. } = slot.state {
+                if repair_after <= now {
+                    return Some(slot.sequence);
+                }
+                next_repair_at = Some(
+                    next_repair_at.map_or(repair_after, |current: Nanos| current.min(repair_after)),
+                );
             }
         }
-        unreachable!("pending repair counts disagree with sequence slots")
+        self.next_repair_at = next_repair_at;
+        None
     }
 
     fn advance_window(&mut self, new_start: u64) {
@@ -405,7 +445,7 @@ impl SessionState {
         self.advance_window(new_start);
     }
 
-    fn observe_watermark(&mut self, next_sequence: u64) {
+    fn observe_watermark(&mut self, next_sequence: u64, observed_at: Nanos) {
         if next_sequence <= self.watermark {
             return;
         }
@@ -413,7 +453,7 @@ impl SessionState {
         self.maybe_advance_window(next_sequence);
         for sequence in self.watermark..next_sequence {
             if !self.is_done(sequence) {
-                self.ensure_pending(sequence);
+                self.ensure_pending(sequence, observed_at);
             }
         }
         self.watermark = next_sequence;
@@ -424,11 +464,18 @@ impl SessionState {
         fragment: Fragment<'_>,
         recv_ts: Nanos,
         handler: &mut F,
-    ) -> Result<(), String>
+    ) -> Result<(), InsertFragmentError>
     where
         F: for<'a> FnMut(SubscriberEvent<'a>),
     {
         let sequence = fragment.header.seq;
+
+        if fragment.header.len as usize > self.max_message_size {
+            return Err(InsertFragmentError::MessageTooLarge {
+                message_length: fragment.header.len,
+                maximum: self.max_message_size,
+            });
+        }
 
         self.maybe_advance_window(sequence + 1);
         if self.is_done(sequence) {
@@ -443,14 +490,20 @@ impl SessionState {
         }
 
         let fragment_payload_size = self.fragment_payload_size;
-        let pending = self.pending_mut(sequence);
+        let pending = self.pending_mut(sequence, recv_ts);
         let SlotState::Pending { ingest_ts, .. } = &mut pending.state else {
             unreachable!("ensured sequence slot is not pending")
         };
         ingest_ts.get_or_insert(recv_ts);
-        if pending.buffer.is_initialized() && pending.buffer.message_length() != fragment.header.len
-        {
-            return Err(format!("inconsistent message length for sequence {sequence}"));
+        if pending.buffer.is_initialized() {
+            let expected = pending.buffer.message_length();
+            if expected != fragment.header.len {
+                return Err(InsertFragmentError::InconsistentMessageLength {
+                    sequence,
+                    expected,
+                    actual: fragment.header.len,
+                });
+            }
         }
         if !pending.buffer.is_initialized() {
             pending.buffer.reset(fragment.header.len, fragment_payload_size);
@@ -534,6 +587,10 @@ impl UdpSubscriber {
     where
         F: for<'a> FnMut(SubscriberEvent<'a>),
     {
+        let max_message_size = self.config.max_message_size;
+        let repair_delay = Nanos(self.config.repair_delay.as_nanos() as u64);
+        let sequence_window = self.config.sequence_window;
+        let fragment_payload_size = self.config.max_datagram_size - UDP_HEADER_SIZE;
         let can_repair = &mut self.repair_ready;
         let session = &mut self.session;
         let mut protocol_error = None;
@@ -564,7 +621,7 @@ impl UdpSubscriber {
                         Ok(PublisherMessage::State { session_id, next_sequence }) => {
                             match session {
                                 Some(current) if current.session_id == session_id => {
-                                    current.observe_watermark(next_sequence);
+                                    current.observe_watermark(next_sequence, recv_ts);
                                 }
                                 Some(current) => {
                                     current.reset(session_id, next_sequence);
@@ -573,8 +630,10 @@ impl UdpSubscriber {
                                     *session = Some(SessionState::new(
                                         session_id,
                                         next_sequence,
-                                        self.config.sequence_window,
-                                        self.config.max_datagram_size - UDP_HEADER_SIZE,
+                                        sequence_window,
+                                        fragment_payload_size,
+                                        max_message_size,
+                                        repair_delay,
                                     ));
                                 }
                             }
@@ -583,6 +642,14 @@ impl UdpSubscriber {
                         Ok(PublisherMessage::RepairData { session_id, sequence, payload }) => {
                             let Some(current) = session.as_mut() else { return };
                             if !*can_repair || current.session_id != session_id {
+                                return;
+                            }
+                            if payload.len() > max_message_size {
+                                protocol_error = Some(format!(
+                                    "repair payload length {} exceeds configured maximum {}",
+                                    payload.len(),
+                                    max_message_size
+                                ));
                                 return;
                             }
 
@@ -691,6 +758,7 @@ impl UdpSubscriber {
             return;
         }
 
+        let request_ts = Nanos::now();
         loop {
             let Some(session) = self.session.as_mut() else {
                 return;
@@ -698,12 +766,11 @@ impl UdpSubscriber {
             if session.requested_count >= self.config.max_inflight_repair_requests {
                 return;
             }
-            let Some(sequence) = session.next_repair() else {
+            let Some(sequence) = session.next_repair(request_ts) else {
                 return;
             };
             let session_id = session.session_id;
 
-            let request_ts = Nanos::now();
             let request = SubscriberMessage::Repair { session_id, sequence };
             self.repair.write_or_enqueue_with(SendBehavior::Single(self.repair_token), |output| {
                 request.encode(output);

--- a/crates/flux-network/src/udp/subscriber.rs
+++ b/crates/flux-network/src/udp/subscriber.rs
@@ -103,10 +103,10 @@ struct RecvMetadata {
     messages: [libc::mmsghdr; RECV_BATCH_SIZE],
 }
 
-/// Reusable `recvmmsg` storage for up to 64 already-queued datagrams per syscall.
-/// `MSG_DONTWAIT` adds no batching delay. The payload and metadata are heap-backed
-/// because the prewired message headers contain pointers into both allocations,
-/// which must remain stable when the subscriber moves.
+/// Reusable `recvmmsg` storage for up to 64 already-queued datagrams per
+/// syscall. `MSG_DONTWAIT` adds no batching delay. The payload and metadata are
+/// heap-backed because the prewired message headers contain pointers into both
+/// allocations, which must remain stable when the subscriber moves.
 struct RecvBatch {
     buffer: Box<[u8]>,
     metadata: Box<RecvMetadata>,

--- a/crates/flux-network/src/udp/wire.rs
+++ b/crates/flux-network/src/udp/wire.rs
@@ -1,0 +1,316 @@
+use std::net::SocketAddr;
+
+use thiserror::Error;
+
+/// Magic bytes at the start of every UDP datagram.
+pub const UDP_MAGIC: [u8; 3] = *b"FLX";
+/// Reliable UDP wire version implemented by this module.
+pub const UDP_VERSION: u8 = 1;
+/// Size of the fixed version 1 UDP header.
+pub const UDP_HEADER_SIZE: usize = 24;
+/// Default maximum UDP payload for an IPv4 publisher, including the Flux
+/// header.
+pub const DEFAULT_IPV4_MAX_DATAGRAM_SIZE: usize = 1400;
+/// Default maximum UDP payload for an IPv6 publisher, including the Flux
+/// header.
+pub const DEFAULT_IPV6_MAX_DATAGRAM_SIZE: usize = 1200;
+/// Largest portable UDP payload supported by the encoder (IPv4 maximum).
+pub const MAX_DATAGRAM_SIZE: usize = 65_507;
+
+/// Selects the family-specific default from the publisher address.
+pub fn default_max_datagram_size_for(publisher_addr: SocketAddr) -> usize {
+    if publisher_addr.is_ipv4() {
+        DEFAULT_IPV4_MAX_DATAGRAM_SIZE
+    } else {
+        DEFAULT_IPV6_MAX_DATAGRAM_SIZE
+    }
+}
+
+/// Fixed, self-describing header carried by every UDP fragment.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct FragmentHeader {
+    pub(crate) session_id: u32,
+    pub(crate) seq: u64,
+    pub(crate) len: u32,
+    pub(crate) offset: u32,
+}
+
+impl FragmentHeader {
+    pub(crate) fn encode(self, buf: &mut [u8; UDP_HEADER_SIZE]) {
+        buf[..3].copy_from_slice(&UDP_MAGIC);
+        buf[3] = UDP_VERSION;
+        buf[4..8].copy_from_slice(&self.session_id.to_le_bytes());
+        buf[8..16].copy_from_slice(&self.seq.to_le_bytes());
+        buf[16..20].copy_from_slice(&self.len.to_le_bytes());
+        buf[20..24].copy_from_slice(&self.offset.to_le_bytes());
+    }
+
+    pub(crate) fn decode(bytes: &[u8]) -> Result<Self, DatagramError> {
+        if bytes.len() < UDP_HEADER_SIZE {
+            return Err(DatagramError::Truncated { actual: bytes.len() });
+        }
+        if bytes[..3] != UDP_MAGIC {
+            return Err(DatagramError::InvalidMagic);
+        }
+        if bytes[3] != UDP_VERSION {
+            return Err(DatagramError::UnsupportedVersion(bytes[3]));
+        }
+
+        Ok(Self {
+            session_id: u32::from_le_bytes(bytes[4..8].try_into().unwrap()),
+            seq: u64::from_le_bytes(bytes[8..16].try_into().unwrap()),
+            len: u32::from_le_bytes(bytes[16..20].try_into().unwrap()),
+            offset: u32::from_le_bytes(bytes[20..24].try_into().unwrap()),
+        })
+    }
+}
+
+/// A validated borrowed UDP fragment.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct Fragment<'a> {
+    pub(crate) header: FragmentHeader,
+    pub(crate) index: usize,
+    pub(crate) payload: &'a [u8],
+}
+
+impl<'a> Fragment<'a> {
+    pub(crate) fn decode(
+        datagram: &'a [u8],
+        expected_session: u32,
+        fragment_payload_size: usize,
+    ) -> Result<Self, DatagramError> {
+        let header = FragmentHeader::decode(datagram)?;
+
+        if header.session_id != expected_session {
+            return Err(DatagramError::UnexpectedSession {
+                expected: expected_session,
+                actual: header.session_id,
+            });
+        }
+
+        let payload = &datagram[UDP_HEADER_SIZE..];
+        if payload.is_empty() {
+            if header.len != 0 || header.offset != 0 {
+                return Err(DatagramError::EmptyFragment);
+            }
+            return Ok(Fragment { header, index: 0, payload });
+        }
+
+        if header.offset >= header.len {
+            return Err(DatagramError::FragmentOutOfBounds {
+                offset: header.offset,
+                payload_length: payload.len(),
+                message_length: header.len,
+            });
+        }
+        if !(header.offset as usize).is_multiple_of(fragment_payload_size) {
+            return Err(DatagramError::MisalignedFragment {
+                offset: header.offset,
+                fragment_payload_size,
+            });
+        }
+
+        let remaining = (header.len - header.offset) as usize;
+        let expected_length = remaining.min(fragment_payload_size);
+        if payload.len() != expected_length {
+            return Err(DatagramError::InvalidFragmentLength {
+                offset: header.offset,
+                actual: payload.len(),
+                expected: expected_length,
+                message_length: header.len,
+            });
+        }
+
+        Ok(Fragment { header, index: header.offset as usize / fragment_payload_size, payload })
+    }
+}
+
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub(crate) enum DatagramError {
+    #[error("UDP datagram is truncated ({actual} bytes)")]
+    Truncated { actual: usize },
+    #[error("UDP datagram has invalid magic")]
+    InvalidMagic,
+    #[error("unsupported UDP protocol version {0}")]
+    UnsupportedVersion(u8),
+    #[error("UDP datagram session {actual} does not match authoritative session {expected}")]
+    UnexpectedSession { expected: u32, actual: u32 },
+    #[error("non-empty UDP message fragment has no payload")]
+    EmptyFragment,
+    #[error(
+        "UDP fragment at offset {offset} with length {payload_length} is outside message length {message_length}"
+    )]
+    FragmentOutOfBounds { offset: u32, payload_length: usize, message_length: u32 },
+    #[error(
+        "UDP fragment offset {offset} is not aligned to fragment payload size {fragment_payload_size}"
+    )]
+    MisalignedFragment { offset: u32, fragment_payload_size: usize },
+    #[error(
+        "UDP fragment at offset {offset} has length {actual}, expected {expected} for message length {message_length}"
+    )]
+    InvalidFragmentLength { offset: u32, actual: usize, expected: usize, message_length: u32 },
+}
+
+pub(crate) fn encode_fragments<F>(
+    max_datagram_size: usize,
+    session_id: u32,
+    seq: u64,
+    message: &[u8],
+    mut emit: F,
+) -> bool
+where
+    F: FnMut(FragmentHeader, &[u8]) -> bool,
+{
+    let len = message.len() as u32;
+    if message.is_empty() {
+        let header = FragmentHeader { session_id, seq, len, offset: 0 };
+        return emit(header, message);
+    }
+
+    let fragment_payload_size = max_datagram_size - UDP_HEADER_SIZE;
+    for (index, payload) in message.chunks(fragment_payload_size).enumerate() {
+        let offset = (index * fragment_payload_size) as u32;
+        let header = FragmentHeader { session_id, seq, len, offset };
+        if !emit(header, payload) {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SESSION: u32 = 0x1234_5678;
+    const FRAGMENT_PAYLOAD_SIZE: usize = 4;
+
+    fn datagram(header: FragmentHeader, payload: &[u8]) -> Vec<u8> {
+        let mut buf = [0; UDP_HEADER_SIZE];
+        header.encode(&mut buf);
+        let mut bytes = buf.to_vec();
+        bytes.extend_from_slice(payload);
+        bytes
+    }
+
+    fn decode(bytes: &[u8]) -> Result<Fragment<'_>, DatagramError> {
+        Fragment::decode(bytes, SESSION, FRAGMENT_PAYLOAD_SIZE)
+    }
+
+    #[test]
+    fn fragment_roundtrip() {
+        let header = FragmentHeader { session_id: SESSION, seq: 42, len: 10, offset: 4 };
+        let bytes = datagram(header, b"4567");
+        let fragment = decode(&bytes).unwrap();
+        assert_eq!(fragment.header, header);
+        assert_eq!(fragment.index, 1);
+        assert_eq!(fragment.payload, b"4567");
+    }
+
+    #[test]
+    fn tail_fragment_roundtrip() {
+        let header = FragmentHeader { session_id: SESSION, seq: 42, len: 10, offset: 8 };
+        let bytes = datagram(header, b"89");
+        let fragment = decode(&bytes).unwrap();
+        assert_eq!(fragment.header, header);
+        assert_eq!(fragment.index, 2);
+        assert_eq!(fragment.payload, b"89");
+    }
+
+    #[test]
+    fn empty_message_roundtrip() {
+        let header = FragmentHeader { session_id: SESSION, seq: 7, len: 0, offset: 0 };
+        let bytes = datagram(header, b"");
+        let fragment = decode(&bytes).unwrap();
+        assert_eq!(fragment.header, header);
+        assert_eq!(fragment.index, 0);
+        assert!(fragment.payload.is_empty());
+    }
+
+    #[test]
+    fn encode_fragments_roundtrip() {
+        let message = b"0123456789a"; // fragments of 4, 4 and 3 bytes
+        let mut reassembled = vec![0; message.len()];
+        let mut fragments = 0;
+        let encoded_all = encode_fragments(
+            UDP_HEADER_SIZE + FRAGMENT_PAYLOAD_SIZE,
+            SESSION,
+            9,
+            message,
+            |header, payload| {
+                let bytes = datagram(header, payload);
+                let fragment = decode(&bytes).unwrap();
+                assert_eq!(fragment.header.seq, 9);
+                assert_eq!(fragment.header.len, message.len() as u32);
+                let offset = fragment.index * FRAGMENT_PAYLOAD_SIZE;
+                reassembled[offset..offset + payload.len()].copy_from_slice(fragment.payload);
+                fragments += 1;
+                true
+            },
+        );
+        assert!(encoded_all);
+        assert_eq!(fragments, 3);
+        assert_eq!(&reassembled[..], &message[..]);
+    }
+
+    #[test]
+    fn decode_rejects_invalid_datagrams() {
+        let valid =
+            datagram(FragmentHeader { session_id: SESSION, seq: 1, len: 4, offset: 0 }, b"abcd");
+
+        assert_eq!(
+            decode(&valid[..UDP_HEADER_SIZE - 1]),
+            Err(DatagramError::Truncated { actual: UDP_HEADER_SIZE - 1 })
+        );
+
+        let mut bad_magic = valid.clone();
+        bad_magic[0] = b'X';
+        assert_eq!(decode(&bad_magic), Err(DatagramError::InvalidMagic));
+
+        let mut bad_version = valid.clone();
+        bad_version[3] = UDP_VERSION + 1;
+        assert_eq!(decode(&bad_version), Err(DatagramError::UnsupportedVersion(UDP_VERSION + 1)));
+
+        assert_eq!(
+            Fragment::decode(&valid, SESSION + 1, FRAGMENT_PAYLOAD_SIZE),
+            Err(DatagramError::UnexpectedSession { expected: SESSION + 1, actual: SESSION })
+        );
+
+        let past_end =
+            datagram(FragmentHeader { session_id: SESSION, seq: 1, len: 4, offset: 4 }, b"x");
+        assert_eq!(
+            decode(&past_end),
+            Err(DatagramError::FragmentOutOfBounds {
+                offset: 4,
+                payload_length: 1,
+                message_length: 4
+            })
+        );
+
+        let misaligned =
+            datagram(FragmentHeader { session_id: SESSION, seq: 1, len: 10, offset: 2 }, b"abcd");
+        assert_eq!(
+            decode(&misaligned),
+            Err(DatagramError::MisalignedFragment {
+                offset: 2,
+                fragment_payload_size: FRAGMENT_PAYLOAD_SIZE
+            })
+        );
+
+        let short_non_tail =
+            datagram(FragmentHeader { session_id: SESSION, seq: 1, len: 10, offset: 4 }, b"abc");
+        assert_eq!(
+            decode(&short_non_tail),
+            Err(DatagramError::InvalidFragmentLength {
+                offset: 4,
+                actual: 3,
+                expected: 4,
+                message_length: 10
+            })
+        );
+
+        let missing_payload =
+            datagram(FragmentHeader { session_id: SESSION, seq: 1, len: 4, offset: 0 }, b"");
+        assert_eq!(decode(&missing_payload), Err(DatagramError::EmptyFragment));
+    }
+}

--- a/crates/flux-network/tests/tcp_client_server_compat.rs
+++ b/crates/flux-network/tests/tcp_client_server_compat.rs
@@ -1,5 +1,6 @@
 use std::{
-    net::{Ipv4Addr, SocketAddr},
+    io::{Read, Write},
+    net::{Ipv4Addr, SocketAddr, TcpStream as StdTcpStream},
     thread,
     time::{Duration, Instant},
 };
@@ -12,6 +13,7 @@ const CLIENT_HELLO: &[u8] = b"client-hello";
 const SERVER_HELLO: &[u8] = b"server-hello";
 const REQUEST: &[u8] = b"request-payload";
 const RESPONSE: &[u8] = b"response-payload";
+const FRAME_HEADER_SIZE: usize = size_of::<u32>() + size_of::<u64>();
 
 fn unused_addr() -> SocketAddr {
     let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
@@ -22,6 +24,23 @@ fn unused_addr() -> SocketAddr {
 
 fn contains(messages: &[Vec<u8>], expected: &[u8]) -> bool {
     messages.iter().any(|message| message == expected)
+}
+
+fn write_raw_frame(stream: &mut StdTcpStream, payload: &[u8]) {
+    let mut frame = Vec::with_capacity(FRAME_HEADER_SIZE + payload.len());
+    frame.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+    frame.extend_from_slice(&0u64.to_le_bytes());
+    frame.extend_from_slice(payload);
+    stream.write_all(&frame).unwrap();
+}
+
+fn read_raw_frame(stream: &mut StdTcpStream) -> Vec<u8> {
+    let mut header = [0; FRAME_HEADER_SIZE];
+    stream.read_exact(&mut header).unwrap();
+    let payload_len = u32::from_le_bytes(header[..size_of::<u32>()].try_into().unwrap()) as usize;
+    let mut payload = vec![0; payload_len];
+    stream.read_exact(&mut payload).unwrap();
+    payload
 }
 
 #[test]
@@ -268,4 +287,49 @@ fn new_client_replays_disconnected_backlog_by_default() {
 #[test]
 fn new_client_can_drop_disconnected_backlog() {
     assert_eq!(receive_after_reconnect(true), (None, true));
+}
+
+#[test]
+fn server_token_lookup_survives_middle_stream_removal() {
+    let addr = unused_addr();
+    let mut server = TcpServer::default();
+    server.listen_at(addr).expect("server failed to listen");
+
+    let mut clients = Vec::new();
+    let mut server_tokens = Vec::new();
+    for _ in 0..3 {
+        let client = StdTcpStream::connect(addr).unwrap();
+        client.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+        clients.push(client);
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while server_tokens.len() != clients.len() && Instant::now() < deadline {
+            server.poll_with(|event| {
+                if let ServerEvent::Accept { stream, .. } = event {
+                    server_tokens.push(stream);
+                }
+            });
+            thread::sleep(Duration::from_millis(1));
+        }
+        assert_eq!(server_tokens.len(), clients.len());
+    }
+
+    server.disconnect(server_tokens[1]);
+    server.write_or_enqueue_with(SendBehavior::Single(server_tokens[2]), |output| {
+        output.extend_from_slice(RESPONSE);
+    });
+    assert_eq!(read_raw_frame(&mut clients[2]), RESPONSE);
+
+    write_raw_frame(&mut clients[2], REQUEST);
+    let mut received = None;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while received.is_none() && Instant::now() < deadline {
+        server.poll_with(|event| {
+            if let ServerEvent::Message { token, payload, .. } = event {
+                received = Some((token, payload.to_vec()));
+            }
+        });
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(received, Some((server_tokens[2], REQUEST.to_vec())));
 }

--- a/crates/flux-network/tests/udp_publisher_subscriber.rs
+++ b/crates/flux-network/tests/udp_publisher_subscriber.rs
@@ -1,0 +1,76 @@
+#![cfg(target_os = "linux")]
+
+use std::{
+    net::{Ipv4Addr, SocketAddr, TcpListener, UdpSocket},
+    thread,
+    time::{Duration, Instant},
+};
+
+use flux_network::udp::{
+    DEFAULT_IPV4_MAX_DATAGRAM_SIZE, PublisherEvent, SubscriberEvent, UdpPublisher, UdpSubscriber,
+};
+
+fn unused_addr() -> SocketAddr {
+    let tcp = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let addr = tcp.local_addr().unwrap();
+    let udp = UdpSocket::bind(addr).unwrap();
+    drop((tcp, udp));
+    addr
+}
+
+fn poll_network(
+    publisher: &mut UdpPublisher,
+    subscriber: &mut UdpSubscriber,
+    received: &mut Vec<Vec<u8>>,
+) {
+    publisher.poll_with(|event| {
+        if let PublisherEvent::Disconnect { addr } = event {
+            panic!("publisher disconnected subscriber {addr}");
+        }
+    });
+    subscriber.poll_with(|event| match event {
+        SubscriberEvent::Connected { .. } => {}
+        SubscriberEvent::Disconnect { peer_addr } => {
+            panic!("subscriber disconnected from publisher {peer_addr}");
+        }
+        SubscriberEvent::Message { payload, .. } => received.push(payload.to_vec()),
+    });
+}
+
+#[test]
+fn publisher_subscriber_roundtrip() {
+    let publisher_addr = unused_addr();
+    let subscriber_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
+    let mut publisher = UdpPublisher::new(publisher_addr).unwrap();
+    let mut subscriber = UdpSubscriber::new(publisher_addr, subscriber_addr).unwrap();
+    let mut received = Vec::new();
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while publisher.active_subscribers() != 1 && Instant::now() < deadline {
+        poll_network(&mut publisher, &mut subscriber, &mut received);
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(publisher.active_subscribers(), 1, "subscriber did not complete subscription");
+
+    // Give the subscriber a chance to consume the publisher's initial State
+    // frame before UDP data starts arriving.
+    for _ in 0..10 {
+        poll_network(&mut publisher, &mut subscriber, &mut received);
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    let small = b"single UDP datagram".to_vec();
+    let fragmented = vec![0x5a; DEFAULT_IPV4_MAX_DATAGRAM_SIZE * 3 + 17];
+    publisher.publish_with(|_| {}, |payload| payload.extend_from_slice(&small));
+    publisher.publish_with(|_| {}, |payload| payload.extend_from_slice(&fragmented));
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while received.len() < 2 && Instant::now() < deadline {
+        poll_network(&mut publisher, &mut subscriber, &mut received);
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    assert_eq!(received.len(), 2, "subscriber did not receive both published messages");
+    assert!(received.iter().any(|payload| payload == &small));
+    assert!(received.iter().any(|payload| payload == &fragmented));
+}

--- a/crates/flux-network/tests/udp_publisher_subscriber.rs
+++ b/crates/flux-network/tests/udp_publisher_subscriber.rs
@@ -7,7 +7,8 @@ use std::{
 };
 
 use flux_network::udp::{
-    DEFAULT_IPV4_MAX_DATAGRAM_SIZE, PublisherEvent, SubscriberEvent, UdpPublisher, UdpSubscriber,
+    DEFAULT_IPV4_MAX_DATAGRAM_SIZE, PublisherEvent, SubscriberEvent, UdpConfig, UdpPublisher,
+    UdpSubscriber,
 };
 
 fn unused_addr() -> SocketAddr {
@@ -41,8 +42,10 @@ fn poll_network(
 fn publisher_subscriber_roundtrip() {
     let publisher_addr = unused_addr();
     let subscriber_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
-    let mut publisher = UdpPublisher::new(publisher_addr).unwrap();
-    let mut subscriber = UdpSubscriber::new(publisher_addr, subscriber_addr).unwrap();
+    let config = UdpConfig::default_for_addr(publisher_addr);
+    let mut publisher = UdpPublisher::new_with_config(publisher_addr, config).unwrap();
+    let mut subscriber =
+        UdpSubscriber::new_with_config(publisher_addr, subscriber_addr, config).unwrap();
     let mut received = Vec::new();
 
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -52,8 +55,9 @@ fn publisher_subscriber_roundtrip() {
     }
     assert_eq!(publisher.active_subscribers(), 1, "subscriber did not complete subscription");
 
-    // Give the subscriber a chance to consume the publisher's initial State
-    // frame before UDP data starts arriving.
+    // The publisher can activate a subscriber before its initial State frame is
+    // consumed. UDP arriving in that accepted startup window is recovered by
+    // progress and repair; wait here so this test exercises direct UDP delivery.
     for _ in 0..10 {
         poll_network(&mut publisher, &mut subscriber, &mut received);
         thread::sleep(Duration::from_millis(1));


### PR DESCRIPTION
First iteration of a new UDP based reliable transport. Publisher sends via UDP and offers repairs of messages via a separate TCP channel, up to a configurable number of messages. Main use case is broadcast of small-ish packets 1-4kb to multiple subscribers. Follow ups planned: proper benchmark, multicast, GSO/GRO batching, AF_XDP