### PR TITLE
fix(flux-utils): return a real thread id on macOS

### DIFF
--- a/crates/flux-utils/src/thread.rs
+++ b/crates/flux-utils/src/thread.rs
@@ -58,7 +58,19 @@ pub fn get_tid() -> i64 {
     unsafe { libc::gettid() as i64 }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "macos")]
+pub fn get_tid() -> i64 {
+    // pthread_threadid_np(self) returns the calling thread's unique 64-bit id
+    // — the per-thread ring identity the profiler relies on. Without it every
+    // thread shares tid 0 and collides on one ring file.
+    let mut tid: u64 = 0;
+    unsafe {
+        libc::pthread_threadid_np(libc::pthread_self(), &mut tid);
+    }
+    tid as i64
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 pub fn get_tid() -> i64 {
     0
 }


### PR DESCRIPTION
## Problem

`get_tid()` is a hardcoded `0` on every non-Linux platform. The profiler's per-thread ring identity is `"{thread-name}-{tid}"` (`producer.rs::thread_token`), so on macOS:

1. Every thread sharing a name (e.g. all tokio workers, which are all named `tokio-runtime-worker`) collides on **one ring file**.
2. Each new thread's `QueueDir::ring()` does `cleanup_flink` + `create_or_open_shared` on that same path — **deleting and recreating the ring**, silently wiping every other thread's events.
3. Survivors interleave into a single event stream, corrupting per-thread stack matching.

Net effect: on macOS a multi-threaded producer loses most of its trace with no error, and what survives is mis-attributed across threads. (The reader's existing `tid == 0` synthetic-koid fallback in `fxt.rs` masks the symptom, which is why this went unnoticed.) Linux is unaffected.

## Fix

Use `pthread_threadid_np(pthread_self())` on macOS — the calling thread's unique 64-bit id. `libc` is already a dependency of `flux-utils`.

Verified: with this change, a multi-threaded tokio server produces one ring per worker thread (`events-tokio-rt-worker-<tid>`, 5 distinct rings observed) and the event counts match the expected call counts exactly (previously ~2/3 of frames vanished).

Other non-Linux platforms keep the `0` fallback; the same collision applies there, so a follow-up could map `syscall(SYS_gettid)` equivalents per-OS.