### PR TITLE
fix(flux-communication): probe pid liveness without /proc on macOS

### DIFF
--- a/crates/flux-communication/src/cleanup.rs
+++ b/crates/flux-communication/src/cleanup.rs
@@ -3,9 +3,17 @@ use std::path::{Path, PathBuf};
 use shared_memory::ShmemConf;
 use tracing::warn;
 
-/// Check whether a process is still running via `/proc/<pid>`.
+/// Check whether a process is still running. Linux uses `/proc/<pid>`; other
+/// platforms (macOS has no /proc) fall back to `kill(pid, 0)`, which probes
+/// liveness without sending a signal.
 pub fn is_pid_alive(pid: u32) -> bool {
-    Path::new(&format!("/proc/{pid}")).exists()
+    #[cfg(target_os = "linux")]
+    {
+        if Path::new(&format!("/proc/{pid}")).exists() {
+            return true;
+        }
+    }
+    unsafe { libc::kill(pid as i32, 0) == 0 }
 }
 /// Unlink the shmem backing for a flink, then remove the flink file.
 ///


### PR DESCRIPTION
## Problem

`is_pid_alive()` checks for `/proc/<pid>`, which does not exist on macOS. Every call returns `false` there, so:

- `QueueDir::live_pid()` always returns `None` on macOS;
- `live_apps()` reports no producers, and the `flux-profiler` CLI fails with `"no live `#[timed]` producer found"` even when an instrumented app is running and publishing rings.

The producer side works on macOS (shmem rings are files under the data dir), so the CLI simply can never attach to it. Linux is unaffected.

## Fix

Keep the `/proc` check on Linux, and fall back to `kill(pid, 0)` elsewhere — a standard liveness probe that sends no signal (macOS, and any other Unix without /proc). `libc` is already a dependency of `flux-communication`.

Verified on macOS: the CLI now resolves the live producer and attaches (`attached to '<app>' (pid …); Ctrl-C to stop and export`).

## Not covered here

Cross-process *frame-name resolution* (`symbols.rs::CrossProcessSymbolsResolver`) also reads `/proc/<pid>/maps` and is therefore Linux-only as well. Fixing that on macOS is a larger task (Mach-O segment parsing + a way to read another process's memory — `task_for_pid` is privileged), tracked separately so this small, safe fix can land on its own.