### PR TITLE
share reconnect clock across TCP groups

### DIFF
--- a/crates/flux-network/src/tcp/network.rs
+++ b/crates/flux-network/src/tcp/network.rs
@@ -256,8 +256,9 @@ impl NetworkState {
     }
 
     fn maybe_reconnect(&mut self) {
+        let now = Instant::now();
         for group_index in 0..self.groups.len() {
-            if !self.groups[group_index].reconnector.fired() {
+            if !self.groups[group_index].reconnector.fired_at(now) {
                 continue;
             }
             let group = TcpGroup(group_index);

--- a/crates/flux-timing/src/repeater.rs
+++ b/crates/flux-timing/src/repeater.rs
@@ -28,9 +28,14 @@ impl Repeater {
 
     #[inline]
     pub fn fired(&mut self) -> bool {
-        let el = self.last_acted.elapsed();
+        self.fired_at(Instant::now())
+    }
+
+    #[inline]
+    pub fn fired_at(&mut self, now: Instant) -> bool {
+        let el = now.elapsed_since(self.last_acted);
         if el >= self.interval {
-            self.last_acted = Instant::now();
+            self.last_acted = now;
             true
         } else {
             false
@@ -79,5 +84,19 @@ impl AddAssign<Duration> for Repeater {
 impl SubAssign<Duration> for Repeater {
     fn sub_assign(&mut self, rhs: Duration) {
         self.interval = self.interval.saturating_sub(rhs);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Duration, Instant, Repeater};
+
+    #[test]
+    fn fired_at_uses_the_supplied_instant() {
+        let mut repeater = Repeater::every(Duration(10));
+        assert!(!repeater.fired_at(Instant(9)));
+        assert!(repeater.fired_at(Instant(10)));
+        assert!(!repeater.fired_at(Instant(19)));
+        assert!(repeater.fired_at(Instant(20)));
     }
 }


### PR DESCRIPTION
# Share one reconnect clock read across TCP groups

## Idea

`TcpNetwork::poll_with()` checks every TCP group for reconnect work.

Each `Repeater::fired()` call read the clock independently.

Read the clock once per network poll and pass it to every group repeater.

## Change

- Add `Repeater::fired_at(Instant)`.
- Keep `Repeater::fired()` as the existing convenience method.
- Read `Instant::now()` once in `NetworkState::maybe_reconnect()`.
- Use that timestamp for every TCP group.
- Add a unit test for `fired_at()` timing behavior.

Reconnect intervals and connection behavior do not change.

## Validation

- `cargo +1.91.0 test -p flux-timing`
- `cargo +1.91.0 test -p flux-network --lib`
- `cargo +1.91.0 clippy -p flux-timing -p flux-network --all-targets -- -D warnings`
- `git diff --check`
