### PR TITLE
feat(network): export FRAME_HEADER_SIZE and write_frame_header

### DIFF
--- a/crates/flux-network/src/tcp/mod.rs
+++ b/crates/flux-network/src/tcp/mod.rs
@@ -2,4 +2,4 @@ mod connector;
 mod stream;
 
 pub use connector::{PollEvent, SendBehavior, TcpConnector};
-pub use stream::{ConnState, TcpStream, TcpTelemetry};
+pub use stream::{ConnState, FRAME_HEADER_SIZE, TcpStream, TcpTelemetry, write_frame_header};

--- a/crates/flux-network/src/tcp/stream.rs
+++ b/crates/flux-network/src/tcp/stream.rs
@@ -54,7 +54,7 @@ const LEN_HEADER_SIZE: usize = core::mem::size_of::<u32>();
 /// Nanos timestamp when the sender finished serialising and handed bytes to
 /// kernel or enqueued in backlog.
 const TS_HEADER_SIZE: usize = core::mem::size_of::<Nanos>();
-pub(crate) const FRAME_HEADER_SIZE: usize = LEN_HEADER_SIZE + TS_HEADER_SIZE;
+pub const FRAME_HEADER_SIZE: usize = LEN_HEADER_SIZE + TS_HEADER_SIZE;
 // TODO: might need to tweak these
 const RX_BUF_SIZE: usize = 32 * 1024;
 
@@ -62,7 +62,7 @@ const RX_BUF_SIZE: usize = 32 * 1024;
 ///
 /// Shared by the per-stream serialise path and the broadcast path
 #[inline]
-pub(crate) fn write_frame_header(
+pub fn write_frame_header(
     header: &mut [u8; FRAME_HEADER_SIZE],
     payload_len: usize,
     ts: Nanos,


### PR DESCRIPTION
gattaca-com/builder#2872 produces flux-framed TCP broadcasts from the RPC's serialisation ring, which `TcpConnector` cannot consume (multi-producer, and the same ring also feeds the legacy byte-stream port). It currently restates the 12-byte `[u32 len LE][u64 send_ts LE]` header locally; review asked for it to come from flux instead.

This makes `FRAME_HEADER_SIZE` and `write_frame_header` public and re-exports them from `tcp`. No behaviour change.

Branched off `ce40087` (the rev builder currently pins) so builder can bump straight to this commit without pulling anything else in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)