### PR TITLE
flux-network: support TCP and Unix-domain streams

### DIFF
--- a/crates/flux-network/src/http.rs
+++ b/crates/flux-network/src/http.rs
@@ -6,9 +6,10 @@
 //! ```no_run
 //! use std::net::SocketAddr;
 //! use flux_network::http::{HttpEvent, HttpNetwork};
+//! use flux_network::stream::Endpoint;
 //! let mut http = HttpNetwork::default();
-//! http.listen("127.0.0.1:8080".parse::<SocketAddr>().unwrap())?;
-//! let peer = http.connect("127.0.0.1:8081".parse::<SocketAddr>().unwrap());
+//! http.listen(Endpoint::Tcp("127.0.0.1:8080".parse::<SocketAddr>().unwrap()))?;
+//! let peer = http.connect(Endpoint::Unix("/run/flux/upstream.sock".into()));
 //! loop {
 //!     let mut response = None;
 //!     let mut request = false;
@@ -35,18 +36,17 @@
 //! lingering-close delay. Pipelined requests are served strictly one at a time
 //! per connection.
 
-use std::{
-    io::{self, Write as _},
-    net::SocketAddr,
-};
+use std::io::{self, Write as _};
 
 use flux_timing::{Duration, Instant};
 use mio::Token;
 
-use crate::stream::{ConnectionGroup, ConnectionGroupConfig, Framing, StreamEvent, StreamNetwork};
+use crate::stream::{
+    ConnectionGroup, ConnectionGroupConfig, Endpoint, Framing, Peer, StreamEvent, StreamNetwork,
+};
 
 pub enum HttpEvent<'a> {
-    Accepted { token: Token, peer_addr: SocketAddr },
+    Accepted { token: Token, peer: Peer },
     Connected { token: Token },
     Response { token: Token, response: HttpResponse<'a> },
     Request { token: Token, request: HttpRequest<'a> },
@@ -60,7 +60,7 @@ enum State {
 }
 enum Role {
     Accepted { state: State, close: bool, continued: bool, head_request: bool },
-    Outbound { addr: SocketAddr, method: Option<String> },
+    Outbound { endpoint: Endpoint, method: Option<String> },
 }
 struct Conn {
     token: Token,
@@ -72,7 +72,7 @@ struct Conn {
 }
 #[derive(Clone, Copy)]
 enum Lifecycle {
-    Connected(Token, Option<SocketAddr>),
+    Connected(Token, Option<Peer>),
     Disconnected(Token),
 }
 pub struct HttpNetwork {
@@ -128,7 +128,7 @@ impl HttpNetwork {
         self.max_headers = max_headers;
         self
     }
-    /// Sets the TCP socket buffer size.
+    /// Sets the socket buffer size.
     pub fn with_socket_buf_size(mut self, socket_buf_size: usize) -> Self {
         assert!(self.group.is_none(), "configure before listen or connect");
         self.socket_buf_size = Some(socket_buf_size);
@@ -162,9 +162,14 @@ impl HttpNetwork {
             })
         })
     }
-    pub fn listen(&mut self, addr: SocketAddr) -> io::Result<()> {
+    /// Adds a listener.
+    ///
+    /// An [`Endpoint::Unix`] socket file is created with mode `0777` less the
+    /// umask bits and is unlinked when this instance is dropped; see
+    /// [`StreamNetwork::listen`].
+    pub fn listen(&mut self, endpoint: Endpoint) -> io::Result<()> {
         let group = self.group();
-        self.network.listen(group, addr)
+        self.network.listen(group, endpoint)
     }
     /// Immediately disconnects an accepted client.
     pub fn disconnect(&mut self, token: Token) -> bool {
@@ -188,9 +193,7 @@ impl HttpNetwork {
         let conns = &mut self.conns;
         let lifecycle = &mut self.lifecycle;
         self.network.poll_with(|event| match event {
-            StreamEvent::Accepted { group: event_group, token, peer_addr }
-                if event_group == group =>
-            {
+            StreamEvent::Accepted { group: event_group, token, peer } if event_group == group => {
                 conns.push(Conn {
                     token,
                     buf: Vec::new(),
@@ -204,7 +207,7 @@ impl HttpNetwork {
                         head_request: false,
                     },
                 });
-                lifecycle.push(Lifecycle::Connected(token, Some(peer_addr)));
+                lifecycle.push(Lifecycle::Connected(token, Some(peer)));
             }
             StreamEvent::Connected { group: event_group, token, .. } if event_group == group => {
                 lifecycle.push(Lifecycle::Connected(token, None));
@@ -262,8 +265,8 @@ impl HttpNetwork {
         F: for<'a> FnMut(HttpEvent<'a>),
     {
         match event {
-            Lifecycle::Connected(token, Some(peer_addr)) => {
-                handler(HttpEvent::Accepted { token, peer_addr });
+            Lifecycle::Connected(token, Some(peer)) => {
+                handler(HttpEvent::Accepted { token, peer });
             }
             Lifecycle::Connected(token, None) => handler(HttpEvent::Connected { token }),
             Lifecycle::Disconnected(token) => {
@@ -304,16 +307,18 @@ impl HttpNetwork {
             self.parse_outbound(i, handler);
         }
     }
-    pub fn connect(&mut self, addr: SocketAddr) -> Token {
+    /// Adds a persistent outbound endpoint and immediately starts
+    /// connecting. The returned token remains stable across reconnects.
+    pub fn connect(&mut self, endpoint: Endpoint) -> Token {
         let group = self.group();
-        let token = self.network.connect(group, addr);
+        let token = self.network.connect(group, endpoint.clone());
         self.conns.push(Conn {
             token,
             buf: Vec::new(),
             dirty: false,
             over_limit: false,
             last_activity: Instant::now(),
-            role: Role::Outbound { addr, method: None },
+            role: Role::Outbound { endpoint, method: None },
         });
         token
     }
@@ -332,6 +337,10 @@ impl HttpNetwork {
         true
     }
     /// Queues one request on an outbound endpoint.
+    ///
+    /// When the caller supplies no `Host` header, a TCP endpoint sends its
+    /// socket address; a Unix-domain endpoint has no address to name and
+    /// sends `localhost`.
     pub fn request(
         &mut self,
         token: Token,
@@ -357,8 +366,11 @@ impl HttpNetwork {
         else {
             return false
         };
-        let Role::Outbound { addr, .. } = &c.role else { return false };
-        let host = addr.to_string();
+        let Role::Outbound { endpoint, .. } = &c.role else { return false };
+        let host = match endpoint {
+            Endpoint::Tcp(addr) => addr.to_string(),
+            Endpoint::Unix(_) => "localhost".to_owned(),
+        };
         let sent = self.network.send_with(token, |out| {
             write!(out, "{method} {path} HTTP/1.1\r\n").unwrap();
             let mut has_host = false;

--- a/crates/flux-network/src/stream/endpoint.rs
+++ b/crates/flux-network/src/stream/endpoint.rs
@@ -1,0 +1,59 @@
+use std::{fmt, net::SocketAddr, path::PathBuf};
+
+/// The address a listener binds or an outbound connection targets.
+///
+/// The set of transports is closed: a caller that accepts addresses as text
+/// parses them itself and builds the variant it wants.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Endpoint {
+    /// A TCP socket address.
+    Tcp(SocketAddr),
+    /// A Unix-domain socket path.
+    Unix(PathBuf),
+}
+
+impl Endpoint {
+    /// The identity every connection to this endpoint reports.
+    pub(crate) fn peer(&self) -> Peer {
+        match self {
+            Self::Tcp(addr) => Peer::Tcp(*addr),
+            Self::Unix(_) => Peer::Unix,
+        }
+    }
+}
+
+impl From<SocketAddr> for Endpoint {
+    fn from(addr: SocketAddr) -> Self {
+        Self::Tcp(addr)
+    }
+}
+
+impl fmt::Display for Endpoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Tcp(addr) => write!(f, "{addr}"),
+            Self::Unix(path) => write!(f, "{}", path.display()),
+        }
+    }
+}
+
+/// The identity of the remote end of a connection.
+///
+/// A Unix-domain client is anonymous: it binds no path of its own, so the
+/// kernel reports an unnamed address for it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Peer {
+    /// The remote TCP socket address.
+    Tcp(SocketAddr),
+    /// The unnamed remote end of a Unix-domain connection.
+    Unix,
+}
+
+impl fmt::Display for Peer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Tcp(addr) => write!(f, "{addr}"),
+            Self::Unix => f.write_str("unix"),
+        }
+    }
+}

--- a/crates/flux-network/src/stream/endpoint.rs
+++ b/crates/flux-network/src/stream/endpoint.rs
@@ -22,12 +22,6 @@ impl Endpoint {
     }
 }
 
-impl From<SocketAddr> for Endpoint {
-    fn from(addr: SocketAddr) -> Self {
-        Self::Tcp(addr)
-    }
-}
-
 impl fmt::Display for Endpoint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/crates/flux-network/src/stream/mod.rs
+++ b/crates/flux-network/src/stream/mod.rs
@@ -8,6 +8,7 @@ pub use connector::{PollEvent, SendBehavior, TcpConnector};
 pub use endpoint::{Endpoint, Peer};
 pub use network::{
     ConnectionGroup, ConnectionGroupConfig, Framing, PayloadBuf, StreamEvent, StreamNetwork,
+    TcpOptions,
 };
 pub(crate) use tcp_stream::set_socket_buf_size;
 pub use tcp_stream::{ConnState, TcpStream, TcpTelemetry};

--- a/crates/flux-network/src/stream/mod.rs
+++ b/crates/flux-network/src/stream/mod.rs
@@ -1,8 +1,11 @@
 mod connector;
+mod endpoint;
 mod network;
 mod tcp_stream;
+mod transport;
 
 pub use connector::{PollEvent, SendBehavior, TcpConnector};
+pub use endpoint::{Endpoint, Peer};
 pub use network::{
     ConnectionGroup, ConnectionGroupConfig, Framing, PayloadBuf, StreamEvent, StreamNetwork,
 };

--- a/crates/flux-network/src/stream/network.rs
+++ b/crates/flux-network/src/stream/network.rs
@@ -1,20 +1,21 @@
 use std::{
     io::{self, IoSlice, Read, Write},
-    net::{Shutdown, SocketAddr},
+    net::Shutdown,
     ops::{Deref, DerefMut},
 };
 
 use flux_communication::Timer;
 use flux_timing::{Duration, Instant, Nanos, Repeater};
-use mio::{Events, Interest, Poll, Registry, Token, event::Event, net::TcpListener};
+use mio::{Events, Interest, Poll, Registry, Token, event::Event};
 use tracing::{debug, error, info, warn};
 
 use super::{
-    TcpTelemetry, set_socket_buf_size,
+    Endpoint, Peer, TcpTelemetry, set_socket_buf_size,
     tcp_stream::{
-        DEFAULT_TCP_USER_TIMEOUT_MS, FRAME_HEADER_SIZE, frame_payload_len, set_keepalive,
-        set_user_timeout, write_frame_header, write_frame_len, write_frame_ts,
+        DEFAULT_TCP_USER_TIMEOUT_MS, FRAME_HEADER_SIZE, frame_payload_len, write_frame_header,
+        write_frame_len, write_frame_ts,
     },
+    transport::{ListenSocket, TransportStream},
 };
 
 const EVENTS_CAPACITY: usize = 128;
@@ -201,13 +202,16 @@ pub struct ConnectionGroupConfig {
     /// Static payload sent on every newly established connection before its
     /// lifecycle event is emitted.
     pub on_connect_msg: Option<Vec<u8>>,
-    /// Requested `SO_SNDBUF` and `SO_RCVBUF` size.
+    /// Requested `SO_SNDBUF` and `SO_RCVBUF` size, applied to every transport.
     pub socket_buf_size: Option<usize>,
-    /// Whether to enable `TCP_NODELAY`.
+    /// Whether to enable `TCP_NODELAY`. Unix-domain endpoints have no such
+    /// option and ignore it.
     pub nodelay: bool,
-    /// Whether to enable TCP keepalive.
+    /// Whether to enable TCP keepalive. Unix-domain endpoints have no such
+    /// option and ignore it.
     pub keepalive: bool,
-    /// Linux `TCP_USER_TIMEOUT`, in milliseconds.
+    /// Linux `TCP_USER_TIMEOUT`, in milliseconds. Unix-domain endpoints have
+    /// no such option and ignore it.
     pub user_timeout_ms: u32,
     /// Retry interval for persistent outbound endpoints.
     pub reconnect_interval: Duration,
@@ -229,7 +233,7 @@ pub struct ConnectionGroupConfig {
 impl Default for ConnectionGroupConfig {
     fn default() -> Self {
         Self {
-            name: "tcp",
+            name: "stream",
             on_connect_msg: None,
             socket_buf_size: None,
             nodelay: true,
@@ -256,15 +260,15 @@ impl ConnectionGroupConfig {
 /// Event emitted by [`StreamNetwork::poll_with`].
 pub enum StreamEvent<'a> {
     /// A listener accepted a new connection.
-    Accepted { group: ConnectionGroup, token: Token, peer_addr: SocketAddr },
+    Accepted { group: ConnectionGroup, token: Token, peer: Peer },
     /// A persistent outbound endpoint established a connection.
-    Connected { group: ConnectionGroup, token: Token, peer_addr: SocketAddr },
+    Connected { group: ConnectionGroup, token: Token, peer: Peer },
     /// A complete length-prefixed message or a raw read chunk was received.
     /// For raw-framed groups, chunks do not preserve message boundaries and
     /// `send_ts` is the local receive time.
     Message { group: ConnectionGroup, token: Token, payload: &'a [u8], send_ts: Nanos },
     /// An established connection was closed.
-    Disconnected { group: ConnectionGroup, token: Token, peer_addr: SocketAddr },
+    Disconnected { group: ConnectionGroup, token: Token, peer: Peer },
 }
 
 struct GroupState {
@@ -275,27 +279,23 @@ struct GroupState {
 struct Listener {
     token: Token,
     group: ConnectionGroup,
-    socket: TcpListener,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ConnectionKind {
-    Accepted,
-    Outbound,
+    socket: ListenSocket,
 }
 
 #[allow(clippy::large_enum_variant)]
 enum ConnectionState {
     Disconnected,
-    Connecting(mio::net::TcpStream),
+    Connecting(TransportStream),
     Connected(FramedStream),
 }
 
 struct Connection {
     token: Token,
     group: ConnectionGroup,
-    peer_addr: SocketAddr,
-    kind: ConnectionKind,
+    peer: Peer,
+    /// The endpoint a persistent outbound connection reconnects to; `None`
+    /// for a connection the network accepted.
+    endpoint: Option<Endpoint>,
     state: ConnectionState,
     close_when_drained: bool,
     timers: Option<NetworkTimers>,
@@ -312,11 +312,11 @@ impl NetworkTimers {
         telemetry: TcpTelemetry,
         group_name: &str,
         token: Token,
-        peer_addr: SocketAddr,
+        peer: Peer,
         framing: Framing,
     ) -> Option<Self> {
         let TcpTelemetry::Enabled { app_name } = telemetry else { return None };
-        let label = format!("{group_name}-{}-{peer_addr}", token.0);
+        let label = format!("{group_name}-{}-{peer}", token.0);
         Some(Self {
             latency: (framing == Framing::LengthPrefixed)
                 .then(|| Timer::new(app_name, format!("tcp_latency_{label}"))),
@@ -329,7 +329,7 @@ impl NetworkTimers {
 struct PendingDisconnect {
     group: ConnectionGroup,
     token: Token,
-    peer_addr: SocketAddr,
+    peer: Peer,
 }
 
 struct NetworkState {
@@ -348,7 +348,7 @@ struct NetworkState {
 impl Default for NetworkState {
     fn default() -> Self {
         Self {
-            poll: Poll::new().expect("couldn't set up a poll for tcp network"),
+            poll: Poll::new().expect("couldn't set up a poll for the stream network"),
             groups: Vec::with_capacity(INITIAL_GROUP_CAPACITY),
             listeners: Vec::with_capacity(INITIAL_LISTENER_CAPACITY),
             connections: Vec::with_capacity(INITIAL_CONNECTION_CAPACITY),
@@ -362,7 +362,7 @@ impl Default for NetworkState {
 impl NetworkState {
     fn next_token(&mut self) -> Token {
         let token = Token(self.next_token);
-        self.next_token = self.next_token.checked_add(1).expect("tcp token space exhausted");
+        self.next_token = self.next_token.checked_add(1).expect("stream token space exhausted");
         token
     }
 
@@ -370,28 +370,28 @@ impl NetworkState {
         &self.groups[group.0].config
     }
 
-    fn listen(&mut self, group: ConnectionGroup, addr: SocketAddr) -> io::Result<()> {
+    fn listen(&mut self, group: ConnectionGroup, endpoint: Endpoint) -> io::Result<()> {
         if group.0 >= self.groups.len() {
-            return Err(io::Error::new(io::ErrorKind::InvalidInput, "unknown TCP group"));
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "unknown connection group"));
         }
-        let mut socket = TcpListener::bind(addr)?;
+        let mut socket = ListenSocket::bind(endpoint)?;
         let token = self.next_token();
         self.poll.registry().register(&mut socket, token, Interest::READABLE)?;
         self.listeners.push(Listener { token, group, socket });
         Ok(())
     }
 
-    fn connect(&mut self, group: ConnectionGroup, peer_addr: SocketAddr) -> Token {
-        assert!(group.0 < self.groups.len(), "unknown TCP group");
+    fn connect(&mut self, group: ConnectionGroup, endpoint: Endpoint) -> Token {
+        assert!(group.0 < self.groups.len(), "unknown connection group");
         let token = self.next_token();
+        let peer = endpoint.peer();
         let config = self.config(group);
-        let timers =
-            NetworkTimers::new(config.telemetry, config.name, token, peer_addr, config.framing);
+        let timers = NetworkTimers::new(config.telemetry, config.name, token, peer, config.framing);
         self.connections.push(Connection {
             token,
             group,
-            peer_addr,
-            kind: ConnectionKind::Outbound,
+            peer,
+            endpoint: Some(endpoint),
             state: ConnectionState::Disconnected,
             close_when_drained: false,
             timers,
@@ -402,19 +402,18 @@ impl NetworkState {
 
     fn start_connect(&mut self, index: usize) {
         let connection = &self.connections[index];
-        if connection.kind != ConnectionKind::Outbound ||
-            !matches!(connection.state, ConnectionState::Disconnected)
-        {
+        if !matches!(connection.state, ConnectionState::Disconnected) {
             return;
         }
+        let Some(endpoint) = &connection.endpoint else { return };
 
         let token = connection.token;
         let group = connection.group;
-        let peer_addr = connection.peer_addr;
+        let peer = connection.peer;
         let socket_buf_size = self.config(group).socket_buf_size;
 
-        let Ok(mut socket) = mio::net::TcpStream::connect(peer_addr)
-            .inspect_err(|err| debug!(?err, %peer_addr, "couldn't start tcp connection"))
+        let Ok(mut socket) = TransportStream::connect(endpoint)
+            .inspect_err(|err| debug!(?err, %endpoint, "couldn't start connection"))
         else {
             return;
         };
@@ -422,7 +421,7 @@ impl NetworkState {
             set_socket_buf_size(&socket, size);
         }
         if let Err(err) = self.poll.registry().register(&mut socket, token, Interest::WRITABLE) {
-            warn!(?err, %peer_addr, "couldn't register connecting tcp stream");
+            warn!(?err, %peer, "couldn't register connecting stream");
             let _ = socket.shutdown(Shutdown::Both);
             return;
         }
@@ -438,30 +437,11 @@ impl NetworkState {
             let group = ConnectionGroup(group_index);
             for index in 0..self.connections.len() {
                 if self.connections[index].group == group &&
-                    self.connections[index].kind == ConnectionKind::Outbound &&
                     matches!(self.connections[index].state, ConnectionState::Disconnected)
                 {
                     self.start_connect(index);
                 }
             }
-        }
-    }
-
-    fn connect_complete(socket: &mio::net::TcpStream) -> io::Result<bool> {
-        if let Some(err) = socket.take_error()? {
-            return Err(err);
-        }
-        match socket.peer_addr() {
-            Ok(_) => Ok(true),
-            Err(err)
-                if matches!(
-                    err.kind(),
-                    io::ErrorKind::NotConnected | io::ErrorKind::WouldBlock
-                ) || matches!(err.raw_os_error(), Some(libc::EINPROGRESS | libc::EALREADY)) =>
-            {
-                Ok(false)
-            }
-            Err(err) => Err(err),
         }
     }
 
@@ -472,11 +452,11 @@ impl NetworkState {
         let ConnectionState::Connecting(socket) = &self.connections[index].state else {
             return false;
         };
-        match Self::connect_complete(socket) {
+        match socket.is_connected() {
             Ok(false) => return false,
             Err(err) => {
-                let peer_addr = self.connections[index].peer_addr;
-                debug!(?err, %peer_addr, "tcp connection attempt failed");
+                let peer = self.connections[index].peer;
+                debug!(?err, %peer, "connection attempt failed");
                 self.close_connection_socket(index);
                 return false;
             }
@@ -490,35 +470,35 @@ impl NetworkState {
         };
         let token = self.connections[index].token;
         let group = self.connections[index].group;
-        let peer_addr = self.connections[index].peer_addr;
+        let peer = self.connections[index].peer;
         let mut timers = self.connections[index].timers;
         let config = self.config(group);
         let group_name = config.name;
 
         if config.nodelay &&
-            let Err(err) = socket.set_nodelay(true)
+            let Err(err) = socket.set_nodelay()
         {
-            warn!(?err, %peer_addr, "couldn't set nodelay on tcp stream");
+            warn!(?err, %peer, "couldn't set nodelay on tcp stream");
             let _ = self.poll.registry().deregister(&mut socket);
             let _ = socket.shutdown(Shutdown::Both);
             return false;
         }
         if config.keepalive &&
-            let Err(err) = set_keepalive(&socket)
+            let Err(err) = socket.set_keepalive()
         {
-            warn!(?err, %peer_addr, "couldn't set keepalive on tcp stream");
+            warn!(?err, %peer, "couldn't set keepalive on tcp stream");
             let _ = self.poll.registry().deregister(&mut socket);
             let _ = socket.shutdown(Shutdown::Both);
             return false;
         }
-        set_user_timeout(&socket, config.user_timeout_ms);
+        socket.set_user_timeout(config.user_timeout_ms);
         if let Err(err) = self.poll.registry().reregister(&mut socket, token, Interest::READABLE) {
-            warn!(?err, %peer_addr, "couldn't register connected tcp stream");
+            warn!(?err, %peer, "couldn't register connected stream");
             let _ = socket.shutdown(Shutdown::Both);
             return false;
         }
 
-        let mut stream = FramedStream::new(socket, token, peer_addr, config.max_frame_size);
+        let mut stream = FramedStream::new(socket, token, peer, config.max_frame_size);
         if let Some(message) = config.on_connect_msg.as_deref() {
             let header = (config.framing == Framing::LengthPrefixed).then(|| {
                 let mut header = [0; FRAME_HEADER_SIZE];
@@ -541,8 +521,8 @@ impl NetworkState {
 
         self.connections[index].timers = timers;
         self.connections[index].state = ConnectionState::Connected(stream);
-        info!(group = group_name, %peer_addr, "tcp connection established");
-        handler(StreamEvent::Connected { group, token, peer_addr });
+        info!(group = group_name, %peer, "connection established");
+        handler(StreamEvent::Connected { group, token, peer });
         true
     }
 
@@ -553,11 +533,11 @@ impl NetworkState {
         let group = self.listeners[listener_index].group;
         loop {
             let accepted = self.listeners[listener_index].socket.accept();
-            let (mut socket, peer_addr) = match accepted {
+            let (mut socket, peer) = match accepted {
                 Ok(accepted) => accepted,
                 Err(err) if err.kind() == io::ErrorKind::WouldBlock => break,
                 Err(err) => {
-                    warn!(?err, group = self.config(group).name, "tcp accept failed");
+                    warn!(?err, group = self.config(group).name, "accept failed");
                     break;
                 }
             };
@@ -568,36 +548,31 @@ impl NetworkState {
                     set_socket_buf_size(&socket, size);
                 }
                 if config.nodelay &&
-                    let Err(err) = socket.set_nodelay(true)
+                    let Err(err) = socket.set_nodelay()
                 {
-                    warn!(?err, %peer_addr, "couldn't set nodelay on accepted tcp stream");
+                    warn!(?err, %peer, "couldn't set nodelay on accepted tcp stream");
                     let _ = socket.shutdown(Shutdown::Both);
                     continue;
                 }
                 if config.keepalive &&
-                    let Err(err) = set_keepalive(&socket)
+                    let Err(err) = socket.set_keepalive()
                 {
-                    warn!(?err, %peer_addr, "couldn't set keepalive on accepted tcp stream");
+                    warn!(?err, %peer, "couldn't set keepalive on accepted tcp stream");
                     let _ = socket.shutdown(Shutdown::Both);
                     continue;
                 }
-                set_user_timeout(&socket, config.user_timeout_ms);
+                socket.set_user_timeout(config.user_timeout_ms);
                 if let Err(err) =
                     self.poll.registry().register(&mut socket, token, Interest::READABLE)
                 {
-                    warn!(?err, %peer_addr, "couldn't register accepted tcp stream");
+                    warn!(?err, %peer, "couldn't register accepted stream");
                     let _ = socket.shutdown(Shutdown::Both);
                     continue;
                 }
 
-                let mut timers = NetworkTimers::new(
-                    config.telemetry,
-                    config.name,
-                    token,
-                    peer_addr,
-                    config.framing,
-                );
-                let mut stream = FramedStream::new(socket, token, peer_addr, config.max_frame_size);
+                let mut timers =
+                    NetworkTimers::new(config.telemetry, config.name, token, peer, config.framing);
+                let mut stream = FramedStream::new(socket, token, peer, config.max_frame_size);
                 if let Some(message) = config.on_connect_msg.as_deref() {
                     let header = (config.framing == Framing::LengthPrefixed).then(|| {
                         let mut header = [0; FRAME_HEADER_SIZE];
@@ -622,14 +597,14 @@ impl NetworkState {
             self.connections.push(Connection {
                 token,
                 group,
-                peer_addr,
-                kind: ConnectionKind::Accepted,
+                peer,
+                endpoint: None,
                 state: ConnectionState::Connected(stream),
                 close_when_drained: false,
                 timers,
             });
-            info!(group = group_name, %peer_addr, "tcp connection accepted");
-            handler(StreamEvent::Accepted { group, token, peer_addr });
+            info!(group = group_name, %peer, "connection accepted");
+            handler(StreamEvent::Accepted { group, token, peer });
         }
     }
 
@@ -644,7 +619,7 @@ impl NetworkState {
         }
         let Some(index) = self.connections.iter().position(|connection| connection.token == token)
         else {
-            debug!(?token, "ignoring stale tcp readiness event");
+            debug!(?token, "ignoring stale readiness event");
             return;
         };
 
@@ -658,7 +633,7 @@ impl NetworkState {
         }
 
         let group = self.connections[index].group;
-        let peer_addr = self.connections[index].peer_addr;
+        let peer = self.connections[index].peer;
         let config = &self.groups[group.0].config;
         let (state, queue_empty) = {
             let connection = &mut self.connections[index];
@@ -675,7 +650,7 @@ impl NetworkState {
             (state, stream.send_queue.is_empty())
         };
         if state == StreamState::Disconnected {
-            handler(StreamEvent::Disconnected { group, token, peer_addr });
+            handler(StreamEvent::Disconnected { group, token, peer });
             self.disconnect_index(index, false);
         } else if self.connections[index].close_when_drained && queue_empty {
             self.disconnect_index(index, true);
@@ -703,12 +678,12 @@ impl NetworkState {
         let event = PendingDisconnect {
             group: self.connections[index].group,
             token: self.connections[index].token,
-            peer_addr: self.connections[index].peer_addr,
+            peer: self.connections[index].peer,
         };
-        let kind = self.connections[index].kind;
+        let accepted = self.connections[index].endpoint.is_none();
         self.connections[index].close_when_drained = false;
         let was_connected = self.close_connection_socket(index);
-        if kind == ConnectionKind::Accepted {
+        if accepted {
             self.connections.swap_remove(index);
         }
         if notify && was_connected {
@@ -724,7 +699,7 @@ impl NetworkState {
             handler(StreamEvent::Disconnected {
                 group: event.group,
                 token: event.token,
-                peer_addr: event.peer_addr,
+                peer: event.peer,
             });
         }
     }
@@ -953,12 +928,18 @@ impl NetworkState {
     }
 }
 
-/// A grouped collection of TCP listeners and persistent outbound endpoints
-/// driven by one nonblocking poll.
+/// A grouped collection of listeners and persistent outbound endpoints driven
+/// by one nonblocking poll.
+///
+/// One network mixes both transports of the [`Endpoint`] set: a TCP and a
+/// Unix-domain listener can share a group.
 ///
 /// Unlike [`super::TcpConnector`], queued bytes are never retained across a
 /// disconnected socket. Use `TcpConnector` when reconnect backlog replay is
 /// required.
+///
+/// Dropping the network closes every listener, which unlinks the socket file
+/// of each [`Endpoint::Unix`] listener.
 pub struct StreamNetwork {
     events: Events,
     state: NetworkState,
@@ -978,7 +959,7 @@ impl StreamNetwork {
         if config.framing == Framing::LengthPrefixed {
             assert!(
                 u32::try_from(config.max_frame_size).is_ok(),
-                "max_frame_size exceeds the TCP wire length field"
+                "max_frame_size exceeds the wire length field"
             );
         }
         if let Some(message) = &config.on_connect_msg {
@@ -1001,15 +982,22 @@ impl StreamNetwork {
     }
 
     /// Adds a listener to `group`.
-    pub fn listen(&mut self, group: ConnectionGroup, addr: SocketAddr) -> io::Result<()> {
-        self.state.listen(group, addr)
+    ///
+    /// An [`Endpoint::Unix`] listener creates its socket file with mode `0777`
+    /// less the umask bits; flux sets no mode of its own. Connecting to a
+    /// Unix-domain socket requires *write* permission on that file, so the
+    /// usual `022` umask yields `0755` and admits the owner alone. An operator
+    /// who wants group or world access sets the umask before the bind or
+    /// changes the mode after it.
+    pub fn listen(&mut self, group: ConnectionGroup, endpoint: Endpoint) -> io::Result<()> {
+        self.state.listen(group, endpoint)
     }
 
     /// Adds a persistent outbound endpoint and immediately starts connecting.
     /// The returned token remains stable across reconnects.
     #[must_use = "the token identifies the persistent outbound endpoint"]
-    pub fn connect(&mut self, group: ConnectionGroup, peer_addr: SocketAddr) -> Token {
-        self.state.connect(group, peer_addr)
+    pub fn connect(&mut self, group: ConnectionGroup, endpoint: Endpoint) -> Token {
+        self.state.connect(group, endpoint)
     }
 
     pub fn poll_with<F>(&mut self, mut handler: F)
@@ -1020,7 +1008,7 @@ impl StreamNetwork {
         self.state.maybe_reconnect();
         if let Err(err) = self.state.poll.poll(&mut self.events, Some(std::time::Duration::ZERO)) {
             if err.kind() != io::ErrorKind::Interrupted {
-                flux_utils::safe_panic!("couldn't poll tcp network: {err}");
+                flux_utils::safe_panic!("couldn't poll the stream network: {err}");
             }
             return;
         }
@@ -1091,8 +1079,8 @@ impl StreamNetwork {
 
     /// Closes a connected socket after its queued bytes have been written.
     /// Returns `false` for unknown or disconnected tokens; sends to a draining
-    /// token are rejected. A peer that never drains is bounded only by
-    /// `TCP_USER_TIMEOUT`.
+    /// token are rejected. A TCP peer that never drains is bounded only by
+    /// `TCP_USER_TIMEOUT`; a Unix-domain peer has no such bound.
     pub fn disconnect_when_drained(&mut self, token: Token) -> bool {
         self.state.disconnect_when_drained(token)
     }
@@ -1206,7 +1194,7 @@ impl ByteQueue {
         self.bytes.capacity() != old_capacity
     }
 
-    fn maybe_warn(&mut self, config: &ConnectionGroupConfig, token: Token, peer_addr: SocketAddr) {
+    fn maybe_warn(&mut self, config: &ConnectionGroupConfig, token: Token, peer: Peer) {
         let Some(threshold) = config.backlog_warn_bytes else { return };
         if self.len() <= threshold {
             self.last_warning = None;
@@ -1222,19 +1210,19 @@ impl ByteQueue {
         warn!(
             group = config.name,
             ?token,
-            %peer_addr,
+            %peer,
             queued_bytes = self.len(),
             %age,
-            "tcp send backlog growing"
+            "send backlog growing"
         );
         self.last_warning = Some(Instant::now());
     }
 }
 
 struct FramedStream {
-    socket: mio::net::TcpStream,
+    socket: TransportStream,
     token: Token,
-    peer_addr: SocketAddr,
+    peer: Peer,
     rx_state: RxState,
     rx_buffer: Vec<u8>,
     send_queue: ByteQueue,
@@ -1242,16 +1230,11 @@ struct FramedStream {
 }
 
 impl FramedStream {
-    fn new(
-        socket: mio::net::TcpStream,
-        token: Token,
-        peer_addr: SocketAddr,
-        max_frame_size: usize,
-    ) -> Self {
+    fn new(socket: TransportStream, token: Token, peer: Peer, max_frame_size: usize) -> Self {
         Self {
             socket,
             token,
-            peer_addr,
+            peer,
             rx_state: RxState::default(),
             rx_buffer: vec![0; INITIAL_RX_BUFFER_SIZE.min(max_frame_size)],
             send_queue: ByteQueue::default(),
@@ -1278,7 +1261,7 @@ impl FramedStream {
                         Ok(read) => on_message(&self.rx_buffer[..read], Nanos::now()),
                         Err(err) if err.kind() == io::ErrorKind::WouldBlock => break,
                         Err(err) => {
-                            debug!(?err, %self.peer_addr, "tcp raw read failed");
+                            debug!(?err, %self.peer, "raw read failed");
                             return StreamState::Disconnected;
                         }
                     }
@@ -1332,10 +1315,10 @@ impl FramedStream {
                                 }
                                 if length > max_frame_size {
                                     warn!(
-                                        %self.peer_addr,
+                                        %self.peer,
                                         payload_len = length,
                                         max_frame_size,
-                                        "tcp frame exceeds configured maximum"
+                                        "frame exceeds configured maximum"
                                     );
                                     return ReadOutcome::Disconnected;
                                 }
@@ -1349,7 +1332,7 @@ impl FramedStream {
                                 return ReadOutcome::WouldBlock;
                             }
                             Err(err) => {
-                                debug!(?err, %self.peer_addr, "tcp header read failed");
+                                debug!(?err, %self.peer, "header read failed");
                                 return ReadOutcome::Disconnected;
                             }
                         }
@@ -1374,7 +1357,7 @@ impl FramedStream {
                                 return ReadOutcome::WouldBlock;
                             }
                             Err(err) => {
-                                debug!(?err, %self.peer_addr, "tcp payload read failed");
+                                debug!(?err, %self.peer, "payload read failed");
                                 return ReadOutcome::Disconnected;
                             }
                         }
@@ -1417,7 +1400,7 @@ impl FramedStream {
                 self.enqueue_remainder(registry, header, payload, 0, config, timers)
             }
             Err(err) => {
-                debug!(?err, %self.peer_addr, "tcp frame write failed");
+                debug!(?err, %self.peer, "frame write failed");
                 StreamState::Disconnected
             }
         }
@@ -1444,11 +1427,11 @@ impl FramedStream {
             warn!(
                 group = config.name,
                 ?self.token,
-                %self.peer_addr,
+                %self.peer,
                 queued_bytes = self.send_queue.len(),
                 additional_bytes = additional,
                 max_backlog_bytes = max,
-                "tcp send backlog would exceed configured maximum"
+                "send backlog would exceed configured maximum"
             );
             return StreamState::Disconnected;
         }
@@ -1462,7 +1445,7 @@ impl FramedStream {
         if allocated && let Some(timers) = timers {
             timers.alloc.emit_latency_from_nanos(started, Nanos::now());
         }
-        self.send_queue.maybe_warn(config, self.token, self.peer_addr);
+        self.send_queue.maybe_warn(config, self.token, self.peer);
         self.arm_writable(registry)
     }
 
@@ -1473,16 +1456,16 @@ impl FramedStream {
                 Ok(written) => self.send_queue.consume(written),
                 Err(err) if err.kind() == io::ErrorKind::WouldBlock => break,
                 Err(err) => {
-                    debug!(?err, %self.peer_addr, "tcp backlog write failed");
+                    debug!(?err, %self.peer, "backlog write failed");
                     return StreamState::Disconnected;
                 }
             }
         }
-        self.send_queue.maybe_warn(config, self.token, self.peer_addr);
+        self.send_queue.maybe_warn(config, self.token, self.peer);
         if self.send_queue.is_empty() && self.writable_armed {
             if let Err(err) = registry.reregister(&mut self.socket, self.token, Interest::READABLE)
             {
-                debug!(?err, %self.peer_addr, "couldn't disarm writable interest");
+                debug!(?err, %self.peer, "couldn't disarm writable interest");
                 return StreamState::Disconnected;
             }
             self.writable_armed = false;
@@ -1499,7 +1482,7 @@ impl FramedStream {
             self.token,
             Interest::READABLE | Interest::WRITABLE,
         ) {
-            debug!(?err, %self.peer_addr, "couldn't arm writable interest");
+            debug!(?err, %self.peer, "couldn't arm writable interest");
             return StreamState::Disconnected;
         }
         self.writable_armed = true;
@@ -1523,8 +1506,8 @@ mod tests {
     use mio::{Poll, Token};
 
     use super::{
-        ByteQueue, FRAME_HEADER_SIZE, FramedStream, PayloadBuf, StreamState, ConnectionGroupConfig,
-        set_socket_buf_size, write_frame_header,
+        ByteQueue, ConnectionGroupConfig, FRAME_HEADER_SIZE, FramedStream, PayloadBuf, Peer,
+        StreamState, TransportStream, set_socket_buf_size, write_frame_header,
     };
 
     #[test]
@@ -1592,9 +1575,9 @@ mod tests {
         let (_peer, peer_addr) = listener.accept().unwrap();
         client.set_nonblocking(true).unwrap();
 
-        let socket = mio::net::TcpStream::from_std(client);
+        let socket = TransportStream::Tcp(mio::net::TcpStream::from_std(client));
         set_socket_buf_size(&socket, 1024);
-        let mut stream = FramedStream::new(socket, Token(0), peer_addr, 1024);
+        let mut stream = FramedStream::new(socket, Token(0), Peer::Tcp(peer_addr), 1024);
         let fill = [0; 4096];
         loop {
             match stream.socket.write(&fill) {

--- a/crates/flux-network/src/stream/network.rs
+++ b/crates/flux-network/src/stream/network.rs
@@ -193,6 +193,23 @@ impl Write for PayloadBuf<'_> {
     }
 }
 
+/// Socket options that exist only for TCP connections.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TcpOptions {
+    /// Whether to enable `TCP_NODELAY`.
+    pub nodelay: bool,
+    /// Whether to enable TCP keepalive.
+    pub keepalive: bool,
+    /// Linux `TCP_USER_TIMEOUT`, in milliseconds.
+    pub user_timeout_ms: u32,
+}
+
+impl Default for TcpOptions {
+    fn default() -> Self {
+        Self { nodelay: true, keepalive: false, user_timeout_ms: DEFAULT_TCP_USER_TIMEOUT_MS }
+    }
+}
+
 /// Configuration shared by every listener and connection in a
 /// [`ConnectionGroup`].
 #[derive(Clone)]
@@ -204,15 +221,6 @@ pub struct ConnectionGroupConfig {
     pub on_connect_msg: Option<Vec<u8>>,
     /// Requested `SO_SNDBUF` and `SO_RCVBUF` size, applied to every transport.
     pub socket_buf_size: Option<usize>,
-    /// Whether to enable `TCP_NODELAY`. Unix-domain endpoints have no such
-    /// option and ignore it.
-    pub nodelay: bool,
-    /// Whether to enable TCP keepalive. Unix-domain endpoints have no such
-    /// option and ignore it.
-    pub keepalive: bool,
-    /// Linux `TCP_USER_TIMEOUT`, in milliseconds. Unix-domain endpoints have
-    /// no such option and ignore it.
-    pub user_timeout_ms: u32,
     /// Retry interval for persistent outbound endpoints.
     pub reconnect_interval: Duration,
     /// Emit rate-limited warnings above this many queued bytes. The queue is
@@ -228,6 +236,9 @@ pub struct ConnectionGroupConfig {
     pub framing: Framing,
     /// Per-connection latency and allocation telemetry.
     pub telemetry: TcpTelemetry,
+    /// TCP socket options. Unix-domain connections have no such options and
+    /// ignore them.
+    pub tcp: TcpOptions,
 }
 
 impl Default for ConnectionGroupConfig {
@@ -236,15 +247,13 @@ impl Default for ConnectionGroupConfig {
             name: "stream",
             on_connect_msg: None,
             socket_buf_size: None,
-            nodelay: true,
-            keepalive: false,
-            user_timeout_ms: DEFAULT_TCP_USER_TIMEOUT_MS,
             reconnect_interval: Duration::from_secs(2),
             backlog_warn_bytes: Some(DEFAULT_BACKLOG_WARN_BYTES),
             max_backlog_bytes: None,
             max_frame_size: DEFAULT_MAX_FRAME_SIZE,
             framing: Framing::LengthPrefixed,
             telemetry: TcpTelemetry::Disabled,
+            tcp: TcpOptions::default(),
         }
     }
 }
@@ -252,7 +261,7 @@ impl Default for ConnectionGroupConfig {
 impl ConnectionGroupConfig {
     /// Enables TCP keepalive for every connection in this group.
     pub fn with_keepalive(mut self) -> Self {
-        self.keepalive = true;
+        self.tcp.keepalive = true;
         self
     }
 }
@@ -475,7 +484,7 @@ impl NetworkState {
         let config = self.config(group);
         let group_name = config.name;
 
-        if config.nodelay &&
+        if config.tcp.nodelay &&
             let Err(err) = socket.set_nodelay()
         {
             warn!(?err, %peer, "couldn't set nodelay on tcp stream");
@@ -483,7 +492,7 @@ impl NetworkState {
             let _ = socket.shutdown(Shutdown::Both);
             return false;
         }
-        if config.keepalive &&
+        if config.tcp.keepalive &&
             let Err(err) = socket.set_keepalive()
         {
             warn!(?err, %peer, "couldn't set keepalive on tcp stream");
@@ -491,7 +500,7 @@ impl NetworkState {
             let _ = socket.shutdown(Shutdown::Both);
             return false;
         }
-        socket.set_user_timeout(config.user_timeout_ms);
+        socket.set_user_timeout(config.tcp.user_timeout_ms);
         if let Err(err) = self.poll.registry().reregister(&mut socket, token, Interest::READABLE) {
             warn!(?err, %peer, "couldn't register connected stream");
             let _ = socket.shutdown(Shutdown::Both);
@@ -547,21 +556,21 @@ impl NetworkState {
                 if let Some(size) = config.socket_buf_size {
                     set_socket_buf_size(&socket, size);
                 }
-                if config.nodelay &&
+                if config.tcp.nodelay &&
                     let Err(err) = socket.set_nodelay()
                 {
                     warn!(?err, %peer, "couldn't set nodelay on accepted tcp stream");
                     let _ = socket.shutdown(Shutdown::Both);
                     continue;
                 }
-                if config.keepalive &&
+                if config.tcp.keepalive &&
                     let Err(err) = socket.set_keepalive()
                 {
                     warn!(?err, %peer, "couldn't set keepalive on accepted tcp stream");
                     let _ = socket.shutdown(Shutdown::Both);
                     continue;
                 }
-                socket.set_user_timeout(config.user_timeout_ms);
+                socket.set_user_timeout(config.tcp.user_timeout_ms);
                 if let Err(err) =
                     self.poll.registry().register(&mut socket, token, Interest::READABLE)
                 {
@@ -870,7 +879,12 @@ impl NetworkState {
         self.broadcast_staged(group)
     }
 
-    fn broadcast_many_with<I, F>(&mut self, group: ConnectionGroup, items: I, mut serialise: F) -> usize
+    fn broadcast_many_with<I, F>(
+        &mut self,
+        group: ConnectionGroup,
+        items: I,
+        mut serialise: F,
+    ) -> usize
     where
         I: IntoIterator,
         F: FnMut(&mut PayloadBuf<'_>, I::Item),
@@ -1062,7 +1076,12 @@ impl StreamNetwork {
     /// receives the batch in one socket write when it has no backlog. The
     /// closure is not called when the group has no connected member. Returns
     /// the number of recipients attempted.
-    pub fn broadcast_many_with<I, F>(&mut self, group: ConnectionGroup, items: I, serialise: F) -> usize
+    pub fn broadcast_many_with<I, F>(
+        &mut self,
+        group: ConnectionGroup,
+        items: I,
+        serialise: F,
+    ) -> usize
     where
         I: IntoIterator,
         F: FnMut(&mut PayloadBuf<'_>, I::Item),
@@ -1506,9 +1525,20 @@ mod tests {
     use mio::{Poll, Token};
 
     use super::{
-        ByteQueue, ConnectionGroupConfig, FRAME_HEADER_SIZE, FramedStream, PayloadBuf, Peer,
-        StreamState, TransportStream, set_socket_buf_size, write_frame_header,
+        ByteQueue, ConnectionGroupConfig, DEFAULT_TCP_USER_TIMEOUT_MS, FRAME_HEADER_SIZE,
+        FramedStream, PayloadBuf, Peer, StreamState, TcpOptions, TransportStream,
+        set_socket_buf_size, write_frame_header,
     };
+
+    #[test]
+    fn tcp_options_default_to_nodelay_without_keepalive() {
+        assert_eq!(TcpOptions::default(), TcpOptions {
+            nodelay: true,
+            keepalive: false,
+            user_timeout_ms: DEFAULT_TCP_USER_TIMEOUT_MS,
+        });
+        assert_eq!(ConnectionGroupConfig::default().tcp, TcpOptions::default());
+    }
 
     #[test]
     fn byte_queue_preserves_every_unwritten_suffix() {

--- a/crates/flux-network/src/stream/transport.rs
+++ b/crates/flux-network/src/stream/transport.rs
@@ -1,0 +1,253 @@
+use std::{
+    io::{self, IoSlice, Read, Write},
+    net::Shutdown,
+    os::fd::{AsRawFd, RawFd},
+    path::PathBuf,
+};
+
+use mio::{Interest, Registry, Token, event::Source, net};
+
+use super::{
+    Endpoint, Peer,
+    tcp_stream::{set_keepalive, set_user_timeout},
+};
+
+/// A bound listening socket, one variant per transport.
+pub(crate) enum ListenSocket {
+    Tcp(net::TcpListener),
+    Unix(UnixListenSocket),
+}
+
+impl ListenSocket {
+    /// Binds `endpoint`.
+    pub(crate) fn bind(endpoint: Endpoint) -> io::Result<Self> {
+        match endpoint {
+            Endpoint::Tcp(addr) => net::TcpListener::bind(addr).map(Self::Tcp),
+            Endpoint::Unix(path) => UnixListenSocket::bind(path).map(Self::Unix),
+        }
+    }
+
+    /// Accepts one pending connection, with the identity of its remote end.
+    pub(crate) fn accept(&self) -> io::Result<(TransportStream, Peer)> {
+        match self {
+            Self::Tcp(listener) => listener
+                .accept()
+                .map(|(socket, addr)| (TransportStream::Tcp(socket), Peer::Tcp(addr))),
+            // The accepted address of a Unix-domain client is unnamed, so it
+            // carries no identity to report.
+            Self::Unix(listener) => listener
+                .socket
+                .accept()
+                .map(|(socket, _)| (TransportStream::Unix(socket), Peer::Unix)),
+        }
+    }
+}
+
+impl Source for ListenSocket {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        match self {
+            Self::Tcp(listener) => listener.register(registry, token, interests),
+            Self::Unix(listener) => listener.socket.register(registry, token, interests),
+        }
+    }
+
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        match self {
+            Self::Tcp(listener) => listener.reregister(registry, token, interests),
+            Self::Unix(listener) => listener.socket.reregister(registry, token, interests),
+        }
+    }
+
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
+        match self {
+            Self::Tcp(listener) => listener.deregister(registry),
+            Self::Unix(listener) => listener.socket.deregister(registry),
+        }
+    }
+}
+
+/// A Unix-domain listener together with the socket file it created.
+///
+/// Dropping it unlinks that file, so the path is free for the next bind.
+pub(crate) struct UnixListenSocket {
+    socket: net::UnixListener,
+    path: PathBuf,
+}
+
+impl UnixListenSocket {
+    /// Binds a listener at `path`.
+    fn bind(path: PathBuf) -> io::Result<Self> {
+        let socket = net::UnixListener::bind(&path)?;
+        Ok(Self { socket, path })
+    }
+}
+
+impl Drop for UnixListenSocket {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// A connected or connecting stream, one variant per transport.
+pub(crate) enum TransportStream {
+    Tcp(net::TcpStream),
+    Unix(net::UnixStream),
+}
+
+impl TransportStream {
+    /// Starts a nonblocking connection to `endpoint`.
+    ///
+    /// The returned stream may still be connecting; [`Self::is_connected`]
+    /// reports when the attempt has finished.
+    pub(crate) fn connect(endpoint: &Endpoint) -> io::Result<Self> {
+        match endpoint {
+            Endpoint::Tcp(addr) => net::TcpStream::connect(*addr).map(Self::Tcp),
+            Endpoint::Unix(path) => net::UnixStream::connect(path).map(Self::Unix),
+        }
+    }
+
+    /// Whether a connection attempt has completed, erroring once it has
+    /// failed.
+    pub(crate) fn is_connected(&self) -> io::Result<bool> {
+        if let Some(err) = self.take_error()? {
+            return Err(err);
+        }
+        let connected = match self {
+            Self::Tcp(socket) => socket.peer_addr().map(|_| ()),
+            Self::Unix(socket) => socket.peer_addr().map(|_| ()),
+        };
+        match connected {
+            Ok(()) => Ok(true),
+            Err(err)
+                if matches!(
+                    err.kind(),
+                    io::ErrorKind::NotConnected | io::ErrorKind::WouldBlock
+                ) || matches!(err.raw_os_error(), Some(libc::EINPROGRESS | libc::EALREADY)) =>
+            {
+                Ok(false)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    fn take_error(&self) -> io::Result<Option<io::Error>> {
+        match self {
+            Self::Tcp(socket) => socket.take_error(),
+            Self::Unix(socket) => socket.take_error(),
+        }
+    }
+
+    pub(crate) fn shutdown(&self, how: Shutdown) -> io::Result<()> {
+        match self {
+            Self::Tcp(socket) => socket.shutdown(how),
+            Self::Unix(socket) => socket.shutdown(how),
+        }
+    }
+
+    /// Enables `TCP_NODELAY`, which Unix-domain sockets do not have.
+    pub(crate) fn set_nodelay(&self) -> io::Result<()> {
+        match self {
+            Self::Tcp(socket) => socket.set_nodelay(true),
+            Self::Unix(_) => Ok(()),
+        }
+    }
+
+    /// Enables TCP keepalive, which Unix-domain sockets do not have.
+    pub(crate) fn set_keepalive(&self) -> io::Result<()> {
+        match self {
+            Self::Tcp(socket) => set_keepalive(socket),
+            Self::Unix(_) => Ok(()),
+        }
+    }
+
+    /// Sets `TCP_USER_TIMEOUT`, which Unix-domain sockets do not have.
+    pub(crate) fn set_user_timeout(&self, timeout_ms: u32) {
+        if let Self::Tcp(socket) = self {
+            set_user_timeout(socket, timeout_ms);
+        }
+    }
+}
+
+impl AsRawFd for TransportStream {
+    fn as_raw_fd(&self) -> RawFd {
+        match self {
+            Self::Tcp(socket) => socket.as_raw_fd(),
+            Self::Unix(socket) => socket.as_raw_fd(),
+        }
+    }
+}
+
+impl Read for TransportStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            Self::Tcp(socket) => socket.read(buf),
+            Self::Unix(socket) => socket.read(buf),
+        }
+    }
+}
+
+impl Write for TransportStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            Self::Tcp(socket) => socket.write(buf),
+            Self::Unix(socket) => socket.write(buf),
+        }
+    }
+
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        match self {
+            Self::Tcp(socket) => socket.write_vectored(bufs),
+            Self::Unix(socket) => socket.write_vectored(bufs),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            Self::Tcp(socket) => socket.flush(),
+            Self::Unix(socket) => socket.flush(),
+        }
+    }
+}
+
+impl Source for TransportStream {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        match self {
+            Self::Tcp(socket) => socket.register(registry, token, interests),
+            Self::Unix(socket) => socket.register(registry, token, interests),
+        }
+    }
+
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        match self {
+            Self::Tcp(socket) => socket.reregister(registry, token, interests),
+            Self::Unix(socket) => socket.reregister(registry, token, interests),
+        }
+    }
+
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
+        match self {
+            Self::Tcp(socket) => socket.deregister(registry),
+            Self::Unix(socket) => socket.deregister(registry),
+        }
+    }
+}

--- a/crates/flux-network/src/stream/transport.rs
+++ b/crates/flux-network/src/stream/transport.rs
@@ -1,8 +1,11 @@
 use std::{
     io::{self, IoSlice, Read, Write},
     net::Shutdown,
-    os::fd::{AsRawFd, RawFd},
-    path::PathBuf,
+    os::{
+        fd::{AsRawFd, RawFd},
+        unix::fs::FileTypeExt as _,
+    },
+    path::{Path, PathBuf},
 };
 
 use mio::{Interest, Registry, Token, event::Source, net};
@@ -85,11 +88,70 @@ pub(crate) struct UnixListenSocket {
 }
 
 impl UnixListenSocket {
-    /// Binds a listener at `path`.
+    /// Binds a listener at `path`, replacing a socket file that a process
+    /// which did not clean up left behind.
+    ///
+    /// See [`clear_stale_socket`] for what an occupied path does.
     fn bind(path: PathBuf) -> io::Result<Self> {
+        clear_stale_socket(&path)?;
         let socket = net::UnixListener::bind(&path)?;
         Ok(Self { socket, path })
     }
+}
+
+/// Frees `path` for a bind, removing it when it holds a socket no process
+/// listens on and erroring when it holds anything a bind must not disturb.
+///
+/// The path is inspected with `lstat` and never followed: an object that is
+/// not a socket — a regular file, a directory, a symbolic link even to a
+/// socket — stays where it is and the bind fails with `AlreadyExists`. A
+/// socket is then probed with a connect; a refused connection means no
+/// process is listening, so the file is a stale remnant and is unlinked,
+/// while a connection that succeeds means a live server owns the path and the
+/// bind fails with `AddrInUse`. The `lstat` is what makes the unlink safe:
+/// connecting to a regular file is refused too, so the probe alone says
+/// nothing about what the path holds.
+///
+/// The probe is nonblocking, so an owner that has stopped accepting is
+/// reported rather than waited for: a full accept queue answers `WouldBlock`,
+/// which is as much a live owner as a completed connection is.
+fn clear_stale_socket(path: &Path) -> io::Result<()> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(about(&err, path, "couldn't inspect")),
+    };
+    if !metadata.file_type().is_socket() {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("{} exists and is not a socket", path.display()),
+        ));
+    }
+    match net::UnixStream::connect(path) {
+        Ok(_) => Err(in_use(path)),
+        Err(err)
+            if err.kind() == io::ErrorKind::WouldBlock ||
+                err.raw_os_error() == Some(libc::EINPROGRESS) =>
+        {
+            Err(in_use(path))
+        }
+        Err(err) if err.kind() == io::ErrorKind::ConnectionRefused => std::fs::remove_file(path)
+            .map_err(|err| about(&err, path, "couldn't remove the stale socket")),
+        Err(err) => Err(about(&err, path, "couldn't probe")),
+    }
+}
+
+/// The error for a path a live process is listening on.
+fn in_use(path: &Path) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::AddrInUse,
+        format!("{} belongs to a listening process", path.display()),
+    )
+}
+
+/// Restates `err` with the path it is about, keeping its kind.
+fn about(err: &io::Error, path: &Path, doing: &str) -> io::Error {
+    io::Error::new(err.kind(), format!("{doing} {}: {err}", path.display()))
 }
 
 impl Drop for UnixListenSocket {

--- a/crates/flux-network/tests/http.rs
+++ b/crates/flux-network/tests/http.rs
@@ -5,7 +5,10 @@ use std::{
     time::{Duration, Instant},
 };
 
-use flux_network::http::{HttpEvent, HttpNetwork};
+use flux_network::{
+    http::{HttpEvent, HttpNetwork},
+    stream::{Endpoint, Peer},
+};
 
 const TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -16,7 +19,44 @@ fn unused_addr() -> SocketAddr {
     addr
 }
 
-fn read_available(stream: &mut std::net::TcpStream, out: &mut Vec<u8>) -> bool {
+/// Runs one test body over both transports: a loopback TCP address on an
+/// ephemeral port, and a Unix-domain socket path under a temporary directory
+/// that lives for the duration of the run.
+macro_rules! over_both_transports {
+    ($body:ident, $tcp:ident, $unix:ident) => {
+        #[test]
+        fn $tcp() {
+            $body(&Endpoint::Tcp(unused_addr()));
+        }
+
+        #[test]
+        fn $unix() {
+            let dir = tempfile::tempdir().unwrap();
+            $body(&Endpoint::Unix(dir.path().join("s")));
+        }
+    };
+}
+
+/// A nonblocking client socket speaking raw bytes to a server under test.
+trait ClientStream: Read + Write {}
+impl<T: Read + Write> ClientStream for T {}
+
+fn connect_client(endpoint: &Endpoint) -> Box<dyn ClientStream> {
+    match endpoint {
+        Endpoint::Tcp(addr) => {
+            let stream = std::net::TcpStream::connect(addr).unwrap();
+            stream.set_nonblocking(true).unwrap();
+            Box::new(stream)
+        }
+        Endpoint::Unix(path) => {
+            let stream = std::os::unix::net::UnixStream::connect(path).unwrap();
+            stream.set_nonblocking(true).unwrap();
+            Box::new(stream)
+        }
+    }
+}
+
+fn read_available(stream: &mut impl Read, out: &mut Vec<u8>) -> bool {
     let mut buf = [0; 8192];
     match stream.read(&mut buf) {
         Ok(0) => true,
@@ -45,18 +85,25 @@ fn response_len(bytes: &[u8]) -> Option<usize> {
     (bytes.len() >= head + length).then_some(head + length)
 }
 
-fn server() -> (HttpNetwork, SocketAddr) {
-    let addr = unused_addr();
+fn server_at(endpoint: &Endpoint) -> HttpNetwork {
     let mut server = HttpNetwork::default();
-    server.listen(addr).unwrap();
-    (server, addr)
+    server.listen(endpoint.clone()).unwrap();
+    server
 }
 
-#[test]
-fn get_keepalive_two_requests() {
-    let (mut server, addr) = server();
-    let mut client = std::net::TcpStream::connect(addr).unwrap();
-    client.set_nonblocking(true).unwrap();
+fn server() -> (HttpNetwork, SocketAddr) {
+    let addr = unused_addr();
+    (server_at(&Endpoint::Tcp(addr)), addr)
+}
+
+over_both_transports!(
+    get_keepalive_two_requests,
+    get_keepalive_two_requests_tcp,
+    get_keepalive_two_requests_unix
+);
+fn get_keepalive_two_requests(endpoint: &Endpoint) {
+    let mut server = server_at(endpoint);
+    let mut client = connect_client(endpoint);
     let deadline = Instant::now() + TIMEOUT;
     let mut first = Vec::new();
     client.write_all(b"GET /one HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
@@ -99,12 +146,11 @@ fn get_keepalive_two_requests() {
     assert!(second.ends_with(b"two"));
 }
 
-#[test]
-fn post_echo_body() {
-    let (mut server, addr) = server();
+over_both_transports!(post_echo_body, post_echo_body_tcp, post_echo_body_unix);
+fn post_echo_body(endpoint: &Endpoint) {
+    let mut server = server_at(endpoint);
     let body = vec![42; 4096];
-    let mut client = std::net::TcpStream::connect(addr).unwrap();
-    client.set_nonblocking(true).unwrap();
+    let mut client = connect_client(endpoint);
     client
         .write_all(
             format!("POST / HTTP/1.1\r\nHost: x\r\nContent-Length: {}\r\n\r\n", body.len())
@@ -185,7 +231,7 @@ fn post_binary_body_lone_lf() {
 fn connection_close_large_body() {
     let addr = unused_addr();
     let mut server = HttpNetwork::default().with_socket_buf_size(1024);
-    server.listen(addr).unwrap();
+    server.listen(Endpoint::Tcp(addr)).unwrap();
     let body = vec![7; 256 * 1024];
     let mut client = std::net::TcpStream::connect(addr).unwrap();
     client.set_nonblocking(true).unwrap();
@@ -217,7 +263,7 @@ fn limits_and_errors() {
     ] {
         let addr = unused_addr();
         let mut server = HttpNetwork::default().with_max_head_bytes(64).with_max_body_bytes(8);
-        server.listen(addr).unwrap();
+        server.listen(Endpoint::Tcp(addr)).unwrap();
         let mut client = std::net::TcpStream::connect(addr).unwrap();
         client.set_nonblocking(true).unwrap();
         client.write_all(request).unwrap();
@@ -259,11 +305,10 @@ fn caller_connection_close_header_sent() {
     assert!(text.ends_with("ok"));
 }
 
-#[test]
-fn pipelined_requests() {
-    let (mut server, addr) = server();
-    let mut client = std::net::TcpStream::connect(addr).unwrap();
-    client.set_nonblocking(true).unwrap();
+over_both_transports!(pipelined_requests, pipelined_requests_tcp, pipelined_requests_unix);
+fn pipelined_requests(endpoint: &Endpoint) {
+    let mut server = server_at(endpoint);
+    let mut client = connect_client(endpoint);
     client
         .write_all(b"GET /one HTTP/1.1\r\nHost: x\r\n\r\nGET /two HTTP/1.1\r\nHost: x\r\n\r\n")
         .unwrap();
@@ -288,11 +333,15 @@ fn pipelined_requests() {
     assert!(received.ends_with(b"/two"));
 }
 
-#[test]
-fn client_server_roundtrip() {
-    let (mut server, addr) = server();
+over_both_transports!(
+    client_server_roundtrip,
+    client_server_roundtrip_tcp,
+    client_server_roundtrip_unix
+);
+fn client_server_roundtrip(endpoint: &Endpoint) {
+    let mut server = server_at(endpoint);
     let mut client = HttpNetwork::default();
-    let token = client.connect(addr);
+    let token = client.connect(endpoint.clone());
     let mut sent = false;
     let mut bodies = Vec::new();
     let deadline = Instant::now() + TIMEOUT;
@@ -340,7 +389,7 @@ fn client_chunked_response() {
         s.write_all(b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n3 \r\nhey\r\n2;ext=x\r\n!!\r\n0\r\nX: y\r\n\r\n").unwrap();
     });
     let mut client = HttpNetwork::default();
-    let token = client.connect(addr);
+    let token = client.connect(Endpoint::Tcp(addr));
     let mut sent = false;
     let mut body = None;
     let deadline = Instant::now() + TIMEOUT;
@@ -372,7 +421,7 @@ fn client_head_response_ignores_advisory_content_length() {
         stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 999999\r\n\r\n").unwrap();
     });
     let mut client = HttpNetwork::default().with_max_body_bytes(8);
-    let token = client.connect(addr);
+    let token = client.connect(Endpoint::Tcp(addr));
     let deadline = Instant::now() + TIMEOUT;
     let mut connected = false;
     let mut response = None;
@@ -419,7 +468,7 @@ fn client_binary_bodies() {
         s.write_all(&plain).unwrap();
     });
     let mut client = HttpNetwork::default();
-    let token = client.connect(addr);
+    let token = client.connect(Endpoint::Tcp(addr));
     let mut sent = false;
     let mut bodies = Vec::new();
     let deadline = Instant::now() + TIMEOUT;
@@ -451,7 +500,7 @@ fn client_binary_bodies() {
 fn client_reconnect_after_close() {
     let (mut server, addr) = server();
     let mut client = HttpNetwork::default();
-    let token = client.connect(addr);
+    let token = client.connect(Endpoint::Tcp(addr));
     let mut connected = 0;
     let mut disconnected = 0;
     let mut responses = 0;
@@ -566,7 +615,7 @@ fn assert_chunked_response_disconnect(response: &'static [u8], max_headers: usiz
         stream.write_all(response).unwrap();
     });
     let mut client = HttpNetwork::default().with_max_headers(max_headers);
-    let token = client.connect(addr);
+    let token = client.connect(Endpoint::Tcp(addr));
     let deadline = Instant::now() + TIMEOUT;
     let mut sent = false;
     let mut disconnected = 0;
@@ -616,7 +665,7 @@ fn client_chunked_overflow() {
             stream.write_all(response).unwrap();
         });
         let mut client = HttpNetwork::default().with_max_body_bytes(16);
-        let token = client.connect(addr);
+        let token = client.connect(Endpoint::Tcp(addr));
         let deadline = Instant::now() + TIMEOUT;
         let mut sent = false;
         let mut disconnected = 0;
@@ -644,7 +693,7 @@ fn client_chunked_overflow() {
 fn idle_timeout_disconnects() {
     let addr = unused_addr();
     let mut server = HttpNetwork::default().with_idle_timeout(Duration::from_millis(200).into());
-    server.listen(addr).unwrap();
+    server.listen(Endpoint::Tcp(addr)).unwrap();
     let mut client = std::net::TcpStream::connect(addr).unwrap();
     client.set_nonblocking(true).unwrap();
     let deadline = Instant::now() + Duration::from_secs(2);
@@ -690,7 +739,7 @@ fn idle_timeout_disconnects() {
 fn pending_buffer_cap_disconnects() {
     let addr = unused_addr();
     let mut server = HttpNetwork::default().with_max_head_bytes(64).with_max_body_bytes(64);
-    server.listen(addr).unwrap();
+    server.listen(Endpoint::Tcp(addr)).unwrap();
     let mut client = std::net::TcpStream::connect(addr).unwrap();
     client.set_nonblocking(true).unwrap();
     client.write_all(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
@@ -758,7 +807,7 @@ fn pipelined_binary_bodies() {
 fn client_remove_stops_reconnect() {
     let (mut server, addr) = server();
     let mut client = HttpNetwork::default();
-    let token = client.connect(addr);
+    let token = client.connect(Endpoint::Tcp(addr));
     let deadline = Instant::now() + TIMEOUT;
     let mut connected = false;
     while Instant::now() < deadline && !connected {
@@ -821,8 +870,8 @@ fn server_disconnect_kicks() {
 fn wrong_role_calls_return_false() {
     let addr = unused_addr();
     let mut http = HttpNetwork::default();
-    http.listen(addr).unwrap();
-    let outbound = http.connect(addr);
+    http.listen(Endpoint::Tcp(addr)).unwrap();
+    let outbound = http.connect(Endpoint::Tcp(addr));
     let stream = std::net::TcpStream::connect(addr).unwrap();
     stream.set_nonblocking(true).unwrap();
     let deadline = Instant::now() + TIMEOUT;
@@ -843,8 +892,8 @@ fn wrong_role_calls_return_false() {
 fn single_instance_serves_itself() {
     let addr = unused_addr();
     let mut http = HttpNetwork::default();
-    http.listen(addr).unwrap();
-    let outbound = http.connect(addr);
+    http.listen(Endpoint::Tcp(addr)).unwrap();
+    let outbound = http.connect(Endpoint::Tcp(addr));
     let deadline = Instant::now() + TIMEOUT;
     let mut sent = false;
     let mut body = None;
@@ -869,4 +918,64 @@ fn single_instance_serves_itself() {
         thread::sleep(Duration::from_millis(1));
     }
     assert_eq!(body.as_deref(), Some(b"self".as_slice()));
+}
+
+over_both_transports!(
+    outbound_host_header_names_the_endpoint,
+    outbound_host_header_names_the_endpoint_tcp,
+    outbound_host_header_names_the_endpoint_unix
+);
+fn outbound_host_header_names_the_endpoint(endpoint: &Endpoint) {
+    let mut server = server_at(endpoint);
+    let mut client = HttpNetwork::default();
+    let token = client.connect(endpoint.clone());
+    let mut sent = false;
+    let mut host = None;
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && host.is_none() {
+        let mut replies = Vec::new();
+        server.poll_with(|event| {
+            if let HttpEvent::Request { token, request } = event {
+                host = Some(request.header("Host").map(<[u8]>::to_vec));
+                replies.push(token);
+            }
+        });
+        for token in replies {
+            assert!(server.respond(token, 200, &[], b""));
+        }
+        let mut connected = false;
+        client.poll_with(|event| connected |= matches!(event, HttpEvent::Connected { .. }));
+        if connected && !sent {
+            assert!(client.request(token, "GET", "/", &[], b""));
+            sent = true;
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    let expected = match endpoint {
+        // A Unix-domain endpoint has no address to name.
+        Endpoint::Unix(_) => "localhost".to_owned(),
+        Endpoint::Tcp(addr) => addr.to_string(),
+    };
+    assert_eq!(host.flatten().as_deref(), Some(expected.as_bytes()));
+}
+
+over_both_transports!(accepted_reports_peer, accepted_reports_peer_tcp, accepted_reports_peer_unix);
+fn accepted_reports_peer(endpoint: &Endpoint) {
+    let mut server = server_at(endpoint);
+    let _client = connect_client(endpoint);
+    let mut accepted = None;
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && accepted.is_none() {
+        server.poll_with(|event| {
+            if let HttpEvent::Accepted { peer, .. } = event {
+                accepted = Some(peer);
+            }
+        });
+        thread::sleep(Duration::from_millis(1));
+    }
+    match endpoint {
+        Endpoint::Tcp(_) => assert!(matches!(accepted, Some(Peer::Tcp(_))), "{accepted:?}"),
+        Endpoint::Unix(_) => assert_eq!(accepted, Some(Peer::Unix)),
+    }
 }

--- a/crates/flux-network/tests/stream_network.rs
+++ b/crates/flux-network/tests/stream_network.rs
@@ -7,7 +7,8 @@ use std::{
 };
 
 use flux_network::stream::{
-    ConnectionGroupConfig, PollEvent, SendBehavior, StreamEvent, StreamNetwork, TcpConnector,
+    ConnectionGroupConfig, Endpoint, Peer, PollEvent, SendBehavior, StreamEvent, StreamNetwork,
+    TcpConnector,
 };
 
 const CLIENT_HELLO: &[u8] = b"client-hello";
@@ -21,6 +22,33 @@ fn unused_addr() -> SocketAddr {
     let addr = listener.local_addr().unwrap();
     drop(listener);
     addr
+}
+
+/// Runs one test body over both transports: a loopback TCP address on an
+/// ephemeral port, and a Unix-domain socket path under a temporary directory
+/// that lives for the duration of the run.
+macro_rules! over_both_transports {
+    ($body:ident, $tcp:ident, $unix:ident) => {
+        #[test]
+        fn $tcp() {
+            $body(&Endpoint::Tcp(unused_addr()));
+        }
+
+        #[test]
+        fn $unix() {
+            let dir = tempfile::tempdir().unwrap();
+            $body(&Endpoint::Unix(dir.path().join("s")));
+        }
+    };
+}
+
+/// Connects to `endpoint` the way an unrelated peer would, bypassing flux's
+/// framing so a test can write partial or malformed frames.
+fn raw_peer(endpoint: &Endpoint) -> Box<dyn Write> {
+    match endpoint {
+        Endpoint::Tcp(addr) => Box::new(std::net::TcpStream::connect(addr).unwrap()),
+        Endpoint::Unix(path) => Box::new(std::os::unix::net::UnixStream::connect(path).unwrap()),
+    }
 }
 
 fn contains(messages: &[Vec<u8>], expected: &[u8]) -> bool {
@@ -53,9 +81,12 @@ fn encoded_frame(payload: &[u8]) -> Vec<u8> {
     frame
 }
 
-#[test]
-fn groups_route_events_and_messages() {
-    let addr = unused_addr();
+over_both_transports!(
+    groups_route_events_and_messages,
+    groups_route_events_and_messages_tcp,
+    groups_route_events_and_messages_unix
+);
+fn groups_route_events_and_messages(endpoint: &Endpoint) {
     let mut network = StreamNetwork::default();
     let server_group = network.add_group(ConnectionGroupConfig {
         name: "server",
@@ -68,8 +99,8 @@ fn groups_route_events_and_messages() {
         reconnect_interval: flux_timing::Duration::from_millis(1),
         ..ConnectionGroupConfig::default()
     });
-    network.listen(server_group, addr).unwrap();
-    let client_token = network.connect(client_group, addr);
+    network.listen(server_group, endpoint.clone()).unwrap();
+    let client_token = network.connect(client_group, endpoint.clone());
 
     let mut server_token = None;
     let mut connected = false;
@@ -143,8 +174,8 @@ fn batch_send_preserves_framed_messages() {
     let mut network = StreamNetwork::default();
     let server_group = network.add_group(ConnectionGroupConfig { name: "server", ..Default::default() });
     let client_group = network.add_group(ConnectionGroupConfig { name: "client", ..Default::default() });
-    network.listen(server_group, addr).unwrap();
-    let _ = network.connect(client_group, addr);
+    network.listen(server_group, Endpoint::Tcp(addr)).unwrap();
+    let _ = network.connect(client_group, Endpoint::Tcp(addr));
     let server_token = wait_for_accept(&mut network, server_group);
 
     assert!(network.send_many_with(server_token, BATCH_MESSAGES, |buf, message| {
@@ -177,8 +208,8 @@ fn payload_buffer_is_relative_to_its_own_frame() {
     let mut network = StreamNetwork::default();
     let server_group = network.add_group(ConnectionGroupConfig { name: "server", ..Default::default() });
     let client_group = network.add_group(ConnectionGroupConfig { name: "client", ..Default::default() });
-    network.listen(server_group, addr).unwrap();
-    let _ = network.connect(client_group, addr);
+    network.listen(server_group, Endpoint::Tcp(addr)).unwrap();
+    let _ = network.connect(client_group, Endpoint::Tcp(addr));
     let server_token = wait_for_accept(&mut network, server_group);
 
     // The middle serialiser rewrites its payload from scratch. Every
@@ -215,8 +246,8 @@ fn payload_buffer_is_a_wincode_writer() {
     let mut network = StreamNetwork::default();
     let server_group = network.add_group(ConnectionGroupConfig { name: "server", ..Default::default() });
     let client_group = network.add_group(ConnectionGroupConfig { name: "client", ..Default::default() });
-    network.listen(server_group, addr).unwrap();
-    let _ = network.connect(client_group, addr);
+    network.listen(server_group, Endpoint::Tcp(addr)).unwrap();
+    let _ = network.connect(client_group, Endpoint::Tcp(addr));
     let server_token = wait_for_accept(&mut network, server_group);
 
     let values = [7u64, 11, 13];
@@ -250,8 +281,8 @@ fn batch_skips_oversized_payloads_and_keeps_the_rest() {
         ..Default::default()
     });
     let client_group = network.add_group(ConnectionGroupConfig { name: "client", ..Default::default() });
-    network.listen(server_group, addr).unwrap();
-    let _ = network.connect(client_group, addr);
+    network.listen(server_group, Endpoint::Tcp(addr)).unwrap();
+    let _ = network.connect(client_group, Endpoint::Tcp(addr));
     let server_token = wait_for_accept(&mut network, server_group);
 
     let oversized = [7u8; 64];
@@ -285,9 +316,9 @@ fn broadcast_many_serializes_each_payload_once() {
         reconnect_interval: flux_timing::Duration::from_millis(1),
         ..Default::default()
     });
-    network.listen(server_group, addr).unwrap();
-    let _first_client = network.connect(client_group, addr);
-    let _second_client = network.connect(client_group, addr);
+    network.listen(server_group, Endpoint::Tcp(addr)).unwrap();
+    let _first_client = network.connect(client_group, Endpoint::Tcp(addr));
+    let _second_client = network.connect(client_group, Endpoint::Tcp(addr));
 
     let mut accepted = 0;
     let mut connected = 0;
@@ -339,14 +370,17 @@ fn broadcast_many_serializes_each_payload_once() {
     }
 }
 
-#[test]
-fn partial_header_and_payload_are_not_delivered_early() {
-    let addr = unused_addr();
+over_both_transports!(
+    partial_header_and_payload_are_not_delivered_early,
+    partial_header_and_payload_are_not_delivered_early_tcp,
+    partial_header_and_payload_are_not_delivered_early_unix
+);
+fn partial_header_and_payload_are_not_delivered_early(endpoint: &Endpoint) {
     let mut network = StreamNetwork::default();
     let group = network.add_group(ConnectionGroupConfig { name: "server", ..Default::default() });
-    network.listen(group, addr).unwrap();
+    network.listen(group, endpoint.clone()).unwrap();
 
-    let mut peer = std::net::TcpStream::connect(addr).unwrap();
+    let mut peer = raw_peer(endpoint);
     let token = wait_for_accept(&mut network, group);
     let frame = encoded_frame(REQUEST);
     let mut messages = Vec::new();
@@ -378,18 +412,21 @@ fn partial_header_and_payload_are_not_delivered_early() {
     assert_eq!(messages, [REQUEST]);
 }
 
-#[test]
-fn oversized_frame_disconnects_the_peer() {
-    let addr = unused_addr();
+over_both_transports!(
+    oversized_frame_disconnects_the_peer,
+    oversized_frame_disconnects_the_peer_tcp,
+    oversized_frame_disconnects_the_peer_unix
+);
+fn oversized_frame_disconnects_the_peer(endpoint: &Endpoint) {
     let mut network = StreamNetwork::default();
     let group = network.add_group(ConnectionGroupConfig {
         name: "server",
         max_frame_size: 32,
         ..Default::default()
     });
-    network.listen(group, addr).unwrap();
+    network.listen(group, endpoint.clone()).unwrap();
 
-    let mut peer = std::net::TcpStream::connect(addr).unwrap();
+    let mut peer = raw_peer(endpoint);
     let token = wait_for_accept(&mut network, group);
     let mut header = Vec::with_capacity(12);
     header.extend_from_slice(&33_u32.to_le_bytes());
@@ -412,6 +449,8 @@ fn oversized_frame_disconnects_the_peer() {
     assert!(disconnected);
 }
 
+/// TCP only: the backlog only grows once a write goes short, which this test
+/// arranges through `SO_SNDBUF` on a TCP socket.
 #[test]
 fn hard_backlog_limit_disconnects_the_peer() {
     let addr = unused_addr();
@@ -426,8 +465,8 @@ fn hard_backlog_limit_disconnects_the_peer() {
         max_frame_size: 2 * 1024 * 1024,
         ..Default::default()
     });
-    network.listen(server_group, addr).unwrap();
-    let client_token = network.connect(client_group, addr);
+    network.listen(server_group, Endpoint::Tcp(addr)).unwrap();
+    let client_token = network.connect(client_group, Endpoint::Tcp(addr));
 
     let mut connected = false;
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -457,9 +496,12 @@ fn hard_backlog_limit_disconnects_the_peer() {
     assert!(disconnected);
 }
 
-#[test]
-fn broadcast_serializes_once_for_multiple_connections() {
-    let addr = unused_addr();
+over_both_transports!(
+    broadcast_serializes_once_for_multiple_connections,
+    broadcast_serializes_once_for_multiple_connections_tcp,
+    broadcast_serializes_once_for_multiple_connections_unix
+);
+fn broadcast_serializes_once_for_multiple_connections(endpoint: &Endpoint) {
     let mut network = StreamNetwork::default();
     let server_group =
         network.add_group(ConnectionGroupConfig { name: "server", ..Default::default() });
@@ -468,9 +510,9 @@ fn broadcast_serializes_once_for_multiple_connections() {
         reconnect_interval: flux_timing::Duration::from_millis(1),
         ..Default::default()
     });
-    network.listen(server_group, addr).unwrap();
-    let _first_client = network.connect(client_group, addr);
-    let _second_client = network.connect(client_group, addr);
+    network.listen(server_group, endpoint.clone()).unwrap();
+    let _first_client = network.connect(client_group, endpoint.clone());
+    let _second_client = network.connect(client_group, endpoint.clone());
 
     let mut accepted = 0;
     let mut connected = 0;
@@ -516,9 +558,12 @@ fn broadcast_serializes_once_for_multiple_connections() {
     assert_eq!(received, 2);
 }
 
-#[test]
-fn disconnected_messages_are_dropped_and_token_survives_reconnect() {
-    let addr = unused_addr();
+over_both_transports!(
+    disconnected_messages_are_dropped_and_token_survives_reconnect,
+    disconnected_messages_are_dropped_and_token_survives_reconnect_tcp,
+    disconnected_messages_are_dropped_and_token_survives_reconnect_unix
+);
+fn disconnected_messages_are_dropped_and_token_survives_reconnect(endpoint: &Endpoint) {
     let mut network = StreamNetwork::default();
     let server_group =
         network.add_group(ConnectionGroupConfig { name: "server", ..Default::default() });
@@ -527,8 +572,8 @@ fn disconnected_messages_are_dropped_and_token_survives_reconnect() {
         reconnect_interval: flux_timing::Duration::from_millis(1),
         ..Default::default()
     });
-    network.listen(server_group, addr).unwrap();
-    let client_token = network.connect(client_group, addr);
+    network.listen(server_group, endpoint.clone()).unwrap();
+    let client_token = network.connect(client_group, endpoint.clone());
 
     let mut server_token = None;
     let mut connected = false;
@@ -606,6 +651,7 @@ fn disconnected_messages_are_dropped_and_token_survives_reconnect() {
     assert!(contains(&server_messages, RESPONSE));
 }
 
+/// TCP only: `TcpConnector` speaks TCP alone.
 #[test]
 fn stream_network_is_wire_compatible_with_tcp_connector() {
     let addr = unused_addr();
@@ -615,7 +661,7 @@ fn stream_network_is_wire_compatible_with_tcp_connector() {
         on_connect_msg: Some(SERVER_HELLO.to_vec()),
         ..Default::default()
     });
-    network.listen(server_group, addr).unwrap();
+    network.listen(server_group, Endpoint::Tcp(addr)).unwrap();
 
     let mut connector = TcpConnector::default();
     let connector_token = connector.connect(addr).expect("connector failed to connect");
@@ -660,6 +706,7 @@ fn stream_network_is_wire_compatible_with_tcp_connector() {
     assert!(contains(&connector_messages, RESPONSE));
 }
 
+/// TCP only: `TcpConnector` speaks TCP alone.
 #[test]
 fn stream_network_client_is_wire_compatible_with_tcp_connector_server() {
     let addr = unused_addr();
@@ -673,7 +720,7 @@ fn stream_network_client_is_wire_compatible_with_tcp_connector_server() {
         reconnect_interval: flux_timing::Duration::from_millis(1),
         ..Default::default()
     });
-    let client_token = network.connect(client_group, addr);
+    let client_token = network.connect(client_group, Endpoint::Tcp(addr));
 
     let mut connector_token = None;
     let mut connector_messages = Vec::new();
@@ -733,4 +780,106 @@ fn stream_network_client_is_wire_compatible_with_tcp_connector_server() {
         thread::sleep(Duration::from_millis(1));
     }
     assert!(contains(&network_messages, RESPONSE));
+}
+
+over_both_transports!(
+    accepted_peer_identifies_the_transport,
+    accepted_peer_identifies_the_transport_tcp,
+    accepted_peer_identifies_the_transport_unix
+);
+fn accepted_peer_identifies_the_transport(endpoint: &Endpoint) {
+    let mut network = StreamNetwork::default();
+    let server_group =
+        network.add_group(ConnectionGroupConfig { name: "server", ..Default::default() });
+    let client_group = network.add_group(ConnectionGroupConfig {
+        name: "client",
+        reconnect_interval: flux_timing::Duration::from_millis(1),
+        ..Default::default()
+    });
+    network.listen(server_group, endpoint.clone()).unwrap();
+    let client_token = network.connect(client_group, endpoint.clone());
+
+    let mut accepted = None;
+    let mut connected = None;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline && (accepted.is_none() || connected.is_none()) {
+        network.poll_with(|event| match event {
+            StreamEvent::Accepted { group, peer, .. } => {
+                assert_eq!(group, server_group);
+                accepted = Some(peer);
+            }
+            StreamEvent::Connected { token, peer, .. } => {
+                assert_eq!(token, client_token);
+                connected = Some(peer);
+            }
+            _ => {}
+        });
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    match endpoint {
+        Endpoint::Tcp(addr) => {
+            // The accepted peer is the client's ephemeral port, not the
+            // listening address; only the outbound side knows its target.
+            assert!(matches!(accepted, Some(Peer::Tcp(_))), "{accepted:?}");
+            assert_eq!(connected, Some(Peer::Tcp(*addr)));
+        }
+        Endpoint::Unix(_) => {
+            assert_eq!(accepted, Some(Peer::Unix));
+            assert_eq!(connected, Some(Peer::Unix));
+        }
+    }
+}
+
+/// A Unix-domain endpoint whose socket file does not exist yet retries at the
+/// group's interval, exactly as a refused TCP endpoint does.
+#[test]
+fn unix_endpoint_connects_once_its_listener_appears() {
+    let dir = tempfile::tempdir().unwrap();
+    let endpoint = Endpoint::Unix(dir.path().join("late"));
+
+    let mut client = StreamNetwork::default();
+    let client_group = client.add_group(ConnectionGroupConfig {
+        name: "client",
+        reconnect_interval: flux_timing::Duration::from_millis(5),
+        ..Default::default()
+    });
+    let client_token = client.connect(client_group, endpoint.clone());
+
+    let deadline = Instant::now() + Duration::from_millis(100);
+    while Instant::now() < deadline {
+        client.poll_with(|event| {
+            assert!(
+                !matches!(event, StreamEvent::Connected { .. }),
+                "connected before the listener existed"
+            );
+        });
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert!(!dir.path().join("late").exists());
+
+    let mut server = StreamNetwork::default();
+    let server_group =
+        server.add_group(ConnectionGroupConfig { name: "server", ..Default::default() });
+    server.listen(server_group, endpoint).unwrap();
+
+    let mut accepted = false;
+    let mut connected = false;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline && !(accepted && connected) {
+        server.poll_with(|event| {
+            if matches!(event, StreamEvent::Accepted { .. }) {
+                accepted = true;
+            }
+        });
+        client.poll_with(|event| {
+            if let StreamEvent::Connected { token, .. } = event {
+                assert_eq!(token, client_token);
+                connected = true;
+            }
+        });
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert!(accepted);
+    assert!(connected);
 }

--- a/crates/flux-network/tests/stream_network.rs
+++ b/crates/flux-network/tests/stream_network.rs
@@ -172,8 +172,10 @@ fn groups_route_events_and_messages(endpoint: &Endpoint) {
 fn batch_send_preserves_framed_messages() {
     let addr = unused_addr();
     let mut network = StreamNetwork::default();
-    let server_group = network.add_group(ConnectionGroupConfig { name: "server", ..Default::default() });
-    let client_group = network.add_group(ConnectionGroupConfig { name: "client", ..Default::default() });
+    let server_group =
+        network.add_group(ConnectionGroupConfig { name: "server", ..Default::default() });
+    let client_group =
+        network.add_group(ConnectionGroupConfig { name: "client", ..Default::default() });
     network.listen(server_group, Endpoint::Tcp(addr)).unwrap();
     let _ = network.connect(client_group, Endpoint::Tcp(addr));
     let server_token = wait_for_accept(&mut network, server_group);
@@ -206,8 +208,10 @@ fn batch_send_preserves_framed_messages() {
 fn payload_buffer_is_relative_to_its_own_frame() {
     let addr = unused_addr();
     let mut network = StreamNetwork::default();
-    let server_group = network.add_group(ConnectionGroupConfig { name: "server", ..Default::default() });
-    let client_group = network.add_group(ConnectionGroupConfig { name: "client", ..Default::default() });
+    let server_group =
+        network.add_group(ConnectionGroupConfig { name: "server", ..Default::default() });
+    let client_group =
+        network.add_group(ConnectionGroupConfig { name: "client", ..Default::default() });
     network.listen(server_group, Endpoint::Tcp(addr)).unwrap();
     let _ = network.connect(client_group, Endpoint::Tcp(addr));
     let server_token = wait_for_accept(&mut network, server_group);
@@ -244,8 +248,10 @@ fn payload_buffer_is_relative_to_its_own_frame() {
 fn payload_buffer_is_a_wincode_writer() {
     let addr = unused_addr();
     let mut network = StreamNetwork::default();
-    let server_group = network.add_group(ConnectionGroupConfig { name: "server", ..Default::default() });
-    let client_group = network.add_group(ConnectionGroupConfig { name: "client", ..Default::default() });
+    let server_group =
+        network.add_group(ConnectionGroupConfig { name: "server", ..Default::default() });
+    let client_group =
+        network.add_group(ConnectionGroupConfig { name: "client", ..Default::default() });
     network.listen(server_group, Endpoint::Tcp(addr)).unwrap();
     let _ = network.connect(client_group, Endpoint::Tcp(addr));
     let server_token = wait_for_accept(&mut network, server_group);
@@ -280,7 +286,8 @@ fn batch_skips_oversized_payloads_and_keeps_the_rest() {
         max_frame_size: 32,
         ..Default::default()
     });
-    let client_group = network.add_group(ConnectionGroupConfig { name: "client", ..Default::default() });
+    let client_group =
+        network.add_group(ConnectionGroupConfig { name: "client", ..Default::default() });
     network.listen(server_group, Endpoint::Tcp(addr)).unwrap();
     let _ = network.connect(client_group, Endpoint::Tcp(addr));
     let server_token = wait_for_accept(&mut network, server_group);
@@ -310,7 +317,8 @@ fn batch_skips_oversized_payloads_and_keeps_the_rest() {
 fn broadcast_many_serializes_each_payload_once() {
     let addr = unused_addr();
     let mut network = StreamNetwork::default();
-    let server_group = network.add_group(ConnectionGroupConfig { name: "server", ..Default::default() });
+    let server_group =
+        network.add_group(ConnectionGroupConfig { name: "server", ..Default::default() });
     let client_group = network.add_group(ConnectionGroupConfig {
         name: "clients",
         reconnect_interval: flux_timing::Duration::from_millis(1),

--- a/crates/flux-network/tests/stream_network_raw.rs
+++ b/crates/flux-network/tests/stream_network_raw.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use flux_network::stream::{ConnectionGroupConfig, Framing, StreamEvent, StreamNetwork};
+use flux_network::stream::{ConnectionGroupConfig, Endpoint, Framing, StreamEvent, StreamNetwork};
 
 const TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -26,7 +26,7 @@ fn raw_roundtrip() {
     let addr = unused_addr();
     let mut network = StreamNetwork::default();
     let group = network.add_group(raw_group("raw-server"));
-    network.listen(group, addr).unwrap();
+    network.listen(group, Endpoint::Tcp(addr)).unwrap();
 
     let mut client = std::net::TcpStream::connect(addr).unwrap();
     client.set_nonblocking(true).unwrap();
@@ -65,7 +65,7 @@ fn raw_batch_concatenates_payloads() {
     let addr = unused_addr();
     let mut network = StreamNetwork::default();
     let group = network.add_group(raw_group("raw-server"));
-    network.listen(group, addr).unwrap();
+    network.listen(group, Endpoint::Tcp(addr)).unwrap();
 
     let mut client = std::net::TcpStream::connect(addr).unwrap();
     client.set_nonblocking(true).unwrap();
@@ -110,7 +110,7 @@ fn http_get_smoke() {
     let addr = unused_addr();
     let mut network = StreamNetwork::default();
     let group = network.add_group(raw_group("http"));
-    network.listen(group, addr).unwrap();
+    network.listen(group, Endpoint::Tcp(addr)).unwrap();
 
     let mut client = std::net::TcpStream::connect(addr).unwrap();
     client.set_nonblocking(true).unwrap();
@@ -174,7 +174,7 @@ fn raw_outbound_connect() {
         reconnect_interval: flux_timing::Duration::from_millis(1),
         ..ConnectionGroupConfig::default()
     });
-    let token = network.connect(group, addr);
+    let token = network.connect(group, Endpoint::Tcp(addr));
     let mut peer = None;
     let deadline = Instant::now() + TIMEOUT;
     while Instant::now() < deadline && peer.is_none() {
@@ -228,8 +228,8 @@ fn framed_and_raw_coexist() {
     let framed_server =
         server.add_group(ConnectionGroupConfig { name: "framed-server", ..Default::default() });
     let raw_server = server.add_group(raw_group("raw-server"));
-    server.listen(framed_server, framed_addr).unwrap();
-    server.listen(raw_server, raw_addr).unwrap();
+    server.listen(framed_server, Endpoint::Tcp(framed_addr)).unwrap();
+    server.listen(raw_server, Endpoint::Tcp(raw_addr)).unwrap();
 
     let mut framed_client = StreamNetwork::default();
     let framed_client_group = framed_client.add_group(ConnectionGroupConfig {
@@ -237,7 +237,8 @@ fn framed_and_raw_coexist() {
         reconnect_interval: flux_timing::Duration::from_millis(1),
         ..Default::default()
     });
-    let framed_client_token = framed_client.connect(framed_client_group, framed_addr);
+    let framed_client_token =
+        framed_client.connect(framed_client_group, Endpoint::Tcp(framed_addr));
     let mut raw_client = std::net::TcpStream::connect(raw_addr).unwrap();
     raw_client.set_nonblocking(true).unwrap();
     raw_client.write_all(b"raw").unwrap();
@@ -309,7 +310,7 @@ fn raw_disconnect_when_drained_flushes_queue() {
         max_frame_size: payload.len(),
         ..ConnectionGroupConfig::default()
     });
-    network.listen(group, addr).unwrap();
+    network.listen(group, Endpoint::Tcp(addr)).unwrap();
 
     let mut client = std::net::TcpStream::connect(addr).unwrap();
     client.set_nonblocking(true).unwrap();

--- a/crates/flux-network/tests/stream_network_telemetry.rs
+++ b/crates/flux-network/tests/stream_network_telemetry.rs
@@ -6,7 +6,7 @@ use std::{
 
 use flux_communication::cleanup_shmem;
 use flux_network::stream::{
-    ConnectionGroup, ConnectionGroupConfig, StreamEvent, StreamNetwork, TcpTelemetry,
+    ConnectionGroup, ConnectionGroupConfig, Endpoint, StreamEvent, StreamNetwork, TcpTelemetry,
 };
 use flux_utils::directories::shmem_dir;
 use mio::Token;
@@ -65,8 +65,8 @@ fn outbound_endpoint_reuses_telemetry_mappings_across_reconnects() {
         telemetry: TcpTelemetry::Enabled { app_name: APP_NAME },
         ..Default::default()
     });
-    network.listen(server_group, addr).unwrap();
-    let client_token = network.connect(client_group, addr);
+    network.listen(server_group, Endpoint::Tcp(addr)).unwrap();
+    let client_token = network.connect(client_group, Endpoint::Tcp(addr));
 
     let mut server_token =
         wait_for_connection(&mut network, server_group, client_group, client_token);

--- a/crates/flux-network/tests/unix_socket_lifecycle.rs
+++ b/crates/flux-network/tests/unix_socket_lifecycle.rs
@@ -1,0 +1,191 @@
+//! ADR 0003: what binding a Unix-domain listener does to an occupied path,
+//! and what closing one leaves behind.
+
+use std::{
+    io::{self, Read, Write},
+    os::{
+        fd::AsRawFd,
+        unix::{
+            fs::FileTypeExt as _,
+            net::{UnixDatagram, UnixListener, UnixStream},
+        },
+    },
+    path::Path,
+    thread,
+    time::{Duration, Instant},
+};
+
+use flux_network::stream::{ConnectionGroupConfig, Endpoint, StreamEvent, StreamNetwork};
+
+/// A network with one group, ready to listen.
+fn network() -> (StreamNetwork, flux_network::stream::ConnectionGroup) {
+    let mut network = StreamNetwork::default();
+    let group = network.add_group(ConnectionGroupConfig { name: "server", ..Default::default() });
+    (network, group)
+}
+
+fn accepts_a_connection(network: &mut StreamNetwork, path: &Path) -> bool {
+    let _client = UnixStream::connect(path).unwrap();
+    let mut accepted = false;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline && !accepted {
+        network.poll_with(|event| accepted |= matches!(event, StreamEvent::Accepted { .. }));
+        thread::sleep(Duration::from_millis(1));
+    }
+    accepted
+}
+
+#[test]
+fn stale_socket_file_is_replaced() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("s");
+
+    // Closing a socket does not unlink its file, so a process that exits
+    // without cleaning up leaves exactly this behind.
+    drop(UnixListener::bind(&path).unwrap());
+    assert!(path.exists());
+
+    let (mut network, group) = network();
+    network.listen(group, Endpoint::Unix(path.clone())).unwrap();
+    assert!(accepts_a_connection(&mut network, &path));
+}
+
+#[test]
+fn live_socket_file_is_left_to_its_owner() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("s");
+    let live = UnixListener::bind(&path).unwrap();
+
+    let (mut network, group) = network();
+    let err = network.listen(group, Endpoint::Unix(path.clone())).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::AddrInUse);
+    assert!(err.to_string().contains(path.to_str().unwrap()), "{err}");
+    assert!(path.exists());
+
+    let mut client = UnixStream::connect(&path).unwrap();
+    client.write_all(b"ping").unwrap();
+    // The refused bind's probe connection is queued ahead of this one and
+    // reads as an immediate end of stream.
+    let mut delivered = Vec::new();
+    for _ in 0..2 {
+        let (mut stream, _) = live.accept().unwrap();
+        let mut buf = [0; 4];
+        let read = stream.read(&mut buf).unwrap();
+        delivered.push(buf[..read].to_vec());
+    }
+    assert!(delivered.contains(&b"ping".to_vec()), "{delivered:?}");
+}
+
+#[test]
+fn regular_file_at_the_path_is_untouched() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("s");
+    std::fs::write(&path, b"not a socket").unwrap();
+
+    let (mut network, group) = network();
+    let err = network.listen(group, Endpoint::Unix(path.clone())).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+    assert!(err.to_string().contains(path.to_str().unwrap()), "{err}");
+    assert_eq!(std::fs::read(&path).unwrap(), b"not a socket");
+}
+
+#[test]
+fn symlink_to_a_socket_is_untouched() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("real");
+    let link = dir.path().join("link");
+    let _live = UnixListener::bind(&target).unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    let (mut network, group) = network();
+    // The link resolves to a live socket, but the bind must not follow it.
+    let err = network.listen(group, Endpoint::Unix(link.clone())).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+    assert!(err.to_string().contains(link.to_str().unwrap()), "{err}");
+    assert!(std::fs::symlink_metadata(&link).unwrap().file_type().is_symlink());
+    assert_eq!(std::fs::read_link(&link).unwrap(), target);
+    assert!(target.exists());
+}
+
+#[test]
+fn closing_the_listener_unlinks_its_socket_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("s");
+
+    let (mut network, group) = network();
+    network.listen(group, Endpoint::Unix(path.clone())).unwrap();
+    assert!(path.exists());
+
+    drop(network);
+    assert!(!path.exists());
+}
+
+#[test]
+fn saturated_live_socket_is_still_left_to_its_owner() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("s");
+    let live = UnixListener::bind(&path).unwrap();
+    // An owner that has stopped accepting is the case ADR 0003 is about, and
+    // the kernel neither completes nor refuses a connection to it.
+    assert_eq!(unsafe { libc::listen(live.as_raw_fd(), 1) }, 0);
+    let mut queued = Vec::new();
+    loop {
+        match mio::net::UnixStream::connect(&path) {
+            Ok(stream) => queued.push(stream),
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => break,
+            Err(err) => panic!("unexpected connect error: {err}"),
+        }
+        assert!(queued.len() < 64, "the accept queue never filled");
+    }
+
+    let (mut network, group) = network();
+    let started = Instant::now();
+    let err = network.listen(group, Endpoint::Unix(path.clone())).unwrap_err();
+    assert!(started.elapsed() < Duration::from_secs(1), "the probe waited for the owner");
+    assert_eq!(err.kind(), io::ErrorKind::AddrInUse);
+    assert!(err.to_string().contains(path.to_str().unwrap()), "{err}");
+    assert!(path.exists());
+
+    // The owner is unharmed: drained, it serves again.
+    drop(queued);
+    live.set_nonblocking(true).unwrap();
+    while live.accept().is_ok() {}
+    live.set_nonblocking(false).unwrap();
+    let mut client = UnixStream::connect(&path).unwrap();
+    client.write_all(b"ping").unwrap();
+    let (mut stream, _) = live.accept().unwrap();
+    let mut buf = [0; 4];
+    stream.read_exact(&mut buf).unwrap();
+    assert_eq!(&buf, b"ping");
+}
+
+#[test]
+fn non_refused_probe_error_leaves_the_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("s");
+    // A datagram socket passes the `lstat`, but a stream connect to it fails
+    // with something other than a refusal, which says nothing about whether
+    // the file is stale.
+    let _datagram = UnixDatagram::bind(&path).unwrap();
+
+    let (mut network, group) = network();
+    let err = network.listen(group, Endpoint::Unix(path.clone())).unwrap_err();
+    assert_ne!(err.kind(), io::ErrorKind::AddrInUse);
+    assert!(err.to_string().contains(path.to_str().unwrap()), "{err}");
+    assert!(std::fs::symlink_metadata(&path).unwrap().file_type().is_socket());
+}
+
+#[test]
+fn directory_at_the_path_is_untouched() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("s");
+    std::fs::create_dir(&path).unwrap();
+    std::fs::write(path.join("keep"), b"contents").unwrap();
+
+    let (mut network, group) = network();
+    let err = network.listen(group, Endpoint::Unix(path.clone())).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+    assert!(err.to_string().contains(path.to_str().unwrap()), "{err}");
+    assert!(path.is_dir());
+    assert_eq!(std::fs::read(path.join("keep")).unwrap(), b"contents");
+}


### PR DESCRIPTION
This PR builds on #137 by adding Unix-domain sockets to `StreamNetwork`. TCP and Unix-domain listeners and outbound connections can coexist in one network and one `ConnectionGroup`.

## Transport model

`StreamNetwork::listen` and `connect` now take an explicit `Endpoint`:

```rust
pub enum Endpoint {
    Tcp(SocketAddr),
    Unix(PathBuf),
}
```

Events identify the remote end as `Peer::Tcp(SocketAddr)` or `Peer::Unix`. Unix clients are anonymous because they do not bind a path of their own.

The two transports share the same connection lifecycle, framing and queue machinery. Private enums dispatch to the corresponding mio listener or stream with one match per operation. This keeps mixed-transport groups possible without generic networks or hot-path virtual calls, as decided in ADR 0002.

`HttpNetwork` accepts the same endpoint set. For an outbound Unix connection, it writes `Host: localhost` when the caller supplies no `Host` header.

## Unix socket paths

Binding a Unix listener follows ADR 0003:

- A missing path is bound normally.
- A stale socket file is removed and replaced.
- A live listener, including one with a full accept queue, returns `AddrInUse`.
- A regular file, directory or symlink is left untouched and returns `AlreadyExists`.
- Other probe failures preserve the existing object and return an error naming its path.

The ownership probe is nonblocking. Dropping the listener removes the socket file it created; after an unclean exit, the next bind detects and replaces the stale file. Outbound Unix endpoints retry at the group's reconnect interval, like TCP endpoints.

Socket-file permissions come from the process umask. Flux does not set a mode or owner.

## Configuration

TCP-only policy is grouped explicitly:

```rust
pub struct ConnectionGroupConfig {
    pub tcp: TcpOptions,
    // Common connection policy...
}
```

`TcpOptions` contains `nodelay`, `keepalive` and `user_timeout_ms`, preserving their previous defaults. Unix connections have no corresponding options. Socket buffer sizing remains common to both transports.

`Endpoint` intentionally has no `From<SocketAddr>` implementation: callers choose the transport explicitly.

The default group name changes from `"tcp"` to `"stream"`. This changes the telemetry suffix for callers that use the default name; the existing `tcp_latency_*` and `tcp_alloc_*` metric prefixes do not change.

## Scope and verification

`listen` still returns `io::Result<()>`; returning the bound endpoint follows later in the stack. `HttpNetwork` remains callback-driven, and this PR adds no scheduling or connection-cap behavior.

The stream-network and HTTP suites exercise shared behavior over both transports. Dedicated lifecycle tests cover stale and live socket files, a saturated listener, non-socket filesystem objects, datagram sockets and unlink-on-close. A unit test pins the `TcpOptions` defaults. Workspace tests, Clippy with warnings denied, and the nightly formatting check pass at this tip.

## Known test flakes

The two pre-existing races described in #137 remain at this stack boundary. One waits a fixed five seconds for a backpressure marker and is fixed in A3; the other guesses an unused TCP port and is fixed later when `listen` can report the endpoint it bound. If either appears in CI, rerun the failed job.

Base: #137. Next: A3, adding network-scheduled services and `HttpService`.

Refer: #143

Assisted-by: Claude Code:claude-fable-5
Assisted-by: Codex:gpt-5
