### PR TITLE
flux-network: schedule services and add HttpService

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,6 +657,7 @@ dependencies = [
 name = "flux-network"
 version = "0.2.0"
 dependencies = [
+ "criterion",
  "flux",
  "flux-communication",
  "flux-timing",

--- a/crates/flux-network/Cargo.toml
+++ b/crates/flux-network/Cargo.toml
@@ -21,10 +21,15 @@ tracing.workspace = true
 wincode = { workspace = true, optional = true }
 
 [dev-dependencies]
+criterion.workspace = true
 spine-derive.workspace = true
 tempfile.workspace = true
 wincode = { workspace = true }
 wincode-derive = { workspace = true }
+
+[[bench]]
+harness = false
+name = "reclaim"
 
 [lints]
 workspace = true

--- a/crates/flux-network/benches/reclaim.rs
+++ b/crates/flux-network/benches/reclaim.rs
@@ -1,0 +1,75 @@
+//! How an HTTP connection buffer reclaims the bytes it has answered.
+//!
+//! Under pipelined keep-alive the buffer always holds a partial tail, so
+//! dropping the answered prefix after every response moves that tail once per
+//! request. The cursor keeps the prefix and moves the tail only when the
+//! prefix has grown to half the buffer.
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+
+/// A modest request: a head and a small body.
+const REQUEST: usize = 200;
+/// Requests arriving together on one connection.
+const PIPELINE: usize = 16;
+/// The head of the next request, still on its way.
+const TAIL: usize = 120;
+/// Batches per measured iteration.
+const ROUNDS: usize = 64;
+
+fn arrivals() -> Vec<u8> {
+    (0..PIPELINE * REQUEST).map(|index| index as u8).collect()
+}
+
+/// Drops the answered prefix after every response.
+fn drain_per_response(batch: &[u8]) -> u64 {
+    let mut buffer = vec![0; TAIL];
+    let mut parsed = 0;
+    for _ in 0..ROUNDS {
+        buffer.extend_from_slice(batch);
+        for _ in 0..PIPELINE {
+            parsed += u64::from(buffer[0]);
+            buffer.drain(..REQUEST);
+        }
+    }
+    parsed
+}
+
+/// Keeps the answered prefix until it is half the buffer.
+fn cursor_with_compaction(batch: &[u8]) -> u64 {
+    let mut buffer = vec![0; TAIL];
+    let mut start = 0;
+    let mut consumed = 0;
+    let mut parsed = 0;
+    for _ in 0..ROUNDS {
+        buffer.extend_from_slice(batch);
+        for _ in 0..PIPELINE {
+            parsed += u64::from(buffer[start]);
+            consumed = start + REQUEST;
+            start = consumed;
+            if start >= buffer.len() / 2 {
+                buffer.drain(..start);
+                consumed -= start;
+                start = 0;
+            }
+        }
+    }
+    let _ = consumed;
+    parsed
+}
+
+fn bench_reclaim(c: &mut Criterion) {
+    let batch = arrivals();
+    let mut group = c.benchmark_group("connection_buffer_reclaim");
+    group.bench_function("drain_per_response", |b| {
+        b.iter(|| black_box(drain_per_response(black_box(&batch))));
+    });
+    group.bench_function("cursor_with_compaction", |b| {
+        b.iter(|| black_box(cursor_with_compaction(black_box(&batch))));
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_reclaim);
+criterion_main!(benches);

--- a/crates/flux-network/src/http.rs
+++ b/crates/flux-network/src/http.rs
@@ -222,7 +222,7 @@ impl<'a> HttpResponse<'a> {
 
 /// The means to answer one request, scoped to its connection.
 ///
-/// Responding consumes the responder, so a request is answered exactly once.
+/// A request can be answered once, inline or later by token.
 #[must_use = "respond now, or drop it to answer later with HttpService::respond; a request never \
               answered is closed by the idle sweep"]
 pub struct Responder<'a> {
@@ -553,10 +553,8 @@ impl HttpService {
     /// Answers a request whose [`Responder`] was dropped, and returns whether
     /// the response was written.
     ///
-    /// Each call completes exactly one request for `token`.
-    ///
     /// Unlike [`Responder::respond`], this path holds no event borrow, so it
-    /// reclaims answered bytes and queues a pipelined request before returning.
+    /// reclaims answered bytes and requeues the connection before returning.
     pub fn respond(
         &mut self,
         net: &mut StreamNetwork,
@@ -629,22 +627,6 @@ impl HttpService {
                 Some(HttpEvent::Response { token, response })
             }
         }
-    }
-
-    /// Where a connection has parsed and answered up to: `start`, `consumed`
-    /// and `req_end`.
-    #[doc(hidden)]
-    pub fn cursors(&self, token: Token) -> Option<(usize, usize, Option<usize>)> {
-        self.index_of(token).map(|index| {
-            let conn = &self.conns[index];
-            (conn.start, conn.state.consumed, conn.state.req_end)
-        })
-    }
-
-    /// Connections queued as ready to parse.
-    #[doc(hidden)]
-    pub fn ready_len(&self) -> usize {
-        self.ready.len() - self.ready_cursor
     }
 
     /// Applies bookkeeping deferred by the last pulled event.
@@ -1450,7 +1432,18 @@ pub fn reason_phrase(status: u16) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::{HttpRequest, span};
+    use std::{
+        io::Write as _,
+        net::{Ipv4Addr, SocketAddr, TcpStream},
+    };
+
+    use flux_timing::Duration;
+    use mio::Token;
+
+    use super::{Conn, HttpConfig, HttpEvent, HttpRequest, HttpService, Phase, Role, span};
+    use crate::stream::{ConnectionGroupConfig, Endpoint, Framing, StreamNetwork};
+
+    const PATIENCE: std::time::Duration = std::time::Duration::from_secs(10);
 
     #[test]
     fn header_lookup_is_case_insensitive() {
@@ -1475,5 +1468,242 @@ mod tests {
         assert_eq!(span(buffer, &buffer[4..9], 0), 4..9);
         assert_eq!(span(buffer, &buffer[4..9], 100), 104..109);
         assert_eq!(span(buffer, b"", 7), 7..7);
+    }
+
+    fn unused_addr() -> SocketAddr {
+        let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        addr
+    }
+
+    /// A service on a raw group of its own, with no listener and no
+    /// connections.
+    fn bare_service(net: &mut StreamNetwork) -> HttpService {
+        let group = net.add_group(ConnectionGroupConfig {
+            name: "http",
+            framing: Framing::Raw,
+            ..ConnectionGroupConfig::default()
+        });
+        HttpService::new(net, group, HttpConfig::default())
+    }
+
+    /// A request of exactly `size` bytes, padded out with a header.
+    fn padded_request(path: &str, size: usize) -> Vec<u8> {
+        let bare = format!("GET {path} HTTP/1.1\r\nX-Pad: \r\n\r\n");
+        let pad = size.checked_sub(bare.len()).expect("the request outgrew its size");
+        let request = format!("GET {path} HTTP/1.1\r\nX-Pad: {}\r\n\r\n", "p".repeat(pad));
+        assert_eq!(request.len(), size);
+        request.into_bytes()
+    }
+
+    /// A connection holding `len` buffered bytes, answered up to `consumed`.
+    fn buffered_conn(len: usize, consumed: usize, req_end: Option<usize>) -> Conn {
+        let mut conn = Conn::new(Token(1), Role::Accepted);
+        conn.buffer = vec![b'x'; len];
+        conn.state.consumed = consumed;
+        conn.state.req_end = req_end;
+        conn
+    }
+
+    #[test]
+    fn an_answered_prefix_is_dropped_once_it_is_half_the_buffer() {
+        // Under half, the cursor moves onto the answered bytes and they stay.
+        let mut conn = buffered_conn(100, 40, Some(90));
+        conn.reclaim();
+        assert_eq!((conn.start, conn.state.consumed, conn.state.req_end), (40, 40, Some(90)));
+        assert_eq!(conn.buffer.len(), 100);
+        assert_eq!(conn.unconsumed(), 60);
+
+        // Half or more, the prefix goes and every cursor comes down with it.
+        let mut conn = buffered_conn(100, 60, Some(90));
+        conn.reclaim();
+        assert_eq!((conn.start, conn.state.consumed, conn.state.req_end), (0, 0, Some(30)));
+        assert_eq!(conn.buffer.len(), 40);
+        assert_eq!(conn.unconsumed(), 40);
+    }
+
+    #[test]
+    fn a_compaction_rebases_every_cursor() {
+        let mut conn = buffered_conn(200, 128, Some(160));
+        conn.buffer[128..].fill(b'y');
+        conn.start = 128;
+        conn.compact();
+        assert_eq!(conn.start, 0);
+        assert_eq!(conn.state.consumed, 0);
+        assert_eq!(conn.state.req_end, Some(32), "the pending request moved with the buffer");
+        assert_eq!(conn.buffer, vec![b'y'; 72], "the answered prefix is what went");
+    }
+
+    #[test]
+    fn a_ready_connection_is_queued_once() {
+        let mut net = StreamNetwork::default();
+        let mut http = bare_service(&mut net);
+        http.conns.push(Conn::new(Token(1), Role::Accepted));
+
+        http.mark_ready(0);
+        http.mark_ready(0);
+        assert_eq!(http.ready, [Token(1)], "one entry however many reads arrive");
+        assert!(http.conns[0].ready);
+
+        // Taking it off the queue frees it to be queued by the next read.
+        assert_eq!(http.pop_ready(), Some(0));
+        assert!(!http.conns[0].ready);
+        http.mark_ready(0);
+        assert_eq!(http.ready, [Token(1)]);
+    }
+
+    #[test]
+    fn a_connection_owing_a_response_is_never_queued() {
+        let mut net = StreamNetwork::default();
+        let mut http = bare_service(&mut net);
+        let mut conn = Conn::new(Token(1), Role::Accepted);
+        conn.state.phase = Phase::Pending;
+        http.conns.push(conn);
+
+        http.mark_ready(0);
+        assert!(http.ready.is_empty());
+        assert!(!http.conns[0].ready);
+
+        // The answer frees it to parse the request pipelined behind it.
+        http.conns[0].state.phase = Phase::Idle;
+        http.mark_ready(0);
+        assert_eq!(http.ready, [Token(1)]);
+    }
+
+    /// A service listening on loopback with one client connected to it, for
+    /// the tests that need a connection to answer on.
+    struct Harness {
+        net: StreamNetwork,
+        http: HttpService,
+        /// The client end, held open for as long as the harness lives.
+        _client: TcpStream,
+    }
+
+    impl Harness {
+        /// A service holding two pipelined requests, the second of them the
+        /// larger: an answered first request is then under half the buffer,
+        /// where reclaiming it moves the cursor without moving the bytes.
+        fn with_two_requests() -> (Self, usize) {
+            let mut net = StreamNetwork::default();
+            let mut http = bare_service(&mut net);
+            let addr = unused_addr();
+            http.listen(&mut net, Endpoint::Tcp(addr)).unwrap();
+            let mut client = TcpStream::connect(addr).unwrap();
+            let first = padded_request("/one", 64);
+            client.write_all(&[first.clone(), padded_request("/two", 192)].concat()).unwrap();
+            (Self { net, http, _client: client }, first.len())
+        }
+
+        fn drive(&mut self) -> bool {
+            self.net.drive(Some(Duration::ZERO), &mut [self.http.as_service()], |_| {})
+        }
+
+        /// Drives until a request is delivered and reports its token,
+        /// answering it through the responder it came with when `inline`.
+        fn pull_request(&mut self, inline: bool) -> Token {
+            let deadline = std::time::Instant::now() + PATIENCE;
+            while std::time::Instant::now() < deadline {
+                self.drive();
+                while let Some(event) = self.http.next_event(&mut self.net) {
+                    if let HttpEvent::Request { token, responder, .. } = event {
+                        if inline {
+                            assert!(responder.respond(200, &[], b""));
+                        }
+                        return token
+                    }
+                }
+            }
+            panic!("no request arrived")
+        }
+
+        /// Pulls one event with no driver call before it, which is what the
+        /// reclaim-timing tests are about.
+        fn pull_without_driving(&mut self) -> bool {
+            self.http.next_event(&mut self.net).is_some()
+        }
+
+        fn respond(&mut self, token: Token) -> bool {
+            self.http.respond(&mut self.net, token, 200, &[], b"")
+        }
+
+        /// Where a connection has parsed and answered up to: `start`,
+        /// `consumed` and `req_end`.
+        fn cursors(&self, token: Token) -> (usize, usize, Option<usize>) {
+            let index = self.http.index_of(token).expect("the connection went");
+            let conn = &self.http.conns[index];
+            (conn.start, conn.state.consumed, conn.state.req_end)
+        }
+
+        /// Connections queued as ready to parse.
+        fn queued(&self) -> usize {
+            self.http.ready.len() - self.http.ready_cursor
+        }
+    }
+
+    #[test]
+    fn an_inline_answer_reclaims_at_the_next_pull() {
+        let (mut harness, first) = Harness::with_two_requests();
+        let token = harness.pull_request(true);
+
+        // The event borrowed the connection, so the answer moved `consumed`
+        // and nothing else: `start` sits where the parse left it, and the
+        // connection stays out of the ready queue.
+        assert_eq!(harness.cursors(token), (0, first, None));
+        assert_eq!(harness.queued(), 0);
+
+        assert!(harness.pull_without_driving(), "the pipelined request is delivered");
+        let (start, consumed, _) = harness.cursors(token);
+        assert_eq!(start, consumed, "the pull reclaimed what the answer consumed");
+        assert_eq!(start, first, "the pipelined request holds off the compaction");
+    }
+
+    #[test]
+    fn an_inline_answer_reclaims_at_the_next_drive() {
+        let (mut harness, first) = Harness::with_two_requests();
+        let token = harness.pull_request(true);
+        assert_eq!(harness.cursors(token), (0, first, None));
+
+        harness.drive();
+        let (start, consumed, _) = harness.cursors(token);
+        assert_eq!(start, consumed, "the tick reclaimed what the answer consumed");
+        assert_eq!(start, first, "the pipelined request holds off the compaction");
+        assert_eq!(harness.queued(), 1, "and queued the request behind it");
+    }
+
+    #[test]
+    fn a_by_token_answer_reclaims_before_it_returns() {
+        let (mut harness, first) = Harness::with_two_requests();
+        let token = harness.pull_request(false);
+        assert_eq!(harness.cursors(token), (0, 0, Some(first)));
+        assert_eq!(harness.queued(), 0);
+
+        // Nothing borrows the connection, so the answer reclaims and queues
+        // with no driver call in between.
+        assert!(harness.respond(token));
+        assert_eq!(harness.cursors(token), (first, first, None));
+        assert_eq!(harness.queued(), 1, "the pipelined request is queued at once");
+
+        // A request is answered once, and the refusal consumes nothing.
+        assert!(!harness.respond(token));
+        assert_eq!(harness.cursors(token), (first, first, None));
+    }
+
+    /// Serves two pipelined requests, answering the first inline or by token,
+    /// and reports the cursors left once the second has been pulled.
+    fn cursors_after_two_requests(inline: bool) -> (usize, usize, Option<usize>) {
+        let (mut harness, _) = Harness::with_two_requests();
+        let first = harness.pull_request(inline);
+        if !inline {
+            assert!(harness.respond(first));
+        }
+        let second = harness.pull_request(false);
+        assert_eq!(second, first, "both requests came in on one connection");
+        harness.cursors(second)
+    }
+
+    #[test]
+    fn both_answer_paths_leave_the_same_cursors() {
+        assert_eq!(cursors_after_two_requests(true), cursors_after_two_requests(false));
     }
 }

--- a/crates/flux-network/src/http.rs
+++ b/crates/flux-network/src/http.rs
@@ -1,28 +1,69 @@
 //! Poll-driven HTTP over [`crate::stream::StreamNetwork`].
 //!
-//! [`HttpNetwork`] can listen for requests and maintain outbound endpoints in
-//! one event loop. Events borrow parsed data only for the callback duration.
+//! [`HttpService`] is a service: it owns one raw-framed [`ConnectionGroup`]
+//! inside a network the caller drives, serving requests on that group's
+//! listeners and issuing requests on its outbound endpoints. One call per
+//! iteration drives the network, and the service's protocol events are then
+//! pulled from it.
 //!
 //! ```no_run
 //! use std::net::SocketAddr;
-//! use flux_network::http::{HttpEvent, HttpNetwork};
-//! use flux_network::stream::Endpoint;
-//! let mut http = HttpNetwork::default();
-//! http.listen(Endpoint::Tcp("127.0.0.1:8080".parse::<SocketAddr>().unwrap()))?;
-//! let peer = http.connect(Endpoint::Unix("/run/flux/upstream.sock".into()));
+//!
+//! use flux_network::http::{HttpConfig, HttpEvent, HttpService};
+//! use flux_network::stream::{Endpoint, Framing, ConnectionGroupConfig, StreamNetwork};
+//! use flux_timing::Duration;
+//!
+//! let mut net = StreamNetwork::default();
+//! let group = net.add_group(ConnectionGroupConfig {
+//!     name: "api",
+//!     framing: Framing::Raw,
+//!     ..ConnectionGroupConfig::default()
+//! });
+//! let mut http = HttpService::new(&mut net, group, HttpConfig::default());
+//! http.listen(&mut net, Endpoint::Tcp("127.0.0.1:8080".parse::<SocketAddr>().unwrap()))?;
+//! let upstream = http.connect(&mut net, Endpoint::Unix("/run/flux/upstream.sock".into()));
+//!
+//! let mut slow = Vec::new();
+//! let mut ask_upstream = false;
 //! loop {
-//!     let mut response = None;
-//!     let mut request = false;
-//!     http.poll_with(|event| match event {
-//!         HttpEvent::Request { token, .. } => response = Some(token),
-//!         HttpEvent::Connected { token } if token == peer => request = true,
-//!         _ => {}
-//!     });
-//!     if let Some(token) = response { http.respond(token, 200, &[], b"hello"); }
-//!     if request { http.request(peer, "GET", "/", &[], &[]); }
+//!     net.drive(Some(Duration::from_millis(10)), &mut [http.as_service()], |_| {});
+//!     while let Some(event) = http.next_event(&mut net) {
+//!         match event {
+//!             HttpEvent::Request { token, request, responder } => {
+//!                 if request.path == "/health" {
+//!                     responder.respond(200, &[], b"ok");
+//!                 } else {
+//!                     // Dropping the responder answers later, by token.
+//!                     slow.push(token);
+//!                 }
+//!             }
+//!             HttpEvent::Connected { token } if token == upstream => ask_upstream = true,
+//!             HttpEvent::Response { response, .. } => println!("{}", response.status),
+//!             _ => {}
+//!         }
+//!     }
+//!     for token in slow.drain(..) {
+//!         http.respond(&mut net, token, 200, &[], b"done");
+//!     }
+//!     if std::mem::take(&mut ask_upstream) {
+//!         http.request(&mut net, upstream, "GET", "/", &[], &[]);
+//!     }
 //! }
 //! # Ok::<(), std::io::Error>(())
 //! ```
+//!
+//! # The pull loop
+//! An event borrows the service and the network for as long as it lives, so
+//! nothing in the loop body may touch either: everything a handler needs
+//! arrives through the event, and the [`Responder`] on a request is the only
+//! way to answer from there. Events cannot be stored or cloned. A caller may
+//! stop pulling after any number of events and resume in a later iteration
+//! with nothing lost.
+//!
+//! Dropping a [`Responder`] without responding defers the response to
+//! [`HttpService::respond`], which answers the same request by token; the
+//! connection serves no further request until it is answered, and a request
+//! never answered is closed by the idle sweep.
 //!
 //! # Limitations
 //! HTTP/1.1 and HTTP/1.0 responses are supported. Request bodies require
@@ -36,306 +77,421 @@
 //! lingering-close delay. Pipelined requests are served strictly one at a time
 //! per connection.
 
-use std::io::{self, Write as _};
+use std::{
+    io::{self, Write as _},
+    ops::Range,
+};
 
 use flux_timing::{Duration, Instant};
 use mio::Token;
 
 use crate::stream::{
-    ConnectionGroup, ConnectionGroupConfig, Endpoint, Framing, Peer, StreamEvent, StreamNetwork,
+    ConnectionGroup, Endpoint, Framing, Peer, ServiceRef, StreamEvent, StreamNetwork, private,
 };
 
-pub enum HttpEvent<'a> {
-    Accepted { token: Token, peer: Peer },
-    Connected { token: Token },
-    Response { token: Token, response: HttpResponse<'a> },
-    Request { token: Token, request: HttpRequest<'a> },
-    Disconnected { token: Token },
+/// HTTP parsing and connection-state policy. Transport and queue policy
+/// belongs to the group the service claims.
+#[derive(Clone, Copy, Debug)]
+pub struct HttpConfig {
+    /// Largest message head accepted before rejecting it with `431`.
+    pub max_head_bytes: usize,
+    /// Largest message body accepted before rejecting it with `413`.
+    pub max_body_bytes: usize,
+    /// Largest number of headers parsed in one message.
+    pub max_headers: usize,
+    /// How long an accepted connection may sit without inbound bytes before
+    /// it is closed. Outbound endpoints stay connected.
+    pub idle_timeout: Option<Duration>,
 }
-#[derive(Clone, Copy)]
-enum State {
-    Idle,
-    Pending,
-    Draining,
-}
-enum Role {
-    Accepted { state: State, close: bool, continued: bool, head_request: bool },
-    Outbound { endpoint: Endpoint, method: Option<String> },
-}
-struct Conn {
-    token: Token,
-    buf: Vec<u8>,
-    dirty: bool,
-    over_limit: bool,
-    last_activity: Instant,
-    role: Role,
-}
-#[derive(Clone, Copy)]
-enum Lifecycle {
-    Connected(Token, Option<Peer>),
-    Disconnected(Token),
-}
-pub struct HttpNetwork {
-    network: StreamNetwork,
-    group: Option<ConnectionGroup>,
-    name: &'static str,
-    max_head_bytes: usize,
-    max_body_bytes: usize,
-    max_headers: usize,
-    idle_timeout: Option<Duration>,
-    socket_buf_size: Option<usize>,
-    conns: Vec<Conn>,
-    lifecycle: Vec<Lifecycle>,
-}
-impl Default for HttpNetwork {
+
+impl Default for HttpConfig {
     fn default() -> Self {
         Self {
-            network: StreamNetwork::default(),
-            group: None,
-            name: "http",
             max_head_bytes: 16 * 1024,
             max_body_bytes: 1024 * 1024,
             max_headers: 64,
             idle_timeout: Some(Duration::from_secs(30)),
-            socket_buf_size: None,
-            conns: Vec::new(),
-            lifecycle: Vec::new(),
         }
     }
 }
-impl HttpNetwork {
-    /// Sets the group name.
-    pub fn with_name(mut self, name: &'static str) -> Self {
-        assert!(self.group.is_none(), "configure before listen or connect");
-        self.name = name;
-        self
-    }
+
+impl HttpConfig {
     /// Sets the maximum message head size before rejecting it.
     pub fn with_max_head_bytes(mut self, max_head_bytes: usize) -> Self {
-        assert!(self.group.is_none(), "configure before listen or connect");
         self.max_head_bytes = max_head_bytes;
         self
     }
+
     /// Sets the maximum message body size before rejecting it.
     pub fn with_max_body_bytes(mut self, max_body_bytes: usize) -> Self {
-        assert!(self.group.is_none(), "configure before listen or connect");
         self.max_body_bytes = max_body_bytes;
         self
     }
-    /// Sets the maximum number of request headers accepted.
+
+    /// Sets the maximum number of headers parsed in one message.
     pub fn with_max_headers(mut self, max_headers: usize) -> Self {
-        assert!(self.group.is_none(), "configure before listen or connect");
         self.max_headers = max_headers;
         self
     }
-    /// Sets the socket buffer size.
-    pub fn with_socket_buf_size(mut self, socket_buf_size: usize) -> Self {
-        assert!(self.group.is_none(), "configure before listen or connect");
-        self.socket_buf_size = Some(socket_buf_size);
-        self
-    }
-    /// Sets the idle timeout for accepted connections; outbound endpoints
-    /// remain persistent.
+
+    /// Sets the idle timeout for accepted connections.
     pub fn with_idle_timeout(mut self, idle_timeout: Duration) -> Self {
-        assert!(self.group.is_none(), "configure before listen or connect");
         self.idle_timeout = Some(idle_timeout);
         self
     }
+
     /// Disables the idle connection sweep.
     pub fn without_idle_timeout(mut self) -> Self {
-        assert!(self.group.is_none(), "configure before listen or connect");
         self.idle_timeout = None;
         self
     }
-    fn group(&mut self) -> ConnectionGroup {
-        let Self { network, group, name, max_head_bytes, max_body_bytes, socket_buf_size, .. } =
-            self;
-        *group.get_or_insert_with(|| {
-            network.add_group(ConnectionGroupConfig {
-                name,
-                framing: Framing::Raw,
-                socket_buf_size: *socket_buf_size,
-                max_frame_size: usize::MAX,
-                max_backlog_bytes: Some(max_head_bytes.saturating_add(*max_body_bytes)),
-                backlog_warn_bytes: None,
-                ..Default::default()
-            })
-        })
+
+    /// The most a connection may hold unanswered: one head plus one body.
+    fn buffer_limit(&self) -> usize {
+        self.max_head_bytes.saturating_add(self.max_body_bytes)
     }
+}
+
+/// Event pulled from an [`HttpService`].
+pub enum HttpEvent<'a> {
+    /// A listener accepted a client.
+    Accepted { token: Token, peer: Peer },
+    /// An outbound endpoint established its connection.
+    Connected { token: Token },
+    /// A client sent a request, with the means to answer it.
+    Request { token: Token, request: HttpRequest<'a>, responder: Responder<'a> },
+    /// An outbound endpoint answered a request.
+    Response { token: Token, response: HttpResponse<'a> },
+    /// A connection closed.
+    Disconnected { token: Token },
+}
+
+/// A parsed request, borrowed from the connection that sent it.
+pub struct HttpRequest<'a> {
+    /// The request method.
+    pub method: &'a str,
+    /// The request target.
+    pub path: &'a str,
+    /// The HTTP minor version: `1` for HTTP/1.1.
+    pub version: u8,
+    /// The request body, empty when the request carried none.
+    pub body: &'a [u8],
+    buffer: &'a [u8],
+    headers: &'a [HeaderRange],
+}
+
+impl<'a> HttpRequest<'a> {
+    /// The value of the first header with this name, matched case
+    /// insensitively.
+    pub fn header(&self, name: &str) -> Option<&'a [u8]> {
+        header(self.buffer, self.headers, name)
+    }
+
+    /// Every header, in the order the sender wrote them.
+    pub fn headers(&self) -> impl Iterator<Item = (&'a str, &'a [u8])> + use<'a> {
+        headers(self.buffer, self.headers)
+    }
+}
+
+/// A parsed response, borrowed from the connection that sent it.
+pub struct HttpResponse<'a> {
+    /// The HTTP minor version: `1` for HTTP/1.1.
+    pub version: u8,
+    /// The status code.
+    pub status: u16,
+    /// The reason phrase, which may be empty.
+    pub reason: &'a str,
+    /// The response body, decoded when it arrived chunked.
+    pub body: &'a [u8],
+    buffer: &'a [u8],
+    headers: &'a [HeaderRange],
+}
+
+impl<'a> HttpResponse<'a> {
+    /// The value of the first header with this name, matched case
+    /// insensitively.
+    pub fn header(&self, name: &str) -> Option<&'a [u8]> {
+        header(self.buffer, self.headers, name)
+    }
+
+    /// Every header, in the order the sender wrote them.
+    pub fn headers(&self) -> impl Iterator<Item = (&'a str, &'a [u8])> + use<'a> {
+        headers(self.buffer, self.headers)
+    }
+}
+
+/// The means to answer one request, scoped to its connection.
+///
+/// Responding consumes the responder, so a request is answered exactly once.
+#[must_use = "respond now, or drop it to answer later with HttpService::respond; a request never \
+              answered is closed by the idle sweep"]
+pub struct Responder<'a> {
+    net: &'a mut StreamNetwork,
+    state: &'a mut ConnState,
+    token: Token,
+}
+
+impl Responder<'_> {
+    /// Queues the response and returns whether it was written.
+    ///
+    /// The status must be in `200..=599`; `Content-Length` and
+    /// `Transfer-Encoding` are the service's to write, and a `Connection`
+    /// header only feeds the close decision.
+    pub fn respond(self, status: u16, headers: &[(&str, &str)], body: &[u8]) -> bool {
+        respond_to(self.net, self.state, self.token, status, headers, body)
+    }
+}
+
+/// What answering one request touches, and all a [`Responder`] may reach.
+///
+/// `req_end` marks a parsed request awaiting its response; `consumed` is the
+/// accounting cursor, and bytes below it are answered and cost the connection
+/// nothing against its limits, whether or not they have been reclaimed yet.
+struct ConnState {
+    phase: Phase,
+    close: bool,
+    head_request: bool,
+    req_end: Option<usize>,
+    consumed: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Phase {
+    /// Awaiting the next request.
+    Idle,
+    /// A request was delivered and its response is outstanding.
+    Pending,
+    /// Answered with a close; the connection goes once its bytes are written.
+    Draining,
+}
+
+enum Role {
+    Accepted,
+    Outbound { endpoint: Endpoint, method: Option<String> },
+}
+
+struct Conn {
+    token: Token,
+    buffer: Vec<u8>,
+    /// The reclamation cursor and the parse origin, never past `consumed`.
+    start: usize,
+    /// Whether the connection is queued as ready to parse.
+    ready: bool,
+    /// Whether a read was cut short by the connection's limits.
+    over_limit: bool,
+    /// Whether the client was told to send the body it announced.
+    continued: bool,
+    last_activity: Instant,
+    state: ConnState,
+    role: Role,
+}
+
+impl Conn {
+    fn new(token: Token, role: Role) -> Self {
+        Self {
+            token,
+            buffer: Vec::new(),
+            start: 0,
+            ready: false,
+            over_limit: false,
+            continued: false,
+            last_activity: Instant::now(),
+            state: ConnState {
+                phase: Phase::Idle,
+                close: false,
+                head_request: false,
+                req_end: None,
+                consumed: 0,
+            },
+            role,
+        }
+    }
+
+    /// Moves the reclamation cursor onto the answered bytes, dropping the
+    /// reclaimed prefix once it is worth the move.
+    fn reclaim(&mut self) {
+        self.start = self.state.consumed;
+        if self.start >= self.buffer.len() / 2 {
+            self.compact();
+        }
+    }
+
+    /// Drops the reclaimed prefix, rebasing every cursor onto what is left.
+    fn compact(&mut self) {
+        let start = self.start;
+        if start == 0 {
+            return
+        }
+        self.buffer.drain(..start);
+        self.start = 0;
+        self.state.consumed -= start;
+        self.state.req_end = self.state.req_end.map(|end| end - start);
+    }
+
+    /// Forgets everything buffered, which a closed connection no longer owes
+    /// anyone.
+    fn clear(&mut self) {
+        self.buffer.clear();
+        self.start = 0;
+        self.over_limit = false;
+        self.continued = false;
+        self.state.consumed = 0;
+        self.state.req_end = None;
+        self.state.phase = Phase::Idle;
+        self.state.close = false;
+    }
+
+    /// Bytes counted against the connection's limits.
+    fn unconsumed(&self) -> usize {
+        self.buffer.len() - self.state.consumed
+    }
+}
+
+/// A lifecycle event waiting to be pulled.
+#[derive(Clone, Copy)]
+enum Record {
+    Accepted(Token, Peer),
+    Connected(Token),
+    Disconnected(Token),
+}
+
+/// What the next pull delivers, resolved before any borrow escapes.
+enum Step {
+    Accepted {
+        token: Token,
+        peer: Peer,
+    },
+    Connected {
+        token: Token,
+    },
+    Request {
+        index: usize,
+        method: Range<usize>,
+        path: Range<usize>,
+        version: u8,
+        body: Range<usize>,
+    },
+    Response {
+        index: usize,
+        version: u8,
+        status: u16,
+        reason: Range<usize>,
+        body: Body,
+    },
+    Disconnected {
+        token: Token,
+    },
+}
+
+/// Where a response body was found.
+enum Body {
+    Buffer(Range<usize>),
+    Decoded,
+}
+
+/// The name and value of one header, as byte ranges of a connection buffer.
+type HeaderRange = (Range<usize>, Range<usize>);
+
+/// An HTTP server, client, or both, owning one raw-framed group of a
+/// [`StreamNetwork`].
+///
+/// The network schedules the service — hand it to
+/// [`StreamNetwork::drive`] with [`Self::as_service`] — and the caller pulls
+/// protocol events with [`Self::next_event`].
+pub struct HttpService {
+    group: ConnectionGroup,
+    config: HttpConfig,
+    conns: Vec<Conn>,
+    /// Lifecycle events, oldest first from `record_cursor`.
+    records: Vec<Record>,
+    record_cursor: usize,
+    /// Connections with bytes to parse, oldest first from `ready_cursor`.
+    ready: Vec<Token>,
+    ready_cursor: usize,
+    /// Header ranges of the message the last pull parsed.
+    headers: Vec<HeaderRange>,
+    /// The body of the last chunked response, decoded.
+    decoded: Vec<u8>,
+    /// The connection the last pulled event left bookkeeping for.
+    last: Option<Token>,
+}
+
+impl HttpService {
+    /// Claims `group` for HTTP.
+    ///
+    /// # Panics
+    /// The group must be [`Framing::Raw`] and unclaimed.
+    pub fn new(net: &mut StreamNetwork, group: ConnectionGroup, config: HttpConfig) -> Self {
+        assert!(
+            net.framing(group) == Framing::Raw,
+            "HTTP frames its own messages and needs a raw-framed group"
+        );
+        net.claim_group(group);
+        Self {
+            group,
+            config,
+            conns: Vec::new(),
+            records: Vec::new(),
+            record_cursor: 0,
+            ready: Vec::new(),
+            ready_cursor: 0,
+            headers: Vec::new(),
+            decoded: Vec::new(),
+            last: None,
+        }
+    }
+
+    /// The group this service owns.
+    pub fn group(&self) -> ConnectionGroup {
+        self.group
+    }
+
+    /// Hands the service to [`StreamNetwork::drive`].
+    pub fn as_service(&mut self) -> ServiceRef<'_> {
+        ServiceRef::new(self)
+    }
+
     /// Adds a listener.
     ///
     /// An [`Endpoint::Unix`] socket file is created with mode `0777` less the
-    /// umask bits and is unlinked when this instance is dropped; see
+    /// umask bits and is unlinked when the service is closed; see
     /// [`StreamNetwork::listen`].
-    pub fn listen(&mut self, endpoint: Endpoint) -> io::Result<()> {
-        let group = self.group();
-        self.network.listen(group, endpoint)
+    pub fn listen(&mut self, net: &mut StreamNetwork, endpoint: Endpoint) -> io::Result<()> {
+        net.listen(self.group, endpoint)
     }
-    /// Immediately disconnects an accepted client.
-    pub fn disconnect(&mut self, token: Token) -> bool {
-        self.group.is_some() &&
-            self.conns
-                .iter()
-                .any(|conn| conn.token == token && matches!(conn.role, Role::Accepted { .. })) &&
-            self.network.disconnect(token)
-    }
-    /// Polls the network and delivers connection, request, and response events.
-    ///
-    /// A request event remains pending until [`Self::respond`] is called. The
-    /// handler may defer that call until a later poll; requests behind it stay
-    /// buffered until the response is sent.
-    pub fn poll_with<F>(&mut self, mut handler: F)
-    where
-        F: for<'a> FnMut(HttpEvent<'a>),
-    {
-        let Some(group) = self.group else { return };
-        let limit = self.buffer_limit();
-        let conns = &mut self.conns;
-        let lifecycle = &mut self.lifecycle;
-        self.network.poll_with(|event| match event {
-            StreamEvent::Accepted { group: event_group, token, peer } if event_group == group => {
-                conns.push(Conn {
-                    token,
-                    buf: Vec::new(),
-                    dirty: false,
-                    over_limit: false,
-                    last_activity: Instant::now(),
-                    role: Role::Accepted {
-                        state: State::Idle,
-                        close: false,
-                        continued: false,
-                        head_request: false,
-                    },
-                });
-                lifecycle.push(Lifecycle::Connected(token, Some(peer)));
-            }
-            StreamEvent::Connected { group: event_group, token, .. } if event_group == group => {
-                lifecycle.push(Lifecycle::Connected(token, None));
-            }
-            StreamEvent::Message { group: event_group, token, payload, .. }
-                if event_group == group =>
-            {
-                if let Some(conn) = conns.iter_mut().find(|conn| conn.token == token) &&
-                    !is_draining(&conn.role) &&
-                    !conn.over_limit
-                {
-                    let available = limit.saturating_sub(conn.buf.len());
-                    if payload.len() > available {
-                        conn.buf.extend_from_slice(&payload[..available]);
-                        conn.over_limit = true;
-                    } else {
-                        conn.buf.extend_from_slice(payload);
-                    }
-                    conn.dirty = true;
-                    conn.last_activity = Instant::now();
-                }
-            }
-            StreamEvent::Disconnected { group: event_group, token, .. } if event_group == group => {
-                lifecycle.push(Lifecycle::Disconnected(token));
-            }
-            _ => {}
-        });
-        for event in std::mem::take(&mut self.lifecycle) {
-            self.emit_lifecycle(event, &mut handler);
-        }
-        self.parse_dirty(&mut handler);
-        for conn in &mut self.conns {
-            if conn.over_limit && !is_draining(&conn.role) {
-                self.network.disconnect(conn.token);
-                conn.over_limit = false;
-            }
-        }
-        if let Some(timeout) = self.idle_timeout {
-            let expired: Vec<_> = self
-                .conns
-                .iter()
-                .filter(|conn| {
-                    matches!(conn.role, Role::Accepted { .. }) &&
-                        conn.last_activity.elapsed() >= timeout
-                })
-                .map(|conn| conn.token)
-                .collect();
-            for token in expired {
-                self.network.disconnect(token);
-            }
-        }
-    }
-    fn emit_lifecycle<F>(&mut self, event: Lifecycle, handler: &mut F)
-    where
-        F: for<'a> FnMut(HttpEvent<'a>),
-    {
-        match event {
-            Lifecycle::Connected(token, Some(peer)) => {
-                handler(HttpEvent::Accepted { token, peer });
-            }
-            Lifecycle::Connected(token, None) => handler(HttpEvent::Connected { token }),
-            Lifecycle::Disconnected(token) => {
-                if let Some(i) = self.conns.iter().position(|conn| conn.token == token) {
-                    if self.conns[i].dirty {
-                        self.parse_connection(i, handler);
-                    }
-                    if matches!(self.conns[i].role, Role::Outbound { .. }) {
-                        self.parse_eof_outbound(i, handler);
-                        self.conns[i].buf.clear();
-                        self.conns[i].dirty = false;
-                        set_outbound_method(&mut self.conns[i].role, None);
-                    } else {
-                        self.conns.remove(i);
-                    }
-                }
-                handler(HttpEvent::Disconnected { token });
-            }
-        }
-    }
-    fn parse_dirty<F>(&mut self, handler: &mut F)
-    where
-        F: for<'a> FnMut(HttpEvent<'a>),
-    {
-        for i in 0..self.conns.len() {
-            if self.conns[i].dirty {
-                self.parse_connection(i, handler);
-            }
-        }
-    }
-    fn parse_connection<F>(&mut self, i: usize, handler: &mut F)
-    where
-        F: for<'a> FnMut(HttpEvent<'a>),
-    {
-        if matches!(self.conns[i].role, Role::Accepted { .. }) {
-            self.parse_and_emit(i, handler);
-        } else {
-            self.parse_outbound(i, handler);
-        }
-    }
-    /// Adds a persistent outbound endpoint and immediately starts
-    /// connecting. The returned token remains stable across reconnects.
-    pub fn connect(&mut self, endpoint: Endpoint) -> Token {
-        let group = self.group();
-        let token = self.network.connect(group, endpoint.clone());
-        self.conns.push(Conn {
-            token,
-            buf: Vec::new(),
-            dirty: false,
-            over_limit: false,
-            last_activity: Instant::now(),
-            role: Role::Outbound { endpoint, method: None },
-        });
+
+    /// Adds a persistent outbound endpoint and immediately starts connecting.
+    /// The returned token remains stable across reconnects.
+    #[must_use = "the token identifies the outbound endpoint"]
+    pub fn connect(&mut self, net: &mut StreamNetwork, endpoint: Endpoint) -> Token {
+        let token = net.connect(self.group, endpoint.clone());
+        self.conns.push(Conn::new(token, Role::Outbound { endpoint, method: None }));
         token
     }
+
+    /// Immediately disconnects an accepted client.
+    pub fn disconnect(&mut self, net: &mut StreamNetwork, token: Token) -> bool {
+        self.index_of(token).is_some_and(|index| matches!(self.conns[index].role, Role::Accepted)) &&
+            net.disconnect(token)
+    }
+
     /// Permanently removes an outbound endpoint and stops it reconnecting.
-    pub fn remove(&mut self, token: Token) -> bool {
-        if self.group.is_none() ||
-            !self
-                .conns
-                .iter()
-                .any(|conn| conn.token == token && matches!(conn.role, Role::Outbound { .. })) ||
-            !self.network.remove(token)
-        {
+    pub fn remove(&mut self, net: &mut StreamNetwork, token: Token) -> bool {
+        let Some(index) = self.index_of(token) else { return false };
+        if !matches!(self.conns[index].role, Role::Outbound { .. }) || !net.remove(token) {
             return false
         }
-        self.conns.retain(|conn| conn.token != token);
+        self.conns.swap_remove(index);
         true
     }
+
+    /// Closes the service: every connection and listener of its group goes,
+    /// un-pulled events are discarded, and the group returns to unclaimed
+    /// status, empty and reusable.
+    pub fn close(self, net: &mut StreamNetwork) {
+        net.close_group(self.group);
+    }
+
     /// Queues one request on an outbound endpoint.
     ///
     /// When the caller supplies no `Host` header, a TCP endpoint sends its
@@ -343,6 +499,7 @@ impl HttpNetwork {
     /// sends `localhost`.
     pub fn request(
         &mut self,
+        net: &mut StreamNetwork,
         token: Token,
         method: &str,
         path: &str,
@@ -352,33 +509,30 @@ impl HttpNetwork {
         if !valid_token(method) ||
             path.is_empty() ||
             path.contains(['\r', '\n', ' ']) ||
-            headers.iter().any(|(n, v)| {
-                !valid_token(n) ||
-                    v.contains(['\r', '\n']) ||
-                    n.eq_ignore_ascii_case("content-length") ||
-                    n.eq_ignore_ascii_case("transfer-encoding")
-            })
+            headers.iter().any(|(name, value)| invalid_header(name, value))
         {
             return false
         }
-        let Some(c) =
-            self.conns.iter_mut().find(|c| c.token == token && outbound_method(&c.role).is_none())
+        let Some(conn) = self
+            .conns
+            .iter_mut()
+            .find(|conn| conn.token == token && outbound_method(&conn.role).is_none())
         else {
             return false
         };
-        let Role::Outbound { endpoint, .. } = &c.role else { return false };
+        let Role::Outbound { endpoint, .. } = &conn.role else { return false };
         let host = match endpoint {
             Endpoint::Tcp(addr) => addr.to_string(),
             Endpoint::Unix(_) => "localhost".to_owned(),
         };
-        let sent = self.network.send_with(token, |out| {
+        let sent = net.send_with(token, |out| {
             write!(out, "{method} {path} HTTP/1.1\r\n").unwrap();
             let mut has_host = false;
-            for (n, v) in headers {
-                has_host |= n.eq_ignore_ascii_case("host");
-                out.extend_from_slice(n.as_bytes());
+            for (name, value) in headers {
+                has_host |= name.eq_ignore_ascii_case("host");
+                out.extend_from_slice(name.as_bytes());
                 out.extend_from_slice(b": ");
-                out.extend_from_slice(v.as_bytes());
+                out.extend_from_slice(value.as_bytes());
                 out.extend_from_slice(b"\r\n");
             }
             if !has_host {
@@ -388,393 +542,734 @@ impl HttpNetwork {
             out.extend_from_slice(body);
         });
         if sent {
-            set_outbound_method(&mut c.role, Some(method.to_owned()));
+            set_outbound_method(&mut conn.role, Some(method.to_owned()));
         }
         sent
     }
-    fn fail_outbound(&mut self, i: usize) {
-        let token = self.conns[i].token;
-        self.conns[i].buf.clear();
-        set_outbound_method(&mut self.conns[i].role, None);
-        self.network.disconnect(token);
-    }
-    fn buffer_limit(&self) -> usize {
-        self.max_head_bytes.saturating_add(self.max_body_bytes)
-    }
-    fn parse_and_emit<F>(&mut self, i: usize, handler: &mut F)
-    where
-        F: for<'a> FnMut(HttpEvent<'a>),
-    {
-        if !matches!(accepted_state_mut(&mut self.conns[i].role), State::Idle) {
-            return
-        }
-        let over_limit = self.conns[i].over_limit;
-        let buf = &self.conns[i].buf;
-        let mut hs = vec![httparse::EMPTY_HEADER; self.max_headers];
-        let mut req = httparse::Request::new(&mut hs);
-        let Ok(state) = req.parse(buf) else {
-            self.error(i, 400);
-            return
-        };
-        let httparse::Status::Complete(head) = state else {
-            // A partial parse means every buffered byte is still head bytes.
-            if !crlf_only(buf) {
-                self.error(i, 400);
-            } else if over_limit || buf.len() > self.max_head_bytes {
-                self.error(i, 431);
-            }
-            return
-        };
-        if !crlf_only(&buf[..head]) {
-            self.error(i, 400);
-            return
-        }
-        if head > self.max_head_bytes {
-            self.error(i, 431);
-            return
-        }
-        let Some(len) = request_content_length(req.headers) else {
-            self.error(i, 400);
-            return
-        };
-        if req.headers.iter().any(|h| h.name.eq_ignore_ascii_case("transfer-encoding")) {
-            self.error(i, 501);
-            return
-        }
-        if len > self.max_body_bytes {
-            self.error(i, 413);
-            return
-        }
-        let Some(end) = head.checked_add(len) else {
-            self.error(i, 413);
-            return
-        };
-        if buf.len() < end {
-            if over_limit {
-                self.error(i, 413);
-                return
-            }
-            if has_token(req.headers, "expect", b"100-continue") &&
-                !accepted_continued_mut(&self.conns[i].role)
-            {
-                let token = self.conns[i].token;
-                if self
-                    .network
-                    .send_with(token, |out| write!(out, "HTTP/1.1 100 Continue\r\n\r\n").unwrap())
-                {
-                    set_accepted_continued(&mut self.conns[i].role, true);
-                }
-            }
-            return
-        }
-        let close = req.version == Some(0) && !has_token(req.headers, "connection", b"keep-alive") ||
-            has_token(req.headers, "connection", b"close");
-        let token = self.conns[i].token;
-        let head_request = req.method == Some("HEAD");
-        let request = HttpRequest {
-            method: req.method.unwrap_or(""),
-            path: req.path.unwrap_or(""),
-            version: req.version.unwrap_or(1),
-            headers: req.headers,
-            body: &buf[head..end],
-        };
-        handler(HttpEvent::Request { token, request });
-        self.conns[i].buf.drain(..end);
-        self.conns[i].dirty = !self.conns[i].buf.is_empty();
-        set_accepted_state(&mut self.conns[i].role, State::Pending);
-        set_accepted_close(&mut self.conns[i].role, close);
-        set_accepted_continued(&mut self.conns[i].role, false);
-        set_accepted_head_request(&mut self.conns[i].role, head_request);
-    }
-    fn error(&mut self, i: usize, status: u16) {
-        set_accepted_state(&mut self.conns[i].role, State::Pending);
-        set_accepted_close(&mut self.conns[i].role, true);
-        let token = self.conns[i].token;
-        let _ = self.respond(token, status, &[], &[]);
-    }
-    /// Sends the response for a pending request and returns whether it was
-    /// queued.
+
+    /// Answers a request whose [`Responder`] was dropped, and returns whether
+    /// the response was written.
     ///
-    /// Call this from a request handler or later from the poll loop. Each call
-    /// completes exactly one request for `token`.
+    /// Each call completes exactly one request for `token`.
     pub fn respond(
         &mut self,
+        net: &mut StreamNetwork,
         token: Token,
         status: u16,
         headers: &[(&str, &str)],
         body: &[u8],
     ) -> bool {
-        let Some(i) = self
-            .conns
-            .iter()
-            .position(|c| c.token == token && matches!(accepted_state(&c.role), State::Pending))
-        else {
-            return false
-        };
-        if !(200..=599).contains(&status) ||
-            headers.iter().any(|(n, v)| {
-                !valid_token(n) ||
-                    v.contains(['\r', '\n']) ||
-                    n.eq_ignore_ascii_case("content-length") ||
-                    n.eq_ignore_ascii_case("transfer-encoding")
-            })
-        {
+        let Some(index) = self.index_of(token) else { return false };
+        if !matches!(self.conns[index].role, Role::Accepted) {
             return false
         }
-        let caller_close = headers.iter().any(|(n, v)| {
-            n.eq_ignore_ascii_case("connection") && has_value_token(v.as_bytes(), b"close")
-        });
-        let close = accepted_close(&self.conns[i].role) || caller_close;
-        let suppress_body =
-            accepted_head_request(&self.conns[i].role) || matches!(status, 100..=199 | 204 | 304);
-        let include_length = !matches!(status, 100..=199 | 204);
-        let ok = self.network.send_with(token, |out| {
-            write!(out, "HTTP/1.1 {status} {}\r\n", reason_phrase(status)).unwrap();
-            // Caller Connection headers only feed the close decision; exactly
-            // one canonical Connection header is always written below.
-            for (n, v) in headers {
-                if n.eq_ignore_ascii_case("connection") {
-                    continue
-                }
-                out.extend_from_slice(n.as_bytes());
-                out.extend_from_slice(b": ");
-                out.extend_from_slice(v.as_bytes());
-                out.extend_from_slice(b"\r\n");
-            }
-            if include_length {
-                write!(out, "Content-Length: {}\r\n", body.len()).unwrap();
-            }
-            out.extend_from_slice(if close {
-                b"Connection: close\r\n"
-            } else {
-                b"Connection: keep-alive\r\n"
-            });
-            out.extend_from_slice(b"\r\n");
-            if !suppress_body {
-                out.extend_from_slice(body);
-            }
-        });
-        if ok {
-            self.conns[i].dirty = !close && !self.conns[i].buf.is_empty();
-            set_accepted_state(
-                &mut self.conns[i].role,
-                if close { State::Draining } else { State::Idle },
-            );
-            if close {
-                self.network.disconnect_when_drained(token);
-            }
+        if !respond_to(net, &mut self.conns[index].state, token, status, headers, body) {
+            return false
         }
-        ok
+        self.reclaim(index);
+        true
     }
-    fn parse_outbound<F>(&mut self, i: usize, handler: &mut F)
-    where
-        F: for<'a> FnMut(HttpEvent<'a>),
-    {
-        self.conns[i].dirty = false;
-        while outbound_method(&self.conns[i].role).is_some() {
-            let b = &self.conns[i].buf;
-            let mut hs = vec![httparse::EMPTY_HEADER; self.max_headers];
-            let mut response = httparse::Response::new(&mut hs);
-            let parsed = response.parse(b);
-            let Ok(state) = parsed else {
-                self.fail_outbound(i);
-                return
-            };
-            let httparse::Status::Complete(head) = state else {
-                // A partial parse means every buffered byte is still head bytes.
-                if !crlf_only(b) || b.len() > self.max_head_bytes {
-                    self.fail_outbound(i);
-                }
-                return
-            };
-            if !crlf_only(&b[..head]) || head > self.max_head_bytes {
-                self.fail_outbound(i);
-                return
-            }
-            let status = response.code.unwrap_or(0);
-            let no_body = outbound_method(&self.conns[i].role).map(String::as_str) == Some("HEAD") ||
-                matches!(status, 100..=199 | 204 | 304);
-            let chunked = transfer_chunked(response.headers);
-            let content_length = response_content_length(response.headers);
-            if status == 101 ||
-                matches!(content_length, ContentLength::Invalid) ||
-                chunked.is_none() ||
-                (chunked == Some(true) && !matches!(content_length, ContentLength::Absent)) ||
-                (!no_body &&
-                    matches!(content_length, ContentLength::Present(length) if length > self.max_body_bytes))
-            {
-                self.fail_outbound(i);
-                return
-            }
-            let (consumed, decoded) = if no_body {
-                (head, None)
-            } else if chunked == Some(true) {
-                match Self::decode_chunked(&b[head..], self.max_body_bytes, self.max_headers) {
-                    Ok(Some((consumed, decoded))) => {
-                        let Some(consumed) = head.checked_add(consumed) else {
-                            self.fail_outbound(i);
-                            return
-                        };
-                        (consumed, Some(decoded))
-                    }
-                    Ok(None) => return,
-                    Err(()) => {
-                        self.fail_outbound(i);
-                        return
-                    }
-                }
-            } else if let ContentLength::Present(length) = content_length {
-                let Some(consumed) = head.checked_add(length) else {
-                    self.fail_outbound(i);
-                    return
+
+    /// The next protocol event, parsed on demand from what the connection
+    /// buffered.
+    ///
+    /// The event borrows the service and the network until it is dropped, so a
+    /// handler reaches the network only through the event it was handed.
+    pub fn next_event<'a>(&'a mut self, net: &'a mut StreamNetwork) -> Option<HttpEvent<'a>> {
+        self.apply_bookkeeping();
+        match self.plan(net)? {
+            Step::Accepted { token, peer } => Some(HttpEvent::Accepted { token, peer }),
+            Step::Connected { token } => Some(HttpEvent::Connected { token }),
+            Step::Disconnected { token } => Some(HttpEvent::Disconnected { token }),
+            Step::Request { index, method, path, version, body } => {
+                let token = self.conns[index].token;
+                self.last = Some(token);
+                let Self { conns, headers, .. } = self;
+                let headers: &[HeaderRange] = headers;
+                let Conn { buffer, state, .. } = &mut conns[index];
+                let buffer: &[u8] = buffer;
+                let request = HttpRequest {
+                    method: text(buffer, method),
+                    path: text(buffer, path),
+                    version,
+                    body: &buffer[body],
+                    buffer,
+                    headers,
                 };
-                if b.len() < consumed {
-                    return
+                Some(HttpEvent::Request {
+                    token,
+                    request,
+                    responder: Responder { net, state, token },
+                })
+            }
+            Step::Response { index, version, status, reason, body } => {
+                let token = self.conns[index].token;
+                self.last = Some(token);
+                let Self { conns, headers, decoded, .. } = self;
+                let headers: &[HeaderRange] = headers;
+                let buffer: &[u8] = &conns[index].buffer;
+                let body = match body {
+                    Body::Buffer(range) => &buffer[range],
+                    Body::Decoded => decoded.as_slice(),
+                };
+                let response = HttpResponse {
+                    version,
+                    status,
+                    reason: text(buffer, reason),
+                    body,
+                    buffer,
+                    headers,
+                };
+                Some(HttpEvent::Response { token, response })
+            }
+        }
+    }
+
+    /// Where a connection has parsed and answered up to: `start`, `consumed`
+    /// and `req_end`.
+    #[doc(hidden)]
+    pub fn cursors(&self, token: Token) -> Option<(usize, usize, Option<usize>)> {
+        self.index_of(token).map(|index| {
+            let conn = &self.conns[index];
+            (conn.start, conn.state.consumed, conn.state.req_end)
+        })
+    }
+
+    /// Connections queued as ready to parse.
+    #[doc(hidden)]
+    pub fn ready_len(&self) -> usize {
+        self.ready.len() - self.ready_cursor
+    }
+
+    /// Applies what the previous event left behind: the bytes it answered are
+    /// reclaimed, and a connection with more to parse queues up again.
+    fn apply_bookkeeping(&mut self) {
+        let Some(token) = self.last.take() else { return };
+        let Some(index) = self.index_of(token) else { return };
+        self.reclaim(index);
+    }
+
+    /// Reclaims one connection's answered bytes and requeues it when bytes
+    /// remain.
+    fn reclaim(&mut self, index: usize) {
+        self.conns[index].reclaim();
+        if self.conns[index].start < self.conns[index].buffer.len() {
+            self.mark_ready(index);
+        }
+    }
+
+    /// Resolves the next event, sending error responses and closing
+    /// connections along the way; no borrow of a connection escapes.
+    fn plan(&mut self, net: &mut StreamNetwork) -> Option<Step> {
+        loop {
+            // Lifecycle first, so a connection's Accepted precedes its first
+            // request, and its Disconnected follows everything it sent.
+            if let Some(record) = self.records.get(self.record_cursor).copied() {
+                match record {
+                    Record::Accepted(token, peer) => {
+                        self.take_record();
+                        return Some(Step::Accepted { token, peer })
+                    }
+                    Record::Connected(token) => {
+                        self.take_record();
+                        return Some(Step::Connected { token })
+                    }
+                    Record::Disconnected(token) => {
+                        if let Some(index) = self.index_of(token) {
+                            if let Some(step) = self.plan_connection(net, index, true) {
+                                return Some(step)
+                            }
+                            self.close_connection(index);
+                        }
+                        self.take_record();
+                        return Some(Step::Disconnected { token })
+                    }
                 }
-                (consumed, None)
-            } else {
-                return
-            };
-            if status < 200 {
-                self.conns[i].buf.drain(..consumed);
-                self.conns[i].dirty = !self.conns[i].buf.is_empty();
+            }
+            let index = self.pop_ready()?;
+            if let Some(step) = self.plan_connection(net, index, false) {
+                return Some(step)
+            }
+        }
+    }
+
+    fn plan_connection(
+        &mut self,
+        net: &mut StreamNetwork,
+        index: usize,
+        at_eof: bool,
+    ) -> Option<Step> {
+        match self.conns[index].role {
+            // A client that has gone can be told nothing, so its last request
+            // is dropped rather than delivered with an answer that fails.
+            Role::Accepted => (!at_eof).then(|| self.plan_request(net, index)).flatten(),
+            Role::Outbound { .. } => self.plan_response(net, index, at_eof),
+        }
+    }
+
+    /// Parses the next request of an accepted connection, answering it here
+    /// when it is malformed or too large.
+    fn plan_request(&mut self, net: &mut StreamNetwork, index: usize) -> Option<Step> {
+        // The ready queue holds no connection that owes a response, but the
+        // lifecycle path reaches a connection without going through it.
+        if self.conns[index].state.phase != Phase::Idle {
+            return None
+        }
+        self.conns[index].reclaim();
+        match self.parse_request(index) {
+            RequestPlan::Incomplete => None,
+            RequestPlan::Error(status) => {
+                self.error(net, index, status);
+                None
+            }
+            RequestPlan::Continue => {
+                let token = self.conns[index].token;
+                if net.send_with(token, |out| {
+                    write!(out, "HTTP/1.1 100 Continue\r\n\r\n").unwrap();
+                }) {
+                    self.conns[index].continued = true;
+                }
+                None
+            }
+            RequestPlan::Ready { method, path, version, body, end, close, head_request } => {
+                let conn = &mut self.conns[index];
+                conn.continued = false;
+                conn.state.phase = Phase::Pending;
+                conn.state.req_end = Some(end);
+                conn.state.close = close;
+                conn.state.head_request = head_request;
+                Some(Step::Request { index, method, path, version, body })
+            }
+        }
+    }
+
+    fn parse_request(&mut self, index: usize) -> RequestPlan {
+        let Self { conns, headers, config, .. } = self;
+        let conn = &conns[index];
+        let base = conn.start;
+        let buffer = &conn.buffer[base..];
+        if buffer.is_empty() {
+            return RequestPlan::Incomplete
+        }
+        let mut scratch = vec![httparse::EMPTY_HEADER; config.max_headers];
+        let mut request = httparse::Request::new(&mut scratch);
+        let Ok(status) = request.parse(buffer) else { return RequestPlan::Error(400) };
+        let httparse::Status::Complete(head) = status else {
+            // A partial parse means every buffered byte is still head bytes.
+            if !crlf_only(buffer) {
+                return RequestPlan::Error(400)
+            }
+            if conn.over_limit || buffer.len() > config.max_head_bytes {
+                return RequestPlan::Error(431)
+            }
+            return RequestPlan::Incomplete
+        };
+        if !crlf_only(&buffer[..head]) {
+            return RequestPlan::Error(400)
+        }
+        if head > config.max_head_bytes {
+            return RequestPlan::Error(431)
+        }
+        let Some(length) = request_content_length(request.headers) else {
+            return RequestPlan::Error(400)
+        };
+        if request.headers.iter().any(|h| h.name.eq_ignore_ascii_case("transfer-encoding")) {
+            return RequestPlan::Error(501)
+        }
+        if length > config.max_body_bytes {
+            return RequestPlan::Error(413)
+        }
+        let Some(end) = head.checked_add(length) else { return RequestPlan::Error(413) };
+        if buffer.len() < end {
+            if conn.over_limit {
+                return RequestPlan::Error(413)
+            }
+            if has_token(request.headers, "expect", b"100-continue") && !conn.continued {
+                return RequestPlan::Continue
+            }
+            return RequestPlan::Incomplete
+        }
+        headers.clear();
+        for header in request.headers.iter() {
+            headers.push((
+                span(buffer, header.name.as_bytes(), base),
+                span(buffer, header.value, base),
+            ));
+        }
+        RequestPlan::Ready {
+            method: span(buffer, request.method.unwrap_or("").as_bytes(), base),
+            path: span(buffer, request.path.unwrap_or("").as_bytes(), base),
+            version: request.version.unwrap_or(1),
+            body: base + head..base + end,
+            end: base + end,
+            close: request.version == Some(0) &&
+                !has_token(request.headers, "connection", b"keep-alive") ||
+                has_token(request.headers, "connection", b"close"),
+            head_request: request.method == Some("HEAD"),
+        }
+    }
+
+    /// Parses the next response of an outbound connection, skipping
+    /// informational ones.
+    fn plan_response(
+        &mut self,
+        net: &mut StreamNetwork,
+        index: usize,
+        at_eof: bool,
+    ) -> Option<Step> {
+        loop {
+            outbound_method(&self.conns[index].role)?;
+            self.conns[index].reclaim();
+            match self.parse_response(index) {
+                ResponsePlan::Incomplete => {
+                    return at_eof.then(|| self.plan_eof_response(index)).flatten()
+                }
+                ResponsePlan::Fail => {
+                    self.fail_outbound(net, index);
+                    return None
+                }
+                ResponsePlan::Informational { end } => self.conns[index].state.consumed = end,
+                ResponsePlan::Ready { version, status, reason, body, end, close } => {
+                    let token = self.conns[index].token;
+                    let conn = &mut self.conns[index];
+                    conn.state.consumed = end;
+                    set_outbound_method(&mut conn.role, None);
+                    if close {
+                        net.disconnect(token);
+                    }
+                    return Some(Step::Response { index, version, status, reason, body })
+                }
+            }
+        }
+    }
+
+    fn parse_response(&mut self, index: usize) -> ResponsePlan {
+        let Self { conns, headers, decoded, config, .. } = self;
+        let conn = &conns[index];
+        let base = conn.start;
+        let buffer = &conn.buffer[base..];
+        if buffer.is_empty() {
+            return ResponsePlan::Incomplete
+        }
+        let mut scratch = vec![httparse::EMPTY_HEADER; config.max_headers];
+        let mut response = httparse::Response::new(&mut scratch);
+        let Ok(status) = response.parse(buffer) else { return ResponsePlan::Fail };
+        let httparse::Status::Complete(head) = status else {
+            // A partial parse means every buffered byte is still head bytes.
+            if !crlf_only(buffer) || buffer.len() > config.max_head_bytes {
+                return ResponsePlan::Fail
+            }
+            return ResponsePlan::Incomplete
+        };
+        if !crlf_only(&buffer[..head]) || head > config.max_head_bytes {
+            return ResponsePlan::Fail
+        }
+        let code = response.code.unwrap_or(0);
+        let no_body = outbound_method(&conn.role).map(String::as_str) == Some("HEAD") ||
+            matches!(code, 100..=199 | 204 | 304);
+        let chunked = transfer_chunked(response.headers);
+        let content_length = response_content_length(response.headers);
+        if code == 101 ||
+            matches!(content_length, ContentLength::Invalid) ||
+            chunked.is_none() ||
+            (chunked == Some(true) && !matches!(content_length, ContentLength::Absent)) ||
+            (!no_body &&
+                matches!(content_length, ContentLength::Present(length) if length > config.max_body_bytes))
+        {
+            return ResponsePlan::Fail
+        }
+        let (end, body) = if no_body {
+            (head, Body::Buffer(base + head..base + head))
+        } else if chunked == Some(true) {
+            match decode_chunked(
+                &buffer[head..],
+                config.max_body_bytes,
+                config.max_headers,
+                decoded,
+            ) {
+                Ok(Some(consumed)) => {
+                    let Some(end) = head.checked_add(consumed) else { return ResponsePlan::Fail };
+                    (end, Body::Decoded)
+                }
+                Ok(None) => return ResponsePlan::Incomplete,
+                Err(()) => return ResponsePlan::Fail,
+            }
+        } else if let ContentLength::Present(length) = content_length {
+            let Some(end) = head.checked_add(length) else { return ResponsePlan::Fail };
+            if buffer.len() < end {
+                return ResponsePlan::Incomplete
+            }
+            (end, Body::Buffer(base + head..base + end))
+        } else {
+            // Delimited by the close of the connection.
+            return ResponsePlan::Incomplete
+        };
+        if code < 200 {
+            return ResponsePlan::Informational { end: base + end }
+        }
+        headers.clear();
+        for header in response.headers.iter() {
+            headers.push((
+                span(buffer, header.name.as_bytes(), base),
+                span(buffer, header.value, base),
+            ));
+        }
+        ResponsePlan::Ready {
+            version: response.version.unwrap_or(1),
+            status: code,
+            reason: span(buffer, response.reason.unwrap_or("").as_bytes(), base),
+            body,
+            end: base + end,
+            close: response.version == Some(0) &&
+                !has_token(response.headers, "connection", b"keep-alive") ||
+                has_token(response.headers, "connection", b"close"),
+        }
+    }
+
+    /// Parses a response whose body the closing connection delimits.
+    fn plan_eof_response(&mut self, index: usize) -> Option<Step> {
+        let plan = {
+            let Self { conns, headers, config, .. } = self;
+            let conn = &conns[index];
+            let base = conn.start;
+            let buffer = &conn.buffer[base..];
+            let mut scratch = vec![httparse::EMPTY_HEADER; config.max_headers];
+            let mut response = httparse::Response::new(&mut scratch);
+            let Ok(httparse::Status::Complete(head)) = response.parse(buffer) else { return None };
+            if !crlf_only(&buffer[..head]) || head > config.max_head_bytes {
+                return None
+            }
+            let code = response.code.unwrap_or(0);
+            let no_body = outbound_method(&conn.role).map(String::as_str) == Some("HEAD") ||
+                matches!(code, 100..=199 | 204 | 304);
+            if no_body ||
+                transfer_chunked(response.headers) != Some(false) ||
+                !matches!(response_content_length(response.headers), ContentLength::Absent) ||
+                buffer.len() - head > config.max_body_bytes
+            {
+                return None
+            }
+            headers.clear();
+            for header in response.headers.iter() {
+                headers.push((
+                    span(buffer, header.name.as_bytes(), base),
+                    span(buffer, header.value, base),
+                ));
+            }
+            Step::Response {
+                index,
+                version: response.version.unwrap_or(1),
+                status: code,
+                reason: span(buffer, response.reason.unwrap_or("").as_bytes(), base),
+                body: Body::Buffer(base + head..conn.buffer.len()),
+            }
+        };
+        let conn = &mut self.conns[index];
+        conn.state.consumed = conn.buffer.len();
+        set_outbound_method(&mut conn.role, None);
+        Some(plan)
+    }
+
+    /// Answers a request the service itself rejected, and closes after it.
+    fn error(&mut self, net: &mut StreamNetwork, index: usize, status: u16) {
+        let token = self.conns[index].token;
+        let state = &mut self.conns[index].state;
+        state.phase = Phase::Pending;
+        state.close = true;
+        state.head_request = false;
+        respond_to(net, state, token, status, &[], &[]);
+    }
+
+    /// Drops an outbound connection whose peer broke the protocol.
+    fn fail_outbound(&mut self, net: &mut StreamNetwork, index: usize) {
+        let token = self.conns[index].token;
+        self.conns[index].clear();
+        set_outbound_method(&mut self.conns[index].role, None);
+        net.disconnect(token);
+    }
+
+    /// Forgets what a closed connection held: an accepted one goes, an
+    /// outbound one stays for its next connection.
+    fn close_connection(&mut self, index: usize) {
+        if matches!(self.conns[index].role, Role::Accepted) {
+            self.conns.swap_remove(index);
+        } else {
+            self.conns[index].clear();
+            set_outbound_method(&mut self.conns[index].role, None);
+        }
+    }
+
+    fn index_of(&self, token: Token) -> Option<usize> {
+        self.conns.iter().position(|conn| conn.token == token)
+    }
+
+    /// Queues a connection as ready to parse, once however many reads
+    /// arrived and only while it is free to take the next request: a
+    /// connection owing a response, or closing after one, parses nothing.
+    fn mark_ready(&mut self, index: usize) {
+        let conn = &mut self.conns[index];
+        if conn.ready || conn.state.phase != Phase::Idle {
+            return
+        }
+        conn.ready = true;
+        self.ready.push(conn.token);
+    }
+
+    fn pop_ready(&mut self) -> Option<usize> {
+        while self.ready_cursor < self.ready.len() {
+            let token = self.ready[self.ready_cursor];
+            self.ready_cursor += 1;
+            if self.ready_cursor == self.ready.len() {
+                self.ready.clear();
+                self.ready_cursor = 0;
+            }
+            if let Some(index) = self.index_of(token) {
+                self.conns[index].ready = false;
+                return Some(index)
+            }
+        }
+        None
+    }
+
+    fn take_record(&mut self) {
+        self.record_cursor += 1;
+        if self.record_cursor == self.records.len() {
+            self.records.clear();
+            self.record_cursor = 0;
+        }
+    }
+
+    /// Buffers one read, up to what the connection's limits allow.
+    fn buffer(&mut self, token: Token, payload: &[u8]) {
+        let limit = self.config.buffer_limit();
+        let Some(index) = self.index_of(token) else { return };
+        let conn = &mut self.conns[index];
+        if conn.state.phase == Phase::Draining || conn.over_limit {
+            return
+        }
+        if conn.state.consumed > 0 && conn.buffer.len() + payload.len() > limit {
+            conn.start = conn.state.consumed;
+            conn.compact();
+        }
+        let available = limit.saturating_sub(conn.unconsumed());
+        if payload.len() > available {
+            conn.buffer.extend_from_slice(&payload[..available]);
+            conn.over_limit = true;
+        } else {
+            conn.buffer.extend_from_slice(payload);
+        }
+        conn.last_activity = Instant::now();
+        self.mark_ready(index);
+    }
+
+    /// Whether a pull would deliver anything.
+    fn pullable(&self) -> bool {
+        self.record_cursor < self.records.len() || self.ready_cursor < self.ready.len()
+    }
+}
+
+impl private::ServiceDriver for HttpService {
+    fn group(&self) -> ConnectionGroup {
+        self.group
+    }
+
+    fn on_event(&mut self, event: &StreamEvent<'_>) {
+        debug_assert_eq!(event.group(), self.group, "the network routes by group");
+        match *event {
+            StreamEvent::Accepted { token, peer, .. } => {
+                self.conns.push(Conn::new(token, Role::Accepted));
+                self.records.push(Record::Accepted(token, peer));
+            }
+            StreamEvent::Connected { token, .. } => self.records.push(Record::Connected(token)),
+            StreamEvent::Message { token, payload, .. } => self.buffer(token, payload),
+            StreamEvent::Disconnected { token, .. } => {
+                self.records.push(Record::Disconnected(token));
+            }
+        }
+    }
+
+    fn tick(&mut self, net: &mut StreamNetwork, now: Instant) -> bool {
+        // No event is live inside a driver call, so what the last pull left
+        // behind is applied here rather than at the next pull: a connection
+        // holding a pipelined request is pullable work, and saying otherwise
+        // would park a caller that answered inline and stopped pulling.
+        self.apply_bookkeeping();
+        for index in 0..self.conns.len() {
+            let conn = &self.conns[index];
+            // A connection queued as ready is answered first: the bytes over
+            // the limit may be the ones that complete a request the service
+            // rejects with a status of its own.
+            if conn.over_limit && !conn.ready && conn.state.phase != Phase::Draining {
+                self.conns[index].over_limit = false;
+                net.disconnect(self.conns[index].token);
+            }
+        }
+        if let Some(timeout) = self.config.idle_timeout {
+            for conn in &self.conns {
+                if matches!(conn.role, Role::Accepted) &&
+                    now.saturating_sub(conn.last_activity) >= timeout
+                {
+                    net.disconnect(conn.token);
+                }
+            }
+        }
+        self.pullable()
+    }
+
+    fn next_deadline(&self) -> Option<Instant> {
+        let timeout = self.config.idle_timeout?;
+        self.conns
+            .iter()
+            .filter(|conn| matches!(conn.role, Role::Accepted))
+            .map(|conn| conn.last_activity + timeout)
+            .min()
+    }
+}
+
+/// What the next request of an accepted connection needs.
+enum RequestPlan {
+    /// Not all of it has arrived.
+    Incomplete,
+    /// Answer with this status and close.
+    Error(u16),
+    /// Tell the client to send the body it announced.
+    Continue,
+    Ready {
+        method: Range<usize>,
+        path: Range<usize>,
+        version: u8,
+        body: Range<usize>,
+        end: usize,
+        close: bool,
+        head_request: bool,
+    },
+}
+
+/// What the next response of an outbound connection needs.
+enum ResponsePlan {
+    /// Not all of it has arrived.
+    Incomplete,
+    /// The peer broke the protocol.
+    Fail,
+    /// An informational response, consumed without an event.
+    Informational {
+        end: usize,
+    },
+    Ready {
+        version: u8,
+        status: u16,
+        reason: Range<usize>,
+        body: Body,
+        end: usize,
+        close: bool,
+    },
+}
+
+/// Writes one response for a pending request and moves the connection on.
+fn respond_to(
+    net: &mut StreamNetwork,
+    state: &mut ConnState,
+    token: Token,
+    status: u16,
+    headers: &[(&str, &str)],
+    body: &[u8],
+) -> bool {
+    if state.phase != Phase::Pending {
+        return false
+    }
+    if !(200..=599).contains(&status) ||
+        headers.iter().any(|(name, value)| invalid_header(name, value))
+    {
+        return false
+    }
+    let caller_close = headers.iter().any(|(name, value)| {
+        name.eq_ignore_ascii_case("connection") && has_value_token(value.as_bytes(), b"close")
+    });
+    let close = state.close || caller_close;
+    let suppress_body = state.head_request || matches!(status, 100..=199 | 204 | 304);
+    let include_length = !matches!(status, 100..=199 | 204);
+    let ok = net.send_with(token, |out| {
+        write!(out, "HTTP/1.1 {status} {}\r\n", reason_phrase(status)).unwrap();
+        // Caller Connection headers only feed the close decision; exactly
+        // one canonical Connection header is always written below.
+        for (name, value) in headers {
+            if name.eq_ignore_ascii_case("connection") {
                 continue
             }
-            let token = self.conns[i].token;
-            let close = response.version == Some(0) &&
-                !has_token(response.headers, "connection", b"keep-alive") ||
-                has_token(response.headers, "connection", b"close");
-            let response_event = HttpResponse {
-                version: response.version.unwrap_or(1),
-                status,
-                reason: response.reason.unwrap_or(""),
-                headers: response.headers,
-                body: if no_body {
-                    &[]
-                } else if let Some(decoded) = decoded.as_deref() {
-                    decoded
-                } else {
-                    &b[head..consumed]
-                },
-            };
-            handler(HttpEvent::Response { token, response: response_event });
-            self.conns[i].buf.drain(..consumed);
-            self.conns[i].dirty = !self.conns[i].buf.is_empty();
-            set_outbound_method(&mut self.conns[i].role, None);
-            if close {
-                self.network.disconnect(token);
-                return
-            }
+            out.extend_from_slice(name.as_bytes());
+            out.extend_from_slice(b": ");
+            out.extend_from_slice(value.as_bytes());
+            out.extend_from_slice(b"\r\n");
         }
-    }
-    fn parse_eof_outbound<F>(&self, i: usize, handler: &mut F)
-    where
-        F: for<'a> FnMut(HttpEvent<'a>),
-    {
-        if outbound_method(&self.conns[i].role).is_none() {
-            return
+        if include_length {
+            write!(out, "Content-Length: {}\r\n", body.len()).unwrap();
         }
-        let b = &self.conns[i].buf;
-        let mut headers = vec![httparse::EMPTY_HEADER; self.max_headers];
-        let mut response = httparse::Response::new(&mut headers);
-        let Ok(httparse::Status::Complete(head)) = response.parse(b) else { return };
-        if !crlf_only(&b[..head]) || head > self.max_head_bytes {
-            return
-        }
-        let status = response.code.unwrap_or(0);
-        let no_body = outbound_method(&self.conns[i].role).map(String::as_str) == Some("HEAD") ||
-            matches!(status, 100..=199 | 204 | 304);
-        if no_body ||
-            transfer_chunked(response.headers) != Some(false) ||
-            !matches!(response_content_length(response.headers), ContentLength::Absent) ||
-            b.len() - head > self.max_body_bytes
-        {
-            return
-        }
-        let token = self.conns[i].token;
-        handler(HttpEvent::Response {
-            token,
-            response: HttpResponse {
-                version: response.version.unwrap_or(1),
-                status,
-                reason: response.reason.unwrap_or(""),
-                headers: response.headers,
-                body: &b[head..],
-            },
+        out.extend_from_slice(if close {
+            b"Connection: close\r\n"
+        } else {
+            b"Connection: keep-alive\r\n"
         });
-    }
-    fn decode_chunked(
-        bytes: &[u8],
-        max_body_bytes: usize,
-        max_headers: usize,
-    ) -> Result<Option<(usize, Vec<u8>)>, ()> {
-        let Some((end, body_len)) = Self::chunked_end(bytes, max_body_bytes, max_headers)? else {
-            return Ok(None)
-        };
-        let mut body = Vec::with_capacity(body_len);
-        let mut at = 0;
-        while at < end {
-            let httparse::Status::Complete((consumed, size)) =
-                httparse::parse_chunk_size(&bytes[at..]).map_err(|_| ())?
-            else {
-                return Err(())
-            };
-            at = at.checked_add(consumed).ok_or(())?;
-            let size = usize::try_from(size).map_err(|_| ())?;
-            if size == 0 {
-                return Ok(Some((end, body)))
-            }
-            body.extend_from_slice(&bytes[at..at + size]);
-            at = at.checked_add(size + 2).ok_or(())?;
+        out.extend_from_slice(b"\r\n");
+        if !suppress_body {
+            out.extend_from_slice(body);
         }
-        Err(())
-    }
-    fn chunked_end(
-        bytes: &[u8],
-        max_body_bytes: usize,
-        max_headers: usize,
-    ) -> Result<Option<(usize, usize)>, ()> {
-        let mut at = 0;
-        let mut body_len = 0;
-        loop {
-            let httparse::Status::Complete((consumed, size)) =
-                httparse::parse_chunk_size(&bytes[at..]).map_err(|_| ())?
-            else {
-                return Ok(None)
-            };
-            let size = usize::try_from(size).map_err(|_| ())?;
-            if size > max_body_bytes.saturating_sub(body_len) {
-                return Err(())
-            }
-            at = at.checked_add(consumed).ok_or(())?;
-            if size == 0 {
-                let mut headers = vec![httparse::EMPTY_HEADER; max_headers];
-                let httparse::Status::Complete((consumed, _)) =
-                    httparse::parse_headers(&bytes[at..], &mut headers).map_err(|_| ())?
-                else {
-                    return Ok(None)
-                };
-                let end = at.checked_add(consumed).ok_or(())?;
-                if !crlf_only(&bytes[at..end]) {
-                    return Err(())
-                }
-                return Ok(Some((end, body_len)))
-            }
-            let Some(chunk_end) = at.checked_add(size).and_then(|at| at.checked_add(2)) else {
-                return Err(())
-            };
-            if bytes.len() < chunk_end || &bytes[at + size..chunk_end] != b"\r\n" {
-                return Ok(None)
-            }
-            body_len += size;
-            at = chunk_end;
+    });
+    if ok {
+        if let Some(end) = state.req_end.take() {
+            state.consumed = end;
+        }
+        state.phase = if close { Phase::Draining } else { Phase::Idle };
+        if close {
+            net.disconnect_when_drained(token);
         }
     }
+    ok
+}
+
+/// The byte range of `part` inside `buffer`, offset by `base`.
+///
+/// A parser reports an absent value as an empty string of its own, which no
+/// buffer range describes; the empty range at the start is the honest answer.
+fn span(buffer: &[u8], part: &[u8], base: usize) -> Range<usize> {
+    let origin = buffer.as_ptr() as usize;
+    let at = part.as_ptr() as usize;
+    if at < origin || at + part.len() > origin + buffer.len() {
+        debug_assert!(part.is_empty(), "a parsed part must lie inside the buffer it came from");
+        return base..base
+    }
+    base + at - origin..base + at - origin + part.len()
+}
+
+fn text(buffer: &[u8], range: Range<usize>) -> &str {
+    std::str::from_utf8(&buffer[range]).unwrap_or("")
+}
+
+fn header<'a>(buffer: &'a [u8], headers: &'a [HeaderRange], name: &str) -> Option<&'a [u8]> {
+    headers
+        .iter()
+        .find(|(header, _)| buffer[header.clone()].eq_ignore_ascii_case(name.as_bytes()))
+        .map(|(_, value)| &buffer[value.clone()])
+}
+
+fn headers<'a>(
+    buffer: &'a [u8],
+    headers: &'a [HeaderRange],
+) -> impl Iterator<Item = (&'a str, &'a [u8])> + use<'a> {
+    headers.iter().map(move |(name, value)| (text(buffer, name.clone()), &buffer[value.clone()]))
 }
 
 fn crlf_only(bytes: &[u8]) -> bool {
     bytes.iter().enumerate().all(|(i, b)| *b != b'\n' || i > 0 && bytes[i - 1] == b'\r')
 }
+
+/// Whether a caller-supplied header is one the service refuses to send.
+fn invalid_header(name: &str, value: &str) -> bool {
+    !valid_token(name) ||
+        value.contains(['\r', '\n']) ||
+        name.eq_ignore_ascii_case("content-length") ||
+        name.eq_ignore_ascii_case("transfer-encoding")
+}
+
 fn request_content_length(headers: &[httparse::Header<'_>]) -> Option<usize> {
     let mut length = None;
     for header in headers.iter().filter(|h| h.name.eq_ignore_ascii_case("content-length")) {
@@ -789,67 +1284,30 @@ fn request_content_length(headers: &[httparse::Header<'_>]) -> Option<usize> {
     }
     Some(length.unwrap_or(0))
 }
+
 fn has_token(headers: &[httparse::Header<'_>], name: &str, value: &[u8]) -> bool {
     headers
         .iter()
         .filter(|h| h.name.eq_ignore_ascii_case(name))
         .any(|h| has_value_token(h.value, value))
 }
+
 fn has_value_token(value: &[u8], wanted: &[u8]) -> bool {
     value.split(|b| *b == b',').any(|part| part.trim_ascii().eq_ignore_ascii_case(wanted))
 }
+
 fn valid_token(value: &str) -> bool {
     !value.is_empty() &&
         value.bytes().all(|b| b.is_ascii_alphanumeric() || b"!#$%&'*+-.^_`|~".contains(&b))
 }
-fn accepted_state(role: &Role) -> State {
-    match role {
-        Role::Accepted { state, .. } => *state,
-        Role::Outbound { .. } => State::Draining,
-    }
-}
-fn accepted_state_mut(role: &mut Role) -> &mut State {
-    match role {
-        Role::Accepted { state, .. } => state,
-        Role::Outbound { .. } => panic!("accepted role"),
-    }
-}
-fn is_draining(role: &Role) -> bool {
-    matches!(role, Role::Accepted { state: State::Draining, .. })
-}
-fn set_accepted_state(role: &mut Role, state: State) {
-    *accepted_state_mut(role) = state;
-}
-fn accepted_close(role: &Role) -> bool {
-    matches!(role, Role::Accepted { close: true, .. })
-}
-fn set_accepted_close(role: &mut Role, close: bool) {
-    if let Role::Accepted { close: current, .. } = role {
-        *current = close;
-    }
-}
-fn accepted_continued_mut(role: &Role) -> bool {
-    matches!(role, Role::Accepted { continued: true, .. })
-}
-fn set_accepted_continued(role: &mut Role, continued: bool) {
-    if let Role::Accepted { continued: current, .. } = role {
-        *current = continued;
-    }
-}
-fn accepted_head_request(role: &Role) -> bool {
-    matches!(role, Role::Accepted { head_request: true, .. })
-}
-fn set_accepted_head_request(role: &mut Role, head_request: bool) {
-    if let Role::Accepted { head_request: current, .. } = role {
-        *current = head_request;
-    }
-}
+
 fn outbound_method(role: &Role) -> Option<&String> {
     match role {
         Role::Outbound { method, .. } => method.as_ref(),
-        Role::Accepted { .. } => None,
+        Role::Accepted => None,
     }
 }
+
 fn set_outbound_method(role: &mut Role, method: Option<String>) {
     if let Role::Outbound { method: current, .. } = role {
         *current = method;
@@ -861,6 +1319,7 @@ enum ContentLength {
     Present(usize),
     Invalid,
 }
+
 fn response_content_length(headers: &[httparse::Header<'_>]) -> ContentLength {
     let mut length = None;
     for header in headers.iter().filter(|h| h.name.eq_ignore_ascii_case("content-length")) {
@@ -875,6 +1334,7 @@ fn response_content_length(headers: &[httparse::Header<'_>]) -> ContentLength {
     }
     length.map_or(ContentLength::Absent, ContentLength::Present)
 }
+
 fn transfer_chunked(headers: &[httparse::Header<'_>]) -> Option<bool> {
     let mut found = false;
     for value in headers
@@ -889,6 +1349,78 @@ fn transfer_chunked(headers: &[httparse::Header<'_>]) -> Option<bool> {
         }
     }
     Some(found)
+}
+
+/// Decodes a chunked body into `out`, reporting how many bytes it spanned.
+fn decode_chunked(
+    bytes: &[u8],
+    max_body_bytes: usize,
+    max_headers: usize,
+    out: &mut Vec<u8>,
+) -> Result<Option<usize>, ()> {
+    let Some((end, body_len)) = chunked_end(bytes, max_body_bytes, max_headers)? else {
+        return Ok(None)
+    };
+    out.clear();
+    out.reserve(body_len);
+    let mut at = 0;
+    while at < end {
+        let httparse::Status::Complete((consumed, size)) =
+            httparse::parse_chunk_size(&bytes[at..]).map_err(|_| ())?
+        else {
+            return Err(())
+        };
+        at = at.checked_add(consumed).ok_or(())?;
+        let size = usize::try_from(size).map_err(|_| ())?;
+        if size == 0 {
+            return Ok(Some(end))
+        }
+        out.extend_from_slice(&bytes[at..at + size]);
+        at = at.checked_add(size + 2).ok_or(())?;
+    }
+    Err(())
+}
+
+fn chunked_end(
+    bytes: &[u8],
+    max_body_bytes: usize,
+    max_headers: usize,
+) -> Result<Option<(usize, usize)>, ()> {
+    let mut at = 0;
+    let mut body_len = 0;
+    loop {
+        let httparse::Status::Complete((consumed, size)) =
+            httparse::parse_chunk_size(&bytes[at..]).map_err(|_| ())?
+        else {
+            return Ok(None)
+        };
+        let size = usize::try_from(size).map_err(|_| ())?;
+        if size > max_body_bytes.saturating_sub(body_len) {
+            return Err(())
+        }
+        at = at.checked_add(consumed).ok_or(())?;
+        if size == 0 {
+            let mut headers = vec![httparse::EMPTY_HEADER; max_headers];
+            let httparse::Status::Complete((consumed, _)) =
+                httparse::parse_headers(&bytes[at..], &mut headers).map_err(|_| ())?
+            else {
+                return Ok(None)
+            };
+            let end = at.checked_add(consumed).ok_or(())?;
+            if !crlf_only(&bytes[at..end]) {
+                return Err(())
+            }
+            return Ok(Some((end, body_len)))
+        }
+        let Some(chunk_end) = at.checked_add(size).and_then(|at| at.checked_add(2)) else {
+            return Err(())
+        };
+        if bytes.len() < chunk_end || &bytes[at + size..chunk_end] != b"\r\n" {
+            return Ok(None)
+        }
+        body_len += size;
+        at = chunk_end;
+    }
 }
 
 /// HTTP reason phrase for common status codes.
@@ -914,40 +1446,32 @@ pub fn reason_phrase(status: u16) -> &'static str {
     }
 }
 
-pub struct HttpRequest<'a> {
-    pub method: &'a str,
-    pub path: &'a str,
-    pub version: u8,
-    pub headers: &'a [httparse::Header<'a>],
-    pub body: &'a [u8],
-}
-impl<'a> HttpRequest<'a> {
-    pub fn header(&self, name: &str) -> Option<&'a [u8]> {
-        self.headers.iter().find(|h| h.name.eq_ignore_ascii_case(name)).map(|h| h.value)
-    }
-}
-pub struct HttpResponse<'a> {
-    pub version: u8,
-    pub status: u16,
-    pub reason: &'a str,
-    pub headers: &'a [httparse::Header<'a>],
-    pub body: &'a [u8],
-}
-impl<'a> HttpResponse<'a> {
-    pub fn header(&self, name: &str) -> Option<&'a [u8]> {
-        self.headers.iter().find(|h| h.name.eq_ignore_ascii_case(name)).map(|h| h.value)
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::HttpRequest;
+    use super::{HttpRequest, span};
 
     #[test]
     fn header_lookup_is_case_insensitive() {
-        let headers = [httparse::Header { name: "Content-Type", value: b"text/plain" }];
-        let request =
-            HttpRequest { method: "GET", path: "/", version: 1, headers: &headers, body: &[] };
+        let buffer = b"Content-Type: text/plain".as_slice();
+        let headers = [(0..12, 14..24)];
+        let request = HttpRequest {
+            method: "GET",
+            path: "/",
+            version: 1,
+            body: &[],
+            buffer,
+            headers: &headers,
+        };
         assert_eq!(request.header("content-type"), Some(&b"text/plain"[..]));
+        assert_eq!(request.header("content-length"), None);
+        assert_eq!(request.headers().collect::<Vec<_>>(), [("Content-Type", &b"text/plain"[..])]);
+    }
+
+    #[test]
+    fn a_span_is_the_offset_of_a_parsed_part() {
+        let buffer = b"GET /path HTTP/1.1".as_slice();
+        assert_eq!(span(buffer, &buffer[4..9], 0), 4..9);
+        assert_eq!(span(buffer, &buffer[4..9], 100), 104..109);
+        assert_eq!(span(buffer, b"", 7), 7..7);
     }
 }

--- a/crates/flux-network/src/http.rs
+++ b/crates/flux-network/src/http.rs
@@ -237,6 +237,10 @@ impl Responder<'_> {
     /// The status must be in `200..=599`; `Content-Length` and
     /// `Transfer-Encoding` are the service's to write, and a `Connection`
     /// header only feeds the close decision.
+    ///
+    /// The request stops counting against connection limits here. Its bytes
+    /// are reclaimed on the next pull or network tick, after the event's
+    /// borrow ends. [`HttpService::respond`] reclaims before it returns.
     pub fn respond(self, status: u16, headers: &[(&str, &str)], body: &[u8]) -> bool {
         respond_to(self.net, self.state, self.token, status, headers, body)
     }
@@ -244,9 +248,8 @@ impl Responder<'_> {
 
 /// What answering one request touches, and all a [`Responder`] may reach.
 ///
-/// `req_end` marks a parsed request awaiting its response; `consumed` is the
-/// accounting cursor, and bytes below it are answered and cost the connection
-/// nothing against its limits, whether or not they have been reclaimed yet.
+/// `req_end` marks a request awaiting its response. `consumed` excludes
+/// answered bytes from limits before they are reclaimed.
 struct ConnState {
     phase: Phase,
     close: bool,
@@ -412,7 +415,7 @@ pub struct HttpService {
     headers: Vec<HeaderRange>,
     /// The body of the last chunked response, decoded.
     decoded: Vec<u8>,
-    /// The connection the last pulled event left bookkeeping for.
+    /// The connection awaiting bookkeeping from the last pulled event.
     last: Option<Token>,
 }
 
@@ -551,6 +554,9 @@ impl HttpService {
     /// the response was written.
     ///
     /// Each call completes exactly one request for `token`.
+    ///
+    /// Unlike [`Responder::respond`], this path holds no event borrow, so it
+    /// reclaims answered bytes and queues a pipelined request before returning.
     pub fn respond(
         &mut self,
         net: &mut StreamNetwork,
@@ -641,8 +647,7 @@ impl HttpService {
         self.ready.len() - self.ready_cursor
     }
 
-    /// Applies what the previous event left behind: the bytes it answered are
-    /// reclaimed, and a connection with more to parse queues up again.
+    /// Applies bookkeeping deferred by the last pulled event.
     fn apply_bookkeeping(&mut self) {
         let Some(token) = self.last.take() else { return };
         let Some(index) = self.index_of(token) else { return };
@@ -1089,10 +1094,7 @@ impl private::ServiceDriver for HttpService {
     }
 
     fn tick(&mut self, net: &mut StreamNetwork, now: Instant) -> bool {
-        // No event is live inside a driver call, so what the last pull left
-        // behind is applied here rather than at the next pull: a connection
-        // holding a pipelined request is pullable work, and saying otherwise
-        // would park a caller that answered inline and stopped pulling.
+        // Apply deferred bookkeeping before reporting pullable work.
         self.apply_bookkeeping();
         for index in 0..self.conns.len() {
             let conn = &self.conns[index];

--- a/crates/flux-network/src/stream/mod.rs
+++ b/crates/flux-network/src/stream/mod.rs
@@ -12,5 +12,6 @@ pub use network::{
     TcpOptions,
 };
 pub use service::ServiceRef;
+pub(crate) use service::private;
 pub(crate) use tcp_stream::set_socket_buf_size;
 pub use tcp_stream::{ConnState, TcpStream, TcpTelemetry};

--- a/crates/flux-network/src/stream/mod.rs
+++ b/crates/flux-network/src/stream/mod.rs
@@ -1,6 +1,7 @@
 mod connector;
 mod endpoint;
 mod network;
+mod service;
 mod tcp_stream;
 mod transport;
 
@@ -10,5 +11,6 @@ pub use network::{
     ConnectionGroup, ConnectionGroupConfig, Framing, PayloadBuf, StreamEvent, StreamNetwork,
     TcpOptions,
 };
+pub use service::ServiceRef;
 pub(crate) use tcp_stream::set_socket_buf_size;
 pub use tcp_stream::{ConnState, TcpStream, TcpTelemetry};

--- a/crates/flux-network/src/stream/network.rs
+++ b/crates/flux-network/src/stream/network.rs
@@ -10,7 +10,7 @@ use mio::{Events, Interest, Poll, Registry, Token, event::Event};
 use tracing::{debug, error, info, warn};
 
 use super::{
-    Endpoint, Peer, TcpTelemetry, set_socket_buf_size,
+    Endpoint, Peer, ServiceRef, TcpTelemetry, set_socket_buf_size,
     tcp_stream::{
         DEFAULT_TCP_USER_TIMEOUT_MS, FRAME_HEADER_SIZE, frame_payload_len, write_frame_header,
         write_frame_len, write_frame_ts,
@@ -266,7 +266,7 @@ impl ConnectionGroupConfig {
     }
 }
 
-/// Event emitted by [`StreamNetwork::poll_with`].
+/// Event emitted by [`StreamNetwork::drive`].
 pub enum StreamEvent<'a> {
     /// A listener accepted a new connection.
     Accepted { group: ConnectionGroup, token: Token, peer: Peer },
@@ -278,6 +278,18 @@ pub enum StreamEvent<'a> {
     Message { group: ConnectionGroup, token: Token, payload: &'a [u8], send_ts: Nanos },
     /// An established connection was closed.
     Disconnected { group: ConnectionGroup, token: Token, peer: Peer },
+}
+
+impl StreamEvent<'_> {
+    /// The group whose service, or whose unclaimed handler, this event is for.
+    pub(crate) fn group(&self) -> ConnectionGroup {
+        match *self {
+            Self::Accepted { group, .. } |
+            Self::Connected { group, .. } |
+            Self::Message { group, .. } |
+            Self::Disconnected { group, .. } => group,
+        }
+    }
 }
 
 struct GroupState {
@@ -437,8 +449,10 @@ impl NetworkState {
         self.connections[index].state = ConnectionState::Connecting(socket);
     }
 
-    fn maybe_reconnect(&mut self) {
-        let now = Instant::now();
+    /// Retries every outbound endpoint whose group is due one, reporting
+    /// whether an attempt was made.
+    fn maybe_reconnect(&mut self, now: Instant) -> bool {
+        let mut attempted = false;
         for group_index in 0..self.groups.len() {
             if !self.groups[group_index].reconnector.fired_at(now) {
                 continue;
@@ -449,9 +463,26 @@ impl NetworkState {
                     matches!(self.connections[index].state, ConnectionState::Disconnected)
                 {
                     self.start_connect(index);
+                    attempted = true;
                 }
             }
         }
+        attempted
+    }
+
+    /// The earliest instant the network's own timers need a call at: the next
+    /// retry of a group holding an outbound endpoint that is down.
+    fn next_deadline(&self) -> Option<Instant> {
+        let mut next: Option<Instant> = None;
+        for connection in &self.connections {
+            if connection.endpoint.is_some() &&
+                matches!(connection.state, ConnectionState::Disconnected)
+            {
+                let fire = self.groups[connection.group.0].reconnector.next_fire();
+                next = Some(next.map_or(fire, |next: Instant| next.min(fire)));
+            }
+        }
+        next
     }
 
     fn finish_connect<F>(&mut self, index: usize, handler: &mut F) -> bool
@@ -954,14 +985,24 @@ impl NetworkState {
 ///
 /// Dropping the network closes every listener, which unlinks the socket file
 /// of each [`Endpoint::Unix`] listener.
+///
+/// A group is either **service-owned** — a protocol layer claimed it and the
+/// network routes its events to that service — or an **unclaimed group**, whose
+/// events reach the handler passed to [`Self::drive`] as they arrive.
 pub struct StreamNetwork {
     events: Events,
     state: NetworkState,
+    /// Whether a service owns the group at each index.
+    claimed: Vec<bool>,
 }
 
 impl Default for StreamNetwork {
     fn default() -> Self {
-        Self { events: Events::with_capacity(EVENTS_CAPACITY), state: NetworkState::default() }
+        Self {
+            events: Events::with_capacity(EVENTS_CAPACITY),
+            state: NetworkState::default(),
+            claimed: Vec::with_capacity(INITIAL_GROUP_CAPACITY),
+        }
     }
 }
 
@@ -992,7 +1033,28 @@ impl StreamNetwork {
         let group = ConnectionGroup(self.state.groups.len());
         let reconnector = Repeater::every(config.reconnect_interval);
         self.state.groups.push(GroupState { config, reconnector });
+        self.claimed.push(false);
         group
+    }
+
+    /// Marks `group` as owned by the service making the call.
+    #[allow(dead_code, reason = "the services that claim a group arrive with HttpService")]
+    pub(crate) fn claim_group(&mut self, group: ConnectionGroup) {
+        assert!(group.0 < self.claimed.len(), "unknown connection group");
+        assert!(!self.claimed[group.0], "connection group {} already has a service", group.0);
+        self.claimed[group.0] = true;
+    }
+
+    /// Returns `group` to unclaimed status.
+    #[allow(dead_code, reason = "the services that release a group arrive with HttpService")]
+    pub(crate) fn release_group(&mut self, group: ConnectionGroup) {
+        assert!(group.0 < self.claimed.len(), "unknown connection group");
+        self.claimed[group.0] = false;
+    }
+
+    /// The earliest instant the network's own timers need a driver call at.
+    pub(crate) fn next_deadline(&self) -> Option<Instant> {
+        self.state.next_deadline()
     }
 
     /// Adds a listener to `group`.
@@ -1014,22 +1076,129 @@ impl StreamNetwork {
         self.state.connect(group, endpoint)
     }
 
-    pub fn poll_with<F>(&mut self, mut handler: F)
+    /// Runs one iteration of the network: maintenance, one poll, event
+    /// delivery and one tick per service. Returns whether anything happened.
+    ///
+    /// The poll blocks for `max_timeout` at the longest, and for less when the
+    /// network's own timers or a service's [`ServiceRef`] deadline fall sooner;
+    /// `None` everywhere blocks until an event arrives. Events of a
+    /// service-owned group go to that service, the rest to `unclaimed_handler`,
+    /// which borrows each payload for the duration of the call. Protocol
+    /// events the services produced are pulled from the services
+    /// afterwards.
+    ///
+    /// The poll wait is where an iteration spends its time, so the ticks that
+    /// follow it are given the time after it: a timer a tick starts runs from
+    /// the moment the wait ended, and one that expired during the wait is due
+    /// in the same iteration rather than the next.
+    ///
+    /// # Panics
+    /// Every service-owned group must appear exactly once among `services`. A
+    /// group whose service is missing or doubled is a configuration error and
+    /// panics before the call does anything else.
+    pub fn drive<F>(
+        &mut self,
+        max_timeout: Option<Duration>,
+        services: &mut [ServiceRef<'_>],
+        mut unclaimed_handler: F,
+    ) -> bool
     where
         F: for<'a> FnMut(StreamEvent<'a>),
     {
-        self.state.drain_pending_disconnects(&mut handler);
-        self.state.maybe_reconnect();
-        if let Err(err) = self.state.poll.poll(&mut self.events, Some(std::time::Duration::ZERO)) {
-            if err.kind() != io::ErrorKind::Interrupted {
-                flux_utils::safe_panic!("couldn't poll the stream network: {err}");
+        let now = Instant::now();
+        self.validate(services);
+
+        let mut routed = false;
+        {
+            let claimed = &self.claimed;
+            let mut route = |event: StreamEvent<'_>| {
+                route_event(claimed, services, &mut unclaimed_handler, &mut routed, event);
+            };
+            self.state.drain_pending_disconnects(&mut route);
+        }
+        let reconnected = self.state.maybe_reconnect(now);
+
+        let timeout = self.poll_timeout(max_timeout, services, now);
+        match self.state.poll.poll(&mut self.events, timeout) {
+            Ok(()) => {
+                let claimed = &self.claimed;
+                let mut route = |event: StreamEvent<'_>| {
+                    route_event(claimed, services, &mut unclaimed_handler, &mut routed, event);
+                };
+                for event in &self.events {
+                    self.state.handle_event(event, &mut route);
+                }
+                self.state.drain_pending_disconnects(&mut route);
             }
-            return;
+            Err(err) if err.kind() == io::ErrorKind::Interrupted => {}
+            Err(err) => flux_utils::safe_panic!("couldn't poll the stream network: {err}"),
         }
-        for event in &self.events {
-            self.state.handle_event(event, &mut handler);
+
+        // The instant this iteration began is older than the poll wait it has
+        // just come out of, which may have been the whole of a timeout.
+        let tick_now = Instant::now();
+        let mut pullable = false;
+        for service in services.iter_mut() {
+            pullable |= service.tick(self, tick_now);
         }
-        self.state.drain_pending_disconnects(&mut handler);
+        routed || reconnected || pullable
+    }
+
+    /// Runs one nonblocking iteration of a network holding unclaimed groups
+    /// only.
+    ///
+    /// # Panics
+    /// Panics when a group is service-owned; such a network is driven with
+    /// [`Self::drive`].
+    pub fn poll_with<F>(&mut self, handler: F)
+    where
+        F: for<'a> FnMut(StreamEvent<'a>),
+    {
+        self.drive(Some(Duration::ZERO), &mut [], handler);
+    }
+
+    /// Panics unless `services` names every service-owned group exactly once.
+    fn validate(&self, services: &[ServiceRef<'_>]) {
+        for (position, service) in services.iter().enumerate() {
+            let group = service.group();
+            assert!(
+                self.claimed.get(group.0).copied().unwrap_or(false),
+                "no service owns connection group {} — a service claims its group when it is built",
+                group.0
+            );
+            assert!(
+                services[..position].iter().all(|other| other.group() != group),
+                "duplicate service for group {}",
+                group.0
+            );
+        }
+        for (index, claimed) in self.claimed.iter().enumerate() {
+            assert!(
+                !claimed || services.iter().any(|service| service.group().0 == index),
+                "service-owned group {index} has no service — call HttpService::close before \
+                 dropping it"
+            );
+        }
+    }
+
+    /// Folds the caller's cap, the network's own timers and every service's
+    /// deadline into the timeout of one poll.
+    fn poll_timeout(
+        &self,
+        max_timeout: Option<Duration>,
+        services: &[ServiceRef<'_>],
+        now: Instant,
+    ) -> Option<std::time::Duration> {
+        let deadline = self
+            .next_deadline()
+            .into_iter()
+            .chain(services.iter().filter_map(|service| service.next_deadline()))
+            .min();
+        let timeout = match (max_timeout, deadline.map(|deadline| deadline.saturating_sub(now))) {
+            (Some(max), Some(next)) => Some(max.min(next)),
+            (max, next) => max.or(next),
+        };
+        timeout.map(std::time::Duration::from)
     }
 
     /// Serializes and sends one payload to a connected token. Length-prefixed
@@ -1108,6 +1277,31 @@ impl StreamNetwork {
     /// the token was found.
     pub fn remove(&mut self, token: Token) -> bool {
         self.state.remove(token)
+    }
+}
+
+/// Hands one event to the service owning its group, or to the unclaimed handler
+/// when no service owns it.
+fn route_event<F>(
+    claimed: &[bool],
+    services: &mut [ServiceRef<'_>],
+    unclaimed_handler: &mut F,
+    routed: &mut bool,
+    event: StreamEvent<'_>,
+) where
+    F: for<'a> FnMut(StreamEvent<'a>),
+{
+    *routed = true;
+    let group = event.group();
+    if let Some(service) = services.iter_mut().find(|service| service.group() == group) {
+        service.on_event(&event);
+    } else {
+        debug_assert!(
+            !claimed[group.0],
+            "service-owned group {} has no service to route to",
+            group.0
+        );
+        unclaimed_handler(event);
     }
 }
 

--- a/crates/flux-network/src/stream/network.rs
+++ b/crates/flux-network/src/stream/network.rs
@@ -449,6 +449,26 @@ impl NetworkState {
         self.connections[index].state = ConnectionState::Connecting(socket);
     }
 
+    /// Hard-closes every listener, accepted connection and outbound endpoint
+    /// of `group`, discarding the disconnect events that produces.
+    ///
+    /// Closing an [`Endpoint::Unix`] listener unlinks its socket file.
+    fn close_group(&mut self, group: ConnectionGroup) {
+        for index in (0..self.listeners.len()).rev() {
+            if self.listeners[index].group == group {
+                let mut listener = self.listeners.swap_remove(index);
+                let _ = self.poll.registry().deregister(&mut listener.socket);
+            }
+        }
+        for index in (0..self.connections.len()).rev() {
+            if self.connections[index].group == group {
+                self.close_connection_socket(index);
+                self.connections.swap_remove(index);
+            }
+        }
+        self.pending_disconnects.retain(|event| event.group != group);
+    }
+
     /// Retries every outbound endpoint whose group is due one, reporting
     /// whether an attempt was made.
     fn maybe_reconnect(&mut self, now: Instant) -> bool {
@@ -1038,7 +1058,6 @@ impl StreamNetwork {
     }
 
     /// Marks `group` as owned by the service making the call.
-    #[allow(dead_code, reason = "the services that claim a group arrive with HttpService")]
     pub(crate) fn claim_group(&mut self, group: ConnectionGroup) {
         assert!(group.0 < self.claimed.len(), "unknown connection group");
         assert!(!self.claimed[group.0], "connection group {} already has a service", group.0);
@@ -1046,10 +1065,22 @@ impl StreamNetwork {
     }
 
     /// Returns `group` to unclaimed status.
-    #[allow(dead_code, reason = "the services that release a group arrive with HttpService")]
     pub(crate) fn release_group(&mut self, group: ConnectionGroup) {
         assert!(group.0 < self.claimed.len(), "unknown connection group");
         self.claimed[group.0] = false;
+    }
+
+    /// The wire encoding of `group`, which a service checks before claiming it.
+    pub(crate) fn framing(&self, group: ConnectionGroup) -> Framing {
+        assert!(group.0 < self.state.groups.len(), "unknown connection group");
+        self.state.config(group).framing
+    }
+
+    /// Hard-closes every listener, accepted connection and outbound endpoint
+    /// of `group` and returns it to unclaimed status, empty and reusable.
+    pub(crate) fn close_group(&mut self, group: ConnectionGroup) {
+        self.state.close_group(group);
+        self.release_group(group);
     }
 
     /// The earliest instant the network's own timers need a driver call at.
@@ -1148,12 +1179,18 @@ impl StreamNetwork {
     /// only.
     ///
     /// # Panics
-    /// Panics when a group is service-owned; such a network is driven with
-    /// [`Self::drive`].
+    /// A network with services is driven with [`Self::drive`], which is what
+    /// delivers their events; polling it without them panics.
     pub fn poll_with<F>(&mut self, handler: F)
     where
         F: for<'a> FnMut(StreamEvent<'a>),
     {
+        if let Some(index) = self.claimed.iter().position(|claimed| *claimed) {
+            panic!(
+                "connection group {index} has a service — drive the network with \
+                 StreamNetwork::drive, passing every service"
+            );
+        }
         self.drive(Some(Duration::ZERO), &mut [], handler);
     }
 

--- a/crates/flux-network/src/stream/service.rs
+++ b/crates/flux-network/src/stream/service.rs
@@ -1,0 +1,423 @@
+//! The scheduling hooks a service exposes to its network, and the carrier that
+//! hands them over.
+
+use flux_timing::Instant;
+
+use super::{ConnectionGroup, StreamEvent, StreamNetwork};
+
+pub(crate) mod private {
+    use flux_timing::Instant;
+
+    use super::{ConnectionGroup, StreamEvent, StreamNetwork};
+
+    /// What a [`StreamNetwork`] calls on the service owning a group, in the
+    /// order [`StreamNetwork::drive`] fixes.
+    ///
+    /// The trait is flux-internal so that the hooks stay the network's alone:
+    /// a service reaches its network only through the opaque
+    /// [`super::ServiceRef`] carrier.
+    pub trait ServiceDriver {
+        /// The group this service owns.
+        fn group(&self) -> ConnectionGroup;
+        /// Takes one transport event for that group.
+        fn on_event(&mut self, event: &StreamEvent<'_>);
+        /// Runs the service's own timers once per iteration, reporting whether
+        /// protocol events are left to pull.
+        fn tick(&mut self, net: &mut StreamNetwork, now: Instant) -> bool;
+        /// The earliest instant this service needs a tick at.
+        fn next_deadline(&self) -> Option<Instant>;
+    }
+}
+
+/// One service, for the duration of a driver call.
+///
+/// A service hands its network a `ServiceRef` — `HttpService::as_service()` —
+/// and the network drives it; the carrier itself offers a caller nothing.
+pub struct ServiceRef<'a>(&'a mut dyn private::ServiceDriver);
+
+impl<'a> ServiceRef<'a> {
+    #[allow(dead_code, reason = "the services that build a carrier arrive with HttpService")]
+    pub(crate) fn new(driver: &'a mut dyn private::ServiceDriver) -> Self {
+        Self(driver)
+    }
+
+    pub(crate) fn group(&self) -> ConnectionGroup {
+        self.0.group()
+    }
+
+    pub(crate) fn on_event(&mut self, event: &StreamEvent<'_>) {
+        self.0.on_event(event);
+    }
+
+    pub(crate) fn tick(&mut self, net: &mut StreamNetwork, now: Instant) -> bool {
+        self.0.tick(net, now)
+    }
+
+    pub(crate) fn next_deadline(&self) -> Option<Instant> {
+        self.0.next_deadline()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        cell::Cell,
+        io::{Read as _, Write as _},
+        net::{Ipv4Addr, SocketAddr, TcpStream as StdTcpStream},
+        rc::Rc,
+    };
+
+    use flux_timing::{Duration, Instant};
+    use mio::Token;
+
+    use super::{ServiceRef, private::ServiceDriver};
+    use crate::stream::{
+        ConnectionGroup, ConnectionGroupConfig, Endpoint, Framing, StreamEvent, StreamNetwork,
+    };
+
+    const PATIENCE: std::time::Duration = std::time::Duration::from_secs(10);
+
+    /// What the network did to a service, in the order it did it.
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    enum Step {
+        Accepted(Token),
+        Connected(Token),
+        Message(Vec<u8>),
+        Disconnected(Token),
+        Tick(usize),
+    }
+
+    /// A service that records how it was driven.
+    struct Probe {
+        group: ConnectionGroup,
+        steps: Vec<Step>,
+        tick_times: Vec<Instant>,
+        clock: Rc<Cell<usize>>,
+        deadline: Option<Instant>,
+        pullable: bool,
+    }
+
+    impl Probe {
+        fn new(group: ConnectionGroup) -> Self {
+            Self {
+                group,
+                steps: Vec::new(),
+                tick_times: Vec::new(),
+                clock: Rc::new(Cell::new(0)),
+                deadline: None,
+                pullable: false,
+            }
+        }
+
+        fn as_service(&mut self) -> ServiceRef<'_> {
+            ServiceRef::new(self)
+        }
+
+        fn events(&self) -> Vec<Step> {
+            self.steps.iter().filter(|step| !matches!(step, Step::Tick(_))).cloned().collect()
+        }
+
+        fn ticks(&self) -> Vec<usize> {
+            self.steps
+                .iter()
+                .filter_map(|step| match step {
+                    Step::Tick(order) => Some(*order),
+                    _ => None,
+                })
+                .collect()
+        }
+
+        fn accepted(&self) -> Option<Token> {
+            self.steps.iter().find_map(|step| match step {
+                Step::Accepted(token) => Some(*token),
+                _ => None,
+            })
+        }
+    }
+
+    impl ServiceDriver for Probe {
+        fn group(&self) -> ConnectionGroup {
+            self.group
+        }
+
+        fn on_event(&mut self, event: &StreamEvent<'_>) {
+            self.steps.push(match *event {
+                StreamEvent::Accepted { token, .. } => Step::Accepted(token),
+                StreamEvent::Connected { token, .. } => Step::Connected(token),
+                StreamEvent::Message { payload, .. } => Step::Message(payload.to_vec()),
+                StreamEvent::Disconnected { token, .. } => Step::Disconnected(token),
+            });
+        }
+
+        fn tick(&mut self, _net: &mut StreamNetwork, now: Instant) -> bool {
+            let order = self.clock.get();
+            self.clock.set(order + 1);
+            self.steps.push(Step::Tick(order));
+            self.tick_times.push(now);
+            self.pullable
+        }
+
+        fn next_deadline(&self) -> Option<Instant> {
+            self.deadline
+        }
+    }
+
+    fn unused_addr() -> SocketAddr {
+        let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        addr
+    }
+
+    fn raw_group(network: &mut StreamNetwork, name: &'static str) -> ConnectionGroup {
+        network.add_group(ConnectionGroupConfig {
+            name,
+            framing: Framing::Raw,
+            ..ConnectionGroupConfig::default()
+        })
+    }
+
+    /// Drives one service until it has seen what the test waits for.
+    fn drive_until(network: &mut StreamNetwork, probe: &mut Probe, done: impl Fn(&Probe) -> bool) {
+        let deadline = std::time::Instant::now() + PATIENCE;
+        while std::time::Instant::now() < deadline {
+            network.drive(Some(Duration::from_millis(1)), &mut [probe.as_service()], |_| {});
+            if done(probe) {
+                return;
+            }
+        }
+        panic!("the service never saw what the test waits for: {:?}", probe.steps);
+    }
+
+    #[test]
+    #[should_panic(expected = "service-owned group 0 has no service")]
+    fn drive_rejects_a_claimed_group_left_without_a_service() {
+        let mut network = StreamNetwork::default();
+        let group = raw_group(&mut network, "orphan");
+        network.claim_group(group);
+        network.drive(Some(Duration::ZERO), &mut [], |_| {});
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate service for group 0")]
+    fn drive_rejects_two_services_for_one_group() {
+        let mut network = StreamNetwork::default();
+        let group = raw_group(&mut network, "shared");
+        network.claim_group(group);
+        let mut one = Probe::new(group);
+        let mut two = Probe::new(group);
+        network.drive(Some(Duration::ZERO), &mut [one.as_service(), two.as_service()], |_| {});
+    }
+
+    #[test]
+    #[should_panic(expected = "no service owns connection group 0")]
+    fn drive_rejects_a_service_of_an_unclaimed_group() {
+        let mut network = StreamNetwork::default();
+        let group = raw_group(&mut network, "raw");
+        let mut probe = Probe::new(group);
+        network.drive(Some(Duration::ZERO), &mut [probe.as_service()], |_| {});
+    }
+
+    #[test]
+    #[should_panic(expected = "already has a service")]
+    fn a_group_takes_one_claim() {
+        let mut network = StreamNetwork::default();
+        let group = raw_group(&mut network, "claimed");
+        network.claim_group(group);
+        network.claim_group(group);
+    }
+
+    #[test]
+    fn releasing_a_claim_returns_the_group_to_raw() {
+        let mut network = StreamNetwork::default();
+        let group = raw_group(&mut network, "released");
+        network.claim_group(group);
+        network.release_group(group);
+        network.drive(Some(Duration::ZERO), &mut [], |_| {});
+    }
+
+    #[test]
+    fn events_reach_the_owning_service_and_unclaimed_groups_reach_the_handler() {
+        let mut network = StreamNetwork::default();
+        let owned = raw_group(&mut network, "owned");
+        let raw = raw_group(&mut network, "raw");
+        let owned_addr = unused_addr();
+        let raw_addr = unused_addr();
+        network.listen(owned, Endpoint::Tcp(owned_addr)).unwrap();
+        network.listen(raw, Endpoint::Tcp(raw_addr)).unwrap();
+        network.claim_group(owned);
+        let mut probe = Probe::new(owned);
+
+        let mut to_owned = StdTcpStream::connect(owned_addr).unwrap();
+        let mut to_raw = StdTcpStream::connect(raw_addr).unwrap();
+        to_owned.write_all(b"for the service").unwrap();
+        to_raw.write_all(b"for the handler").unwrap();
+
+        let mut lent = Vec::new();
+        let deadline = std::time::Instant::now() + PATIENCE;
+        while std::time::Instant::now() < deadline && (probe.events().len() < 2 || lent.is_empty())
+        {
+            network.drive(Some(Duration::from_millis(1)), &mut [probe.as_service()], |event| {
+                if let StreamEvent::Message { group, payload, .. } = event {
+                    assert_eq!(group, raw);
+                    lent.push(payload.to_vec());
+                }
+            });
+        }
+
+        assert!(
+            matches!(probe.events().as_slice(), [Step::Accepted(_), Step::Message(payload)]
+            if payload == b"for the service"),
+            "{:?}",
+            probe.events()
+        );
+        assert_eq!(lent, [b"for the handler".to_vec()]);
+    }
+
+    #[test]
+    fn a_disconnect_from_maintenance_reaches_the_service_before_its_tick() {
+        let mut network = StreamNetwork::default();
+        let group = raw_group(&mut network, "kicked");
+        let addr = unused_addr();
+        network.listen(group, Endpoint::Tcp(addr)).unwrap();
+        network.claim_group(group);
+        let mut probe = Probe::new(group);
+        let client = StdTcpStream::connect(addr).unwrap();
+
+        drive_until(&mut network, &mut probe, |probe| probe.accepted().is_some());
+        let accepted = probe.accepted().unwrap();
+        probe.steps.clear();
+
+        // Disconnecting outside a driver call leaves the event pending, so the
+        // next drive delivers it as maintenance, before any tick.
+        assert!(network.disconnect(accepted));
+        network.drive(Some(Duration::ZERO), &mut [probe.as_service()], |_| {});
+
+        assert!(
+            matches!(probe.steps.as_slice(), [Step::Disconnected(token), Step::Tick(_)]
+                if *token == accepted),
+            "{:?}",
+            probe.steps
+        );
+        drop(client);
+    }
+
+    #[test]
+    fn services_tick_once_each_in_slice_order() {
+        let mut network = StreamNetwork::default();
+        let first = raw_group(&mut network, "first");
+        let second = raw_group(&mut network, "second");
+        network.claim_group(first);
+        network.claim_group(second);
+        let clock = Rc::new(Cell::new(0));
+        let mut one = Probe::new(first);
+        let mut two = Probe::new(second);
+        one.clock = Rc::clone(&clock);
+        two.clock = Rc::clone(&clock);
+
+        network.drive(Some(Duration::ZERO), &mut [one.as_service(), two.as_service()], |_| {});
+        network.drive(Some(Duration::ZERO), &mut [two.as_service(), one.as_service()], |_| {});
+
+        assert_eq!(one.ticks(), [0, 3]);
+        assert_eq!(two.ticks(), [1, 2]);
+    }
+
+    #[test]
+    fn work_is_reported_by_services_and_by_routed_events() {
+        let mut network = StreamNetwork::default();
+        let group = raw_group(&mut network, "work");
+        let addr = unused_addr();
+        network.listen(group, Endpoint::Tcp(addr)).unwrap();
+        network.claim_group(group);
+        let mut probe = Probe::new(group);
+
+        assert!(!network.drive(Some(Duration::ZERO), &mut [probe.as_service()], |_| {}));
+
+        probe.pullable = true;
+        assert!(network.drive(Some(Duration::ZERO), &mut [probe.as_service()], |_| {}));
+        probe.pullable = false;
+
+        let _client = StdTcpStream::connect(addr).unwrap();
+        let deadline = std::time::Instant::now() + PATIENCE;
+        let mut worked = false;
+        while std::time::Instant::now() < deadline && !worked {
+            worked =
+                network.drive(Some(Duration::from_millis(1)), &mut [probe.as_service()], |_| {});
+        }
+        assert!(worked, "an accepted connection is work");
+    }
+
+    #[test]
+    fn the_poll_waits_no_longer_than_the_earliest_service_deadline() {
+        let mut network = StreamNetwork::default();
+        let group = raw_group(&mut network, "deadline");
+        network.claim_group(group);
+        let mut probe = Probe::new(group);
+        probe.deadline = Some(Instant::now() + Duration::from_millis(50));
+
+        let started = std::time::Instant::now();
+        network.drive(Some(Duration::from_secs(5)), &mut [probe.as_service()], |_| {});
+        let waited = started.elapsed();
+
+        assert!(waited >= std::time::Duration::from_millis(40), "{waited:?}");
+        assert!(waited < std::time::Duration::from_secs(1), "{waited:?}");
+    }
+
+    #[test]
+    fn ticks_see_the_time_after_the_poll_wait() {
+        let mut network = StreamNetwork::default();
+        let group = raw_group(&mut network, "waited");
+        network.claim_group(group);
+        let mut probe = Probe::new(group);
+
+        // Nothing is listening and no deadline falls sooner, so the poll waits
+        // the timeout out in full.
+        let timeout = Duration::from_millis(50);
+        let before = Instant::now();
+        network.drive(Some(timeout), &mut [probe.as_service()], |_| {});
+
+        assert_eq!(probe.tick_times.len(), 1, "{:?}", probe.steps);
+        let ticked = probe.tick_times[0];
+        assert!(
+            ticked >= before + timeout,
+            "the tick came {}us into a {}us wait",
+            (ticked - before).as_micros_u64(),
+            timeout.as_micros_u64()
+        );
+    }
+
+    #[test]
+    fn poll_with_never_blocks() {
+        let mut network = StreamNetwork::default();
+        let group = raw_group(&mut network, "raw");
+        network.listen(group, Endpoint::Tcp(unused_addr())).unwrap();
+
+        let started = std::time::Instant::now();
+        network.poll_with(|_| {});
+        assert!(started.elapsed() < std::time::Duration::from_millis(500));
+    }
+
+    #[test]
+    fn a_service_answers_the_bytes_the_network_lends_it() {
+        let mut network = StreamNetwork::default();
+        let group = raw_group(&mut network, "echo");
+        let addr = unused_addr();
+        network.listen(group, Endpoint::Tcp(addr)).unwrap();
+        network.claim_group(group);
+        let mut probe = Probe::new(group);
+        let mut client = StdTcpStream::connect(addr).unwrap();
+        client.write_all(b"ping").unwrap();
+
+        drive_until(&mut network, &mut probe, |probe| {
+            probe.events().contains(&Step::Message(b"ping".to_vec()))
+        });
+
+        let token = probe.accepted().unwrap();
+        assert!(network.send_with(token, |out| out.extend_from_slice(b"pong")));
+        let mut buffer = [0; 4];
+        client.set_nonblocking(false).unwrap();
+        client.set_read_timeout(Some(PATIENCE)).unwrap();
+        client.read_exact(&mut buffer).unwrap();
+        assert_eq!(&buffer, b"pong");
+    }
+}

--- a/crates/flux-network/src/stream/service.rs
+++ b/crates/flux-network/src/stream/service.rs
@@ -36,7 +36,6 @@ pub(crate) mod private {
 pub struct ServiceRef<'a>(&'a mut dyn private::ServiceDriver);
 
 impl<'a> ServiceRef<'a> {
-    #[allow(dead_code, reason = "the services that build a carrier arrive with HttpService")]
     pub(crate) fn new(driver: &'a mut dyn private::ServiceDriver) -> Self {
         Self(driver)
     }

--- a/crates/flux-network/tests/http.rs
+++ b/crates/flux-network/tests/http.rs
@@ -1225,6 +1225,225 @@ fn inline_and_deferred_responses_consume_alike() {
     assert_eq!(cursors_after_two_requests(true), cursors_after_two_requests(false));
 }
 
+/// Serves two pipelined requests, answers the first inline and leaves the
+/// pull, then makes one service access and checks what it reclaimed. The
+/// second request is the larger of the two, which keeps the answered prefix
+/// under half the buffer, so a reclamation without a compaction is legible in
+/// the cursors.
+fn an_inline_answer_reclaims_at(access: impl FnOnce(&mut Http)) {
+    let (mut server, addr) = server();
+    let mut client = std::net::TcpStream::connect(addr).unwrap();
+    client.set_nonblocking(true).unwrap();
+    let first = padded_request("/one", 64);
+    let mut wire = first.clone();
+    wire.extend_from_slice(&padded_request("/two", 192));
+    client.write_all(&wire).unwrap();
+
+    let deadline = Instant::now() + TIMEOUT;
+    let mut answered = None;
+    while Instant::now() < deadline && answered.is_none() {
+        server.drive();
+        while let Some(event) = server.http.next_event(&mut server.net) {
+            if let HttpEvent::Request { token, request, responder } = event {
+                assert_eq!(request.path, "/one");
+                assert!(responder.respond(200, &[], b""));
+                answered = Some(token);
+                break
+            }
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+    let token = answered.expect("no request arrived");
+
+    // The event borrowed the connection, so the answer moved `consumed` and
+    // nothing else: `start` sits where the parse left it and the connection
+    // is out of the ready queue.
+    assert_eq!(server.http.cursors(token), Some((0, first.len(), None)));
+    assert_eq!(server.http.ready_len(), 0);
+
+    access(&mut server);
+
+    let (start, consumed, _) = server.http.cursors(token).expect("the connection went");
+    assert_eq!(start, consumed, "one service access reclaims what the answer consumed");
+    assert_eq!(start, first.len(), "the pipelined request holds off the compaction");
+}
+
+#[test]
+fn an_inline_answer_reclaims_at_the_next_pull() {
+    an_inline_answer_reclaims_at(|server| {
+        // A pull applies the bookkeeping before it parses anything, so the
+        // request behind the answered one is what it delivers.
+        assert!(server.http.next_event(&mut server.net).is_some());
+    });
+}
+
+#[test]
+fn an_inline_answer_reclaims_at_the_next_drive() {
+    an_inline_answer_reclaims_at(|server| {
+        server.drive();
+    });
+}
+
+#[test]
+fn a_by_token_answer_reclaims_before_it_returns() {
+    let (mut server, addr) = server();
+    let mut client = std::net::TcpStream::connect(addr).unwrap();
+    client.set_nonblocking(true).unwrap();
+    let first = padded_request("/one", 64);
+    let mut wire = first.clone();
+    wire.extend_from_slice(&padded_request("/two", 192));
+    client.write_all(&wire).unwrap();
+
+    let (token, path) = pull_deferred_request(&mut server);
+    assert_eq!(path, "/one");
+    // Parsed and owing a response: nothing is consumed, and a connection that
+    // owes a response is never queued.
+    assert_eq!(server.http.cursors(token), Some((0, 0, Some(first.len()))));
+    assert_eq!(server.http.ready_len(), 0);
+
+    assert!(server.respond(token, 200, &[], b""));
+
+    // Nothing borrows the connection, so the answer reclaims and requeues
+    // with no driver call in between.
+    assert_eq!(
+        server.http.cursors(token),
+        Some((first.len(), first.len(), None)),
+        "a by-token answer reclaims what it consumed"
+    );
+    assert_eq!(
+        server.http.ready_len(),
+        1,
+        "the connection is queued for the pipelined request behind the answer"
+    );
+}
+
+/// Serves two pipelined requests, echoing each path back as its body and
+/// answering the first inline or by token, and reports the paths pulled and
+/// every byte the client read.
+fn serve_two_pipelined_requests(inline_first: bool) -> (Vec<String>, Vec<u8>) {
+    let (mut server, addr) = server();
+    let mut client = std::net::TcpStream::connect(addr).unwrap();
+    client.set_nonblocking(true).unwrap();
+    client
+        .write_all(b"GET /one HTTP/1.1\r\nHost: x\r\n\r\nGET /two HTTP/1.1\r\nHost: x\r\n\r\n")
+        .unwrap();
+
+    let deadline = Instant::now() + TIMEOUT;
+    let mut pulled: Vec<String> = Vec::new();
+    let mut received = Vec::new();
+    while Instant::now() < deadline && !received.ends_with(b"/two") {
+        let mut deferred = None;
+        server.drive();
+        while let Some(event) = server.http.next_event(&mut server.net) {
+            if let HttpEvent::Request { token, request, responder } = event {
+                let path = request.path.to_owned();
+                if pulled.is_empty() && !inline_first {
+                    drop(responder);
+                    deferred = Some(token);
+                } else {
+                    assert!(responder.respond(200, &[], path.as_bytes()));
+                }
+                pulled.push(path);
+            }
+        }
+        if let Some(token) = deferred {
+            assert!(server.respond(token, 200, &[], pulled[0].as_bytes()));
+        }
+        read_available(&mut client, &mut received);
+        thread::sleep(Duration::from_millis(1));
+    }
+    (pulled, received)
+}
+
+#[test]
+fn both_answer_paths_write_the_same_responses() {
+    let (inline_paths, inline_bytes) = serve_two_pipelined_requests(true);
+    let (deferred_paths, deferred_bytes) = serve_two_pipelined_requests(false);
+    assert_eq!(inline_paths, ["/one", "/two"], "the requests are served in order");
+    assert_eq!(deferred_paths, inline_paths, "both answer paths pull the same order");
+    assert_eq!(
+        String::from_utf8_lossy(&deferred_bytes),
+        String::from_utf8_lossy(&inline_bytes),
+        "both answer paths put the same bytes on the wire"
+    );
+}
+
+/// Answers the first of two pipelined requests, inline or by token, and
+/// serves the second from what the connection buffered behind it.
+fn serve_the_request_behind_an_answer(inline_first: bool) {
+    let path = if inline_first { "answered inline" } else { "answered by token" };
+    let (mut server, addr) = server();
+    let mut client = std::net::TcpStream::connect(addr).unwrap();
+    client.set_nonblocking(true).unwrap();
+    let mut wire = b"GET /one HTTP/1.1\r\nHost: x\r\n\r\n".to_vec();
+    wire.extend_from_slice(b"POST /two HTTP/1.1\r\nHost: x\r\nContent-Length: 4\r\n\r\nbody");
+    client.write_all(&wire).unwrap();
+
+    let deadline = Instant::now() + TIMEOUT;
+    let mut answered = None;
+    while Instant::now() < deadline && answered.is_none() {
+        let mut deferred = None;
+        server.drive();
+        while let Some(event) = server.http.next_event(&mut server.net) {
+            if let HttpEvent::Request { token, request, responder } = event {
+                assert_eq!(request.path, "/one", "{path}");
+                if inline_first {
+                    assert!(responder.respond(200, &[], b""));
+                } else {
+                    drop(responder);
+                    deferred = Some(token);
+                }
+                answered = Some(token);
+                break
+            }
+        }
+        if let Some(token) = deferred {
+            assert!(server.respond(token, 200, &[], b""));
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+    let token = answered.expect("no request arrived");
+
+    // The answer queues the connection itself, or the driver call that
+    // applies an inline answer's bookkeeping does.
+    while Instant::now() < deadline && server.http.ready_len() == 0 {
+        server.drive();
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(server.http.ready_len(), 1, "the pipelined request is queued: {path}");
+    assert!(server.drive(), "a queued request is work, iteration after iteration: {path}");
+
+    let mut pulled = false;
+    while Instant::now() < deadline && !pulled {
+        while let Some(event) = server.http.next_event(&mut server.net) {
+            if let HttpEvent::Request { request, responder, .. } = event {
+                assert_eq!(request.method, "POST", "{path}");
+                assert_eq!(request.path, "/two", "{path}");
+                assert_eq!(request.body, b"body".as_slice(), "{path}");
+                assert!(responder.respond(200, &[], b""));
+                pulled = true;
+                break
+            }
+        }
+        if !pulled {
+            server.drive();
+            thread::sleep(Duration::from_millis(1));
+        }
+    }
+    assert!(pulled, "the pipelined request was never served: {path}");
+
+    // Both answered and reclaimed, the connection holds nothing and waits.
+    server.drive();
+    assert_eq!(server.http.cursors(token), Some((0, 0, None)), "{path}");
+    assert_eq!(server.http.ready_len(), 0, "{path}");
+}
+
+#[test]
+fn a_pipelined_request_is_served_after_either_answer_path() {
+    serve_the_request_behind_an_answer(true);
+    serve_the_request_behind_an_answer(false);
+}
+
 #[test]
 fn a_refused_second_response_consumes_nothing() {
     let (mut server, addr) = server();

--- a/crates/flux-network/tests/http.rs
+++ b/crates/flux-network/tests/http.rs
@@ -1,22 +1,126 @@
 use std::{
+    collections::BTreeSet,
     io::{self, Read, Write},
     net::{Ipv4Addr, SocketAddr},
+    sync::Mutex,
     thread,
     time::{Duration, Instant},
 };
 
 use flux_network::{
-    http::{HttpEvent, HttpNetwork},
-    stream::{Endpoint, Peer},
+    Token,
+    http::{HttpConfig, HttpEvent, HttpService},
+    stream::{ConnectionGroupConfig, Endpoint, Framing, Peer, StreamEvent, StreamNetwork},
 };
 
 const TIMEOUT: Duration = Duration::from_secs(10);
 
+/// A loopback address no listener holds.
+///
+/// The probe binding is released before the address is handed out, so a port
+/// this run has already given away must never be given away again: the kernel
+/// reuses a released ephemeral port readily, and two tests binding one port is
+/// a failure that has nothing to do with what they test. Ports that collide
+/// stay bound until a fresh one is found, which is what makes the kernel offer
+/// another.
 fn unused_addr() -> SocketAddr {
-    let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-    let addr = listener.local_addr().unwrap();
-    drop(listener);
-    addr
+    static TAKEN: Mutex<BTreeSet<u16>> = Mutex::new(BTreeSet::new());
+    let mut probes = Vec::new();
+    loop {
+        let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let addr = listener.local_addr().unwrap();
+        if TAKEN.lock().unwrap().insert(addr.port()) {
+            return addr;
+        }
+        probes.push(listener);
+        assert!(probes.len() < 64, "no free loopback port");
+    }
+}
+
+fn http_group() -> ConnectionGroupConfig {
+    ConnectionGroupConfig {
+        name: "http",
+        framing: Framing::Raw,
+        max_frame_size: usize::MAX,
+        backlog_warn_bytes: None,
+        ..ConnectionGroupConfig::default()
+    }
+}
+
+/// A network carrying one HTTP service, driven and pulled as one.
+struct Http {
+    net: StreamNetwork,
+    http: HttpService,
+}
+
+impl Http {
+    fn build(group: ConnectionGroupConfig, config: HttpConfig) -> Self {
+        let mut net = StreamNetwork::default();
+        let group = net.add_group(group);
+        let http = HttpService::new(&mut net, group, config);
+        Self { net, http }
+    }
+
+    fn new() -> Self {
+        Self::build(http_group(), HttpConfig::default())
+    }
+
+    fn with_config(config: HttpConfig) -> Self {
+        Self::build(http_group(), config)
+    }
+
+    /// One iteration: drive the network, then pull every protocol event.
+    fn pump(&mut self, mut handler: impl for<'a> FnMut(HttpEvent<'a>)) {
+        self.drive();
+        let mut pulled = 0;
+        while let Some(event) = self.http.next_event(&mut self.net) {
+            handler(event);
+            pulled += 1;
+            assert!(pulled < 10_000, "the pull loop delivered the same work forever");
+        }
+    }
+
+    /// One iteration of the network alone, leaving the events to be pulled.
+    fn drive(&mut self) -> bool {
+        self.net.drive(Some(Duration::ZERO.into()), &mut [self.http.as_service()], |_| {})
+    }
+
+    fn listen(&mut self, endpoint: &Endpoint) {
+        self.http.listen(&mut self.net, endpoint.clone()).unwrap();
+    }
+
+    fn connect(&mut self, endpoint: Endpoint) -> Token {
+        self.http.connect(&mut self.net, endpoint)
+    }
+
+    fn respond(
+        &mut self,
+        token: Token,
+        status: u16,
+        headers: &[(&str, &str)],
+        body: &[u8],
+    ) -> bool {
+        self.http.respond(&mut self.net, token, status, headers, body)
+    }
+
+    fn request(
+        &mut self,
+        token: Token,
+        method: &str,
+        path: &str,
+        headers: &[(&str, &str)],
+        body: &[u8],
+    ) -> bool {
+        self.http.request(&mut self.net, token, method, path, headers, body)
+    }
+
+    fn disconnect(&mut self, token: Token) -> bool {
+        self.http.disconnect(&mut self.net, token)
+    }
+
+    fn remove(&mut self, token: Token) -> bool {
+        self.http.remove(&mut self.net, token)
+    }
 }
 
 /// Runs one test body over both transports: a loopback TCP address on an
@@ -85,13 +189,13 @@ fn response_len(bytes: &[u8]) -> Option<usize> {
     (bytes.len() >= head + length).then_some(head + length)
 }
 
-fn server_at(endpoint: &Endpoint) -> HttpNetwork {
-    let mut server = HttpNetwork::default();
-    server.listen(endpoint.clone()).unwrap();
+fn server_at(endpoint: &Endpoint) -> Http {
+    let mut server = Http::new();
+    server.listen(endpoint);
     server
 }
 
-fn server() -> (HttpNetwork, SocketAddr) {
+fn server() -> (Http, SocketAddr) {
     let addr = unused_addr();
     (server_at(&Endpoint::Tcp(addr)), addr)
 }
@@ -109,8 +213,8 @@ fn get_keepalive_two_requests(endpoint: &Endpoint) {
     client.write_all(b"GET /one HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
     while Instant::now() < deadline && response_len(&first).is_none() {
         let mut replies = Vec::new();
-        server.poll_with(|e| {
-            if let HttpEvent::Request { token, request } = e {
+        server.pump(|e| {
+            if let HttpEvent::Request { token, request, .. } = e {
                 replies.push((
                     token,
                     if request.path == "/one" { b"one".to_vec() } else { b"two".to_vec() },
@@ -128,8 +232,8 @@ fn get_keepalive_two_requests(endpoint: &Endpoint) {
     let mut second = Vec::new();
     while Instant::now() < deadline && response_len(&second).is_none() {
         let mut replies = Vec::new();
-        server.poll_with(|e| {
-            if let HttpEvent::Request { token, request } = e {
+        server.pump(|e| {
+            if let HttpEvent::Request { token, request, .. } = e {
                 replies.push((
                     token,
                     if request.path == "/one" { b"one".to_vec() } else { b"two".to_vec() },
@@ -162,8 +266,8 @@ fn post_echo_body(endpoint: &Endpoint) {
     let deadline = Instant::now() + TIMEOUT;
     while Instant::now() < deadline && response_len(&received).is_none() {
         let mut replies = Vec::new();
-        server.poll_with(|e| {
-            if let HttpEvent::Request { token, request } = e {
+        server.pump(|e| {
+            if let HttpEvent::Request { token, request, .. } = e {
                 replies.push((token, request.body.to_vec()));
             }
         });
@@ -194,8 +298,8 @@ fn post_binary_body_lone_lf() {
     let deadline = Instant::now() + TIMEOUT;
     while Instant::now() < deadline && response_len(&received).is_none() {
         let mut replies = Vec::new();
-        server.poll_with(|e| {
-            if let HttpEvent::Request { token, request } = e {
+        server.pump(|e| {
+            if let HttpEvent::Request { token, request, .. } = e {
                 replies.push((token, request.body.to_vec()));
             }
         });
@@ -212,8 +316,8 @@ fn post_binary_body_lone_lf() {
     let mut second = Vec::new();
     while Instant::now() < deadline && response_len(&second).is_none() {
         let mut replies = Vec::new();
-        server.poll_with(|e| {
-            if let HttpEvent::Request { token, request } = e {
+        server.pump(|e| {
+            if let HttpEvent::Request { token, request, .. } = e {
                 assert_eq!(request.path, "/after");
                 replies.push(token);
             }
@@ -230,8 +334,11 @@ fn post_binary_body_lone_lf() {
 #[test]
 fn connection_close_large_body() {
     let addr = unused_addr();
-    let mut server = HttpNetwork::default().with_socket_buf_size(1024);
-    server.listen(Endpoint::Tcp(addr)).unwrap();
+    let mut server = Http::build(
+        ConnectionGroupConfig { socket_buf_size: Some(1024), ..http_group() },
+        HttpConfig::default(),
+    );
+    server.listen(&Endpoint::Tcp(addr));
     let body = vec![7; 256 * 1024];
     let mut client = std::net::TcpStream::connect(addr).unwrap();
     client.set_nonblocking(true).unwrap();
@@ -240,7 +347,7 @@ fn connection_close_large_body() {
     let deadline = Instant::now() + TIMEOUT;
     while Instant::now() < deadline && !read_available(&mut client, &mut received) {
         let mut tokens = Vec::new();
-        server.poll_with(|e| {
+        server.pump(|e| {
             if let HttpEvent::Request { token, .. } = e {
                 tokens.push(token);
             }
@@ -262,15 +369,17 @@ fn limits_and_errors() {
         (b"POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n".as_slice(), 501),
     ] {
         let addr = unused_addr();
-        let mut server = HttpNetwork::default().with_max_head_bytes(64).with_max_body_bytes(8);
-        server.listen(Endpoint::Tcp(addr)).unwrap();
+        let mut server = Http::with_config(
+            HttpConfig::default().with_max_head_bytes(64).with_max_body_bytes(8),
+        );
+        server.listen(&Endpoint::Tcp(addr));
         let mut client = std::net::TcpStream::connect(addr).unwrap();
         client.set_nonblocking(true).unwrap();
         client.write_all(request).unwrap();
         let mut received = Vec::new();
         let deadline = Instant::now() + TIMEOUT;
         while Instant::now() < deadline && !read_available(&mut client, &mut received) {
-            server.poll_with(|_| {});
+            server.pump(|_| {});
             thread::sleep(Duration::from_millis(1));
         }
         assert!(std::str::from_utf8(&received).unwrap().starts_with(&format!("HTTP/1.1 {status}")));
@@ -287,7 +396,7 @@ fn caller_connection_close_header_sent() {
     let deadline = Instant::now() + TIMEOUT;
     while Instant::now() < deadline && !read_available(&mut client, &mut received) {
         let mut tokens = Vec::new();
-        server.poll_with(|e| {
+        server.pump(|e| {
             if let HttpEvent::Request { token, .. } = e {
                 tokens.push(token);
             }
@@ -317,8 +426,8 @@ fn pipelined_requests(endpoint: &Endpoint) {
     let deadline = Instant::now() + TIMEOUT;
     while Instant::now() < deadline && paths.len() < 2 {
         let mut replies = Vec::new();
-        server.poll_with(|e| {
-            if let HttpEvent::Request { token, request } = e {
+        server.pump(|e| {
+            if let HttpEvent::Request { token, request, .. } = e {
                 paths.push(request.path.to_owned());
                 replies.push(token);
             }
@@ -340,15 +449,15 @@ over_both_transports!(
 );
 fn client_server_roundtrip(endpoint: &Endpoint) {
     let mut server = server_at(endpoint);
-    let mut client = HttpNetwork::default();
+    let mut client = Http::new();
     let token = client.connect(endpoint.clone());
     let mut sent = false;
     let mut bodies = Vec::new();
     let deadline = Instant::now() + TIMEOUT;
     while Instant::now() < deadline && bodies.len() < 2 {
         let mut replies = Vec::new();
-        server.poll_with(|e| {
-            if let HttpEvent::Request { token, request } = e {
+        server.pump(|e| {
+            if let HttpEvent::Request { token, request, .. } = e {
                 replies.push((token, request.body.to_vec()));
             }
         });
@@ -357,7 +466,7 @@ fn client_server_roundtrip(endpoint: &Endpoint) {
         }
         let mut send_second = false;
         let mut connected = false;
-        client.poll_with(|e| match e {
+        client.pump(|e| match e {
             HttpEvent::Connected { .. } => connected = true,
             HttpEvent::Response { response, .. } => {
                 bodies.push(response.body.to_vec());
@@ -388,14 +497,14 @@ fn client_chunked_response() {
         let _ = s.read(&mut b);
         s.write_all(b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n3 \r\nhey\r\n2;ext=x\r\n!!\r\n0\r\nX: y\r\n\r\n").unwrap();
     });
-    let mut client = HttpNetwork::default();
+    let mut client = Http::new();
     let token = client.connect(Endpoint::Tcp(addr));
     let mut sent = false;
     let mut body = None;
     let deadline = Instant::now() + TIMEOUT;
     while Instant::now() < deadline && body.is_none() {
         let mut connected = false;
-        client.poll_with(|e| match e {
+        client.pump(|e| match e {
             HttpEvent::Connected { .. } => connected = true,
             HttpEvent::Response { response, .. } => body = Some(response.body.to_vec()),
             _ => {}
@@ -420,13 +529,13 @@ fn client_head_response_ignores_advisory_content_length() {
         let _ = stream.read(&mut request);
         stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 999999\r\n\r\n").unwrap();
     });
-    let mut client = HttpNetwork::default().with_max_body_bytes(8);
+    let mut client = Http::with_config(HttpConfig::default().with_max_body_bytes(8));
     let token = client.connect(Endpoint::Tcp(addr));
     let deadline = Instant::now() + TIMEOUT;
     let mut connected = false;
     let mut response = None;
     while Instant::now() < deadline && response.is_none() {
-        client.poll_with(|event| match event {
+        client.pump(|event| match event {
             HttpEvent::Connected { token: event_token } if event_token == token => connected = true,
             HttpEvent::Response { token: event_token, response: event_response }
                 if event_token == token =>
@@ -467,7 +576,7 @@ fn client_binary_bodies() {
         .unwrap();
         s.write_all(&plain).unwrap();
     });
-    let mut client = HttpNetwork::default();
+    let mut client = Http::new();
     let token = client.connect(Endpoint::Tcp(addr));
     let mut sent = false;
     let mut bodies = Vec::new();
@@ -475,7 +584,7 @@ fn client_binary_bodies() {
     while Instant::now() < deadline && bodies.len() < 2 {
         let mut connected = false;
         let mut respond_again = false;
-        client.poll_with(|e| match e {
+        client.pump(|e| match e {
             HttpEvent::Connected { .. } => connected = true,
             HttpEvent::Response { response, .. } => {
                 bodies.push(response.body.to_vec());
@@ -499,7 +608,7 @@ fn client_binary_bodies() {
 #[test]
 fn client_reconnect_after_close() {
     let (mut server, addr) = server();
-    let mut client = HttpNetwork::default();
+    let mut client = Http::new();
     let token = client.connect(Endpoint::Tcp(addr));
     let mut connected = 0;
     let mut disconnected = 0;
@@ -507,7 +616,7 @@ fn client_reconnect_after_close() {
     let deadline = Instant::now() + TIMEOUT;
     while Instant::now() < deadline && responses < 2 {
         let mut replies = Vec::new();
-        server.poll_with(|e| {
+        server.pump(|e| {
             if let HttpEvent::Request { token, .. } = e {
                 replies.push(token);
             }
@@ -516,7 +625,7 @@ fn client_reconnect_after_close() {
             server.respond(token, 200, &[("Connection", "close")], b"ok");
         }
         let mut request_again = false;
-        client.poll_with(|e| match e {
+        client.pump(|e| match e {
             HttpEvent::Connected { .. } => {
                 connected += 1;
                 request_again = true;
@@ -565,7 +674,7 @@ fn smuggling_rejected() {
             if accepted { response_len(&received).is_none() } else { !closed }
         {
             let mut replies = Vec::new();
-            server.poll_with(|event| {
+            server.pump(|event| {
                 if let HttpEvent::Request { token, .. } = event {
                     requests += 1;
                     replies.push(token);
@@ -597,7 +706,7 @@ fn bare_lf_head_rejected() {
     let mut received = Vec::new();
     let mut closed = false;
     while Instant::now() < deadline && !closed {
-        server.poll_with(|_| {});
+        server.pump(|_| {});
         closed = read_available(&mut client, &mut received);
         thread::sleep(Duration::from_millis(1));
     }
@@ -614,14 +723,14 @@ fn assert_chunked_response_disconnect(response: &'static [u8], max_headers: usiz
         let _ = stream.read(&mut request);
         stream.write_all(response).unwrap();
     });
-    let mut client = HttpNetwork::default().with_max_headers(max_headers);
+    let mut client = Http::with_config(HttpConfig::default().with_max_headers(max_headers));
     let token = client.connect(Endpoint::Tcp(addr));
     let deadline = Instant::now() + TIMEOUT;
     let mut sent = false;
     let mut disconnected = 0;
     while Instant::now() < deadline && disconnected == 0 {
         let mut connected = false;
-        client.poll_with(|event| match event {
+        client.pump(|event| match event {
             HttpEvent::Connected { .. } => connected = true,
             HttpEvent::Disconnected { token: event_token } if event_token == token => {
                 disconnected += 1;
@@ -664,14 +773,14 @@ fn client_chunked_overflow() {
             let _ = stream.read(&mut request);
             stream.write_all(response).unwrap();
         });
-        let mut client = HttpNetwork::default().with_max_body_bytes(16);
+        let mut client = Http::with_config(HttpConfig::default().with_max_body_bytes(16));
         let token = client.connect(Endpoint::Tcp(addr));
         let deadline = Instant::now() + TIMEOUT;
         let mut sent = false;
         let mut disconnected = 0;
         while Instant::now() < deadline && disconnected == 0 {
             let mut connected = false;
-            client.poll_with(|event| match event {
+            client.pump(|event| match event {
                 HttpEvent::Connected { .. } => connected = true,
                 HttpEvent::Disconnected { token: event_token } if event_token == token => {
                     disconnected += 1;
@@ -692,15 +801,17 @@ fn client_chunked_overflow() {
 #[test]
 fn idle_timeout_disconnects() {
     let addr = unused_addr();
-    let mut server = HttpNetwork::default().with_idle_timeout(Duration::from_millis(200).into());
-    server.listen(Endpoint::Tcp(addr)).unwrap();
+    let mut server = Http::with_config(
+        HttpConfig::default().with_idle_timeout(Duration::from_millis(200).into()),
+    );
+    server.listen(&Endpoint::Tcp(addr));
     let mut client = std::net::TcpStream::connect(addr).unwrap();
     client.set_nonblocking(true).unwrap();
     let deadline = Instant::now() + Duration::from_secs(2);
     let mut bytes = Vec::new();
     let mut closed = false;
     while Instant::now() < deadline && !closed {
-        server.poll_with(|_| {});
+        server.pump(|_| {});
         closed = read_available(&mut client, &mut bytes);
         thread::sleep(Duration::from_millis(1));
     }
@@ -713,7 +824,7 @@ fn idle_timeout_disconnects() {
     let mut response = Vec::new();
     while Instant::now() < deadline && response_len(&response).is_none() {
         let mut replies = Vec::new();
-        server.poll_with(|event| {
+        server.pump(|event| {
             if let HttpEvent::Request { token, .. } = event {
                 replies.push(token);
             }
@@ -728,7 +839,7 @@ fn idle_timeout_disconnects() {
     let deadline = Instant::now() + Duration::from_secs(2);
     let mut closed = false;
     while Instant::now() < deadline && !closed {
-        server.poll_with(|_| {});
+        server.pump(|_| {});
         closed = read_available(&mut client, &mut response);
         thread::sleep(Duration::from_millis(1));
     }
@@ -738,15 +849,16 @@ fn idle_timeout_disconnects() {
 #[test]
 fn pending_buffer_cap_disconnects() {
     let addr = unused_addr();
-    let mut server = HttpNetwork::default().with_max_head_bytes(64).with_max_body_bytes(64);
-    server.listen(Endpoint::Tcp(addr)).unwrap();
+    let mut server =
+        Http::with_config(HttpConfig::default().with_max_head_bytes(64).with_max_body_bytes(64));
+    server.listen(&Endpoint::Tcp(addr));
     let mut client = std::net::TcpStream::connect(addr).unwrap();
     client.set_nonblocking(true).unwrap();
     client.write_all(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
     let deadline = Instant::now() + TIMEOUT;
     let mut accepted = false;
     while Instant::now() < deadline && !accepted {
-        server.poll_with(|event| accepted |= matches!(event, HttpEvent::Request { .. }));
+        server.pump(|event| accepted |= matches!(event, HttpEvent::Request { .. }));
         thread::sleep(Duration::from_millis(1));
     }
     assert!(accepted);
@@ -754,7 +866,7 @@ fn pending_buffer_cap_disconnects() {
     let mut received = Vec::new();
     let mut closed = false;
     while Instant::now() < deadline && !closed {
-        server.poll_with(|_| {});
+        server.pump(|_| {});
         closed = read_available(&mut client, &mut received);
         thread::sleep(Duration::from_millis(1));
     }
@@ -784,8 +896,8 @@ fn pipelined_binary_bodies() {
     let mut received = Vec::new();
     while Instant::now() < deadline && replies.len() < 2 {
         let mut pending = Vec::new();
-        server.poll_with(|event| {
-            if let HttpEvent::Request { token, request } = event {
+        server.pump(|event| {
+            if let HttpEvent::Request { token, request, .. } = event {
                 pending.push((token, request.body.to_vec()));
             }
         });
@@ -806,13 +918,13 @@ fn pipelined_binary_bodies() {
 #[test]
 fn client_remove_stops_reconnect() {
     let (mut server, addr) = server();
-    let mut client = HttpNetwork::default();
+    let mut client = Http::new();
     let token = client.connect(Endpoint::Tcp(addr));
     let deadline = Instant::now() + TIMEOUT;
     let mut connected = false;
     while Instant::now() < deadline && !connected {
-        server.poll_with(|_| {});
-        client.poll_with(|event| connected |= matches!(event, HttpEvent::Connected { token: event_token } if event_token == token));
+        server.pump(|_| {});
+        client.pump(|event| connected |= matches!(event, HttpEvent::Connected { token: event_token } if event_token == token));
         thread::sleep(Duration::from_millis(1));
     }
     assert!(connected);
@@ -821,8 +933,8 @@ fn client_remove_stops_reconnect() {
     let deadline = Instant::now() + Duration::from_millis(500);
     let mut reconnects = 0;
     while Instant::now() < deadline {
-        server.poll_with(|_| {});
-        client.poll_with(|event| {
+        server.pump(|_| {});
+        client.pump(|event| {
             if matches!(event, HttpEvent::Connected { token: event_token } if event_token == token)
             {
                 reconnects += 1;
@@ -841,7 +953,7 @@ fn server_disconnect_kicks() {
     let deadline = Instant::now() + TIMEOUT;
     let mut token = None;
     while Instant::now() < deadline && token.is_none() {
-        server.poll_with(|event| {
+        server.pump(|event| {
             if let HttpEvent::Accepted { token: connected, .. } = event {
                 token = Some(connected);
             }
@@ -854,7 +966,7 @@ fn server_disconnect_kicks() {
     let mut closed = false;
     let mut disconnected = 0;
     while Instant::now() < deadline && (!closed || disconnected == 0) {
-        server.poll_with(|event| {
+        server.pump(|event| {
             if matches!(event, HttpEvent::Disconnected { token: event_token } if event_token == token) {
                 disconnected += 1;
             }
@@ -869,15 +981,15 @@ fn server_disconnect_kicks() {
 #[test]
 fn wrong_role_calls_return_false() {
     let addr = unused_addr();
-    let mut http = HttpNetwork::default();
-    http.listen(Endpoint::Tcp(addr)).unwrap();
+    let mut http = Http::new();
+    http.listen(&Endpoint::Tcp(addr));
     let outbound = http.connect(Endpoint::Tcp(addr));
     let stream = std::net::TcpStream::connect(addr).unwrap();
     stream.set_nonblocking(true).unwrap();
     let deadline = Instant::now() + TIMEOUT;
     let mut accepted = None;
     while Instant::now() < deadline && accepted.is_none() {
-        http.poll_with(|event| {
+        http.pump(|event| {
             if let HttpEvent::Accepted { token, .. } = event {
                 accepted = Some(token);
             }
@@ -891,8 +1003,8 @@ fn wrong_role_calls_return_false() {
 #[test]
 fn single_instance_serves_itself() {
     let addr = unused_addr();
-    let mut http = HttpNetwork::default();
-    http.listen(Endpoint::Tcp(addr)).unwrap();
+    let mut http = Http::new();
+    http.listen(&Endpoint::Tcp(addr));
     let outbound = http.connect(Endpoint::Tcp(addr));
     let deadline = Instant::now() + TIMEOUT;
     let mut sent = false;
@@ -900,7 +1012,7 @@ fn single_instance_serves_itself() {
     while Instant::now() < deadline && body.is_none() {
         let mut respond = None;
         let mut request = false;
-        http.poll_with(|event| match event {
+        http.pump(|event| match event {
             HttpEvent::Connected { token } if token == outbound => request = true,
             HttpEvent::Request { token, .. } => respond = Some(token),
             HttpEvent::Response { token, response } if token == outbound => {
@@ -927,15 +1039,15 @@ over_both_transports!(
 );
 fn outbound_host_header_names_the_endpoint(endpoint: &Endpoint) {
     let mut server = server_at(endpoint);
-    let mut client = HttpNetwork::default();
+    let mut client = Http::new();
     let token = client.connect(endpoint.clone());
     let mut sent = false;
     let mut host = None;
     let deadline = Instant::now() + TIMEOUT;
     while Instant::now() < deadline && host.is_none() {
         let mut replies = Vec::new();
-        server.poll_with(|event| {
-            if let HttpEvent::Request { token, request } = event {
+        server.pump(|event| {
+            if let HttpEvent::Request { token, request, .. } = event {
                 host = Some(request.header("Host").map(<[u8]>::to_vec));
                 replies.push(token);
             }
@@ -944,7 +1056,7 @@ fn outbound_host_header_names_the_endpoint(endpoint: &Endpoint) {
             assert!(server.respond(token, 200, &[], b""));
         }
         let mut connected = false;
-        client.poll_with(|event| connected |= matches!(event, HttpEvent::Connected { .. }));
+        client.pump(|event| connected |= matches!(event, HttpEvent::Connected { .. }));
         if connected && !sent {
             assert!(client.request(token, "GET", "/", &[], b""));
             sent = true;
@@ -967,7 +1079,7 @@ fn accepted_reports_peer(endpoint: &Endpoint) {
     let mut accepted = None;
     let deadline = Instant::now() + TIMEOUT;
     while Instant::now() < deadline && accepted.is_none() {
-        server.poll_with(|event| {
+        server.pump(|event| {
             if let HttpEvent::Accepted { peer, .. } = event {
                 accepted = Some(peer);
             }
@@ -978,4 +1090,793 @@ fn accepted_reports_peer(endpoint: &Endpoint) {
         Endpoint::Tcp(_) => assert!(matches!(accepted, Some(Peer::Tcp(_))), "{accepted:?}"),
         Endpoint::Unix(_) => assert_eq!(accepted, Some(Peer::Unix)),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Responder, consumption and readiness
+
+/// Pulls events until one request has been delivered, returning its token and
+/// what it said. The responder is dropped, which defers the response.
+fn pull_deferred_request(server: &mut Http) -> (Token, String) {
+    let deadline = Instant::now() + TIMEOUT;
+    let mut request = None;
+    while Instant::now() < deadline && request.is_none() {
+        server.pump(|event| {
+            if let HttpEvent::Request { token, request: pulled, responder } = event {
+                request = Some((token, pulled.path.to_owned()));
+                drop(responder);
+            }
+        });
+        thread::sleep(Duration::from_millis(1));
+    }
+    request.expect("no request arrived")
+}
+
+fn read_until_response(server: &mut Http, client: &mut impl Read, out: &mut Vec<u8>) {
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && response_len(out).is_none() {
+        server.pump(|_| {});
+        read_available(client, out);
+        thread::sleep(Duration::from_millis(1));
+    }
+}
+
+#[test]
+fn a_dropped_responder_answers_later_by_token() {
+    let (mut server, addr) = server();
+    let mut client = std::net::TcpStream::connect(addr).unwrap();
+    client.set_nonblocking(true).unwrap();
+    client.write_all(b"GET /defer HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
+
+    let (token, path) = pull_deferred_request(&mut server);
+    assert_eq!(path, "/defer");
+    let mut received = Vec::new();
+    read_available(&mut client, &mut received);
+    assert!(received.is_empty(), "a dropped responder answers nothing by itself");
+
+    assert!(server.respond(token, 200, &[], b"late"));
+    read_until_response(&mut server, &mut client, &mut received);
+    assert!(received.ends_with(b"late"), "{received:?}");
+}
+
+#[test]
+fn a_pipelined_request_waits_for_the_pending_response() {
+    let (mut server, addr) = server();
+    let mut client = std::net::TcpStream::connect(addr).unwrap();
+    client.set_nonblocking(true).unwrap();
+    client
+        .write_all(b"GET /one HTTP/1.1\r\nHost: x\r\n\r\nGET /two HTTP/1.1\r\nHost: x\r\n\r\n")
+        .unwrap();
+
+    let (token, path) = pull_deferred_request(&mut server);
+    assert_eq!(path, "/one");
+
+    let mut paths = Vec::new();
+    for _ in 0..20 {
+        server.pump(|event| {
+            if let HttpEvent::Request { request, .. } = event {
+                paths.push(request.path.to_owned());
+            }
+        });
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert!(paths.is_empty(), "one request in flight per connection: {paths:?}");
+    assert_eq!(server.http.ready_len(), 0, "a connection owing a response is never queued");
+
+    assert!(server.respond(token, 200, &[], b"one"));
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && paths.is_empty() {
+        let mut replies = Vec::new();
+        server.pump(|event| {
+            if let HttpEvent::Request { token, request, .. } = event {
+                paths.push(request.path.to_owned());
+                replies.push(token);
+            }
+        });
+        for token in replies {
+            assert!(server.respond(token, 200, &[], b"two"));
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(paths, ["/two"]);
+}
+
+/// Serves two pipelined requests, answering the first inline or by token, and
+/// reports the cursors left once the second request has been pulled.
+fn cursors_after_two_requests(inline: bool) -> (usize, usize, Option<usize>) {
+    let (mut server, addr) = server();
+    let mut client = std::net::TcpStream::connect(addr).unwrap();
+    client.set_nonblocking(true).unwrap();
+    client
+        .write_all(b"GET /one HTTP/1.1\r\nHost: x\r\n\r\nGET /two HTTP/1.1\r\nHost: x\r\n\r\n")
+        .unwrap();
+
+    let deadline = Instant::now() + TIMEOUT;
+    let mut answered = None;
+    let mut second = None;
+    while Instant::now() < deadline && second.is_none() {
+        let mut deferred = None;
+        server.pump(|event| {
+            if let HttpEvent::Request { token, request, responder } = event {
+                if answered.is_none() {
+                    assert_eq!(request.path, "/one");
+                    if inline {
+                        assert!(responder.respond(200, &[], b"one"));
+                    } else {
+                        deferred = Some(token);
+                    }
+                    answered = Some(token);
+                } else {
+                    assert_eq!(request.path, "/two");
+                    second = Some(token);
+                }
+            }
+        });
+        if let Some(token) = deferred {
+            assert!(server.respond(token, 200, &[], b"one"));
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+    server.http.cursors(second.expect("the second request never arrived")).unwrap()
+}
+
+#[test]
+fn inline_and_deferred_responses_consume_alike() {
+    assert_eq!(cursors_after_two_requests(true), cursors_after_two_requests(false));
+}
+
+#[test]
+fn a_refused_second_response_consumes_nothing() {
+    let (mut server, addr) = server();
+    let mut client = std::net::TcpStream::connect(addr).unwrap();
+    client.set_nonblocking(true).unwrap();
+    client.write_all(b"GET /once HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
+
+    let (token, _) = pull_deferred_request(&mut server);
+    assert!(server.respond(token, 200, &[], b"first"));
+    let answered = server.http.cursors(token).unwrap();
+    assert!(!server.respond(token, 200, &[], b"second"), "a request is answered once");
+    assert_eq!(server.http.cursors(token).unwrap(), answered);
+
+    let mut received = Vec::new();
+    read_until_response(&mut server, &mut client, &mut received);
+    assert_eq!(received.windows(5).filter(|w| *w == b"first").count(), 1);
+    assert_eq!(received.windows(6).filter(|w| *w == b"second").count(), 0);
+}
+
+#[test]
+fn answered_bytes_cost_the_connection_nothing() {
+    let addr = unused_addr();
+    // Two of these requests together outgrow the limit; one at a time does
+    // not, and an answered one costs nothing even before it is reclaimed.
+    let mut server =
+        Http::with_config(HttpConfig::default().with_max_head_bytes(64).with_max_body_bytes(0));
+    server.listen(&Endpoint::Tcp(addr));
+    let mut client = std::net::TcpStream::connect(addr).unwrap();
+    client.set_nonblocking(true).unwrap();
+    let request = padded_request("/first", 60);
+    client.write_all(&request).unwrap();
+
+    // Answer inline and stop pulling, which leaves the answered bytes in the
+    // buffer with nothing reclaimed.
+    let deadline = Instant::now() + TIMEOUT;
+    let mut token = None;
+    while Instant::now() < deadline && token.is_none() {
+        server.drive();
+        while let Some(event) = server.http.next_event(&mut server.net) {
+            if let HttpEvent::Request { token: pulled, responder, .. } = event {
+                assert!(responder.respond(200, &[], b""));
+                token = Some(pulled);
+                break
+            }
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+    let token = token.expect("no request arrived");
+    assert_eq!(server.http.cursors(token), Some((0, request.len(), None)));
+
+    // The next request arrives before the pull that would reclaim them.
+    client.write_all(&padded_request("/second", 60)).unwrap();
+    while Instant::now() < deadline && server.http.ready_len() == 0 {
+        server.drive();
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    let mut paths = Vec::new();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline && paths.is_empty() {
+        let mut replies = Vec::new();
+        server.pump(|event| {
+            if let HttpEvent::Request { token, request, .. } = event {
+                paths.push(request.path.to_owned());
+                replies.push(token);
+            }
+        });
+        for token in replies {
+            assert!(server.respond(token, 200, &[], b""));
+        }
+        let mut received = Vec::new();
+        assert!(!read_available(&mut client, &mut received), "the connection stayed open");
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(paths, ["/second"]);
+}
+
+/// A request of exactly `size` bytes, padded out with a header.
+fn padded_request(path: &str, size: usize) -> Vec<u8> {
+    let mut request = Vec::new();
+    write!(request, "GET {path} HTTP/1.1\r\nX-Pad: \r\n\r\n").unwrap();
+    let pad = size.checked_sub(request.len()).expect("the request outgrew its size");
+    let mut request = Vec::new();
+    write!(request, "GET {path} HTTP/1.1\r\nX-Pad: {}\r\n\r\n", "p".repeat(pad)).unwrap();
+    assert_eq!(request.len(), size);
+    request
+}
+
+#[test]
+fn a_pending_request_survives_a_compaction() {
+    let addr = unused_addr();
+    let mut server =
+        Http::with_config(HttpConfig::default().with_max_head_bytes(256).with_max_body_bytes(0));
+    server.listen(&Endpoint::Tcp(addr));
+    let mut client = std::net::TcpStream::connect(addr).unwrap();
+    client.set_nonblocking(true).unwrap();
+    let mut pipelined = Vec::new();
+    for path in ["/one", "/two", "/three"] {
+        pipelined.extend_from_slice(&padded_request(path, 64));
+    }
+    client.write_all(&pipelined).unwrap();
+
+    // Answer the first request and leave the second one pending, so that the
+    // buffer holds an answered prefix, an unanswered request, and a third
+    // request behind it.
+    let deadline = Instant::now() + TIMEOUT;
+    let mut pulled = Vec::new();
+    let mut pending = None;
+    while Instant::now() < deadline && pulled.len() < 2 {
+        server.drive();
+        while pulled.len() < 2 {
+            let Some(event) = server.http.next_event(&mut server.net) else { break };
+            if let HttpEvent::Request { token, request, responder } = event {
+                pulled.push(request.path.to_owned());
+                if pulled.len() == 1 {
+                    assert!(responder.respond(200, &[], b""));
+                } else {
+                    pending = Some(token);
+                }
+            }
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(pulled, ["/one", "/two"]);
+    let pending = pending.unwrap();
+    assert_eq!(server.http.cursors(pending), Some((64, 64, Some(128))));
+
+    // A fourth request would outgrow the limit, so the answered prefix goes
+    // and every cursor moves down with it, the pending request included.
+    client.write_all(&padded_request("/four", 96)).unwrap();
+    while Instant::now() < deadline && server.http.cursors(pending) != Some((0, 0, Some(64))) {
+        server.drive();
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(
+        server.http.cursors(pending),
+        Some((0, 0, Some(64))),
+        "the cursors were not rebased"
+    );
+
+    assert!(server.respond(pending, 200, &[], b""));
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline && pulled.len() < 4 {
+        let mut replies = Vec::new();
+        server.pump(|event| {
+            if let HttpEvent::Request { token, request, .. } = event {
+                pulled.push(request.path.to_owned());
+                replies.push(token);
+            }
+        });
+        for token in replies {
+            assert!(server.respond(token, 200, &[], b""));
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(pulled, ["/one", "/two", "/three", "/four"]);
+}
+
+#[test]
+fn pipelined_requests_stay_ranged_across_a_compaction() {
+    let (mut server, addr) = server();
+    let mut client = std::net::TcpStream::connect(addr).unwrap();
+    client.set_nonblocking(true).unwrap();
+    let mut wire = Vec::new();
+    for index in 0..3 {
+        write!(
+            wire,
+            "POST /path-{index} HTTP/1.1\r\nHost: x\r\nX-Index: {index}\r\nContent-Length: 5\r\n\r\nbody{index}"
+        )
+        .unwrap();
+    }
+    let one = wire.len() / 3;
+    client.write_all(&wire).unwrap();
+
+    let mut seen = Vec::new();
+    let mut compacted = false;
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && seen.len() < 3 {
+        let mut replies = Vec::new();
+        server.pump(|event| {
+            if let HttpEvent::Request { token, request, .. } = event {
+                seen.push((
+                    request.method.to_owned(),
+                    request.path.to_owned(),
+                    request.header("x-index").map(<[u8]>::to_vec),
+                    request.body.to_vec(),
+                ));
+                replies.push(token);
+            }
+        });
+        for token in replies {
+            // The third request is parsed from a buffer whose answered prefix
+            // has been dropped: its cursors are rebased onto what is left.
+            if seen.len() == 3 {
+                assert_eq!(server.http.cursors(token), Some((0, 0, Some(one))));
+                compacted = true;
+            }
+            assert!(server.respond(token, 200, &[], b"ok"));
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    assert!(compacted, "the buffer never compacted");
+    for (index, (method, path, header, body)) in seen.iter().enumerate() {
+        assert_eq!(method, "POST");
+        assert_eq!(path, &format!("/path-{index}"));
+        assert_eq!(header.as_deref(), Some(index.to_string().as_bytes()));
+        assert_eq!(body, format!("body{index}").as_bytes());
+    }
+}
+
+#[test]
+fn a_caller_may_stop_pulling_and_resume_later() {
+    let (mut server, addr) = server();
+    let mut first = std::net::TcpStream::connect(addr).unwrap();
+    let mut second = std::net::TcpStream::connect(addr).unwrap();
+    first.set_nonblocking(true).unwrap();
+    second.set_nonblocking(true).unwrap();
+    first.write_all(b"GET /first HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
+    second.write_all(b"GET /second HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
+
+    // Stop after the first request of the iteration, leaving the rest queued.
+    let deadline = Instant::now() + TIMEOUT;
+    let mut deferred = None;
+    while Instant::now() < deadline && deferred.is_none() {
+        server.drive();
+        if let Some(HttpEvent::Request { token, .. }) = server.http.next_event(&mut server.net) {
+            deferred = Some(token);
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+    let deferred = deferred.expect("no request arrived");
+
+    // The next iteration delivers what was left, and the deferred response is
+    // still available.
+    let mut paths = Vec::new();
+    while Instant::now() < deadline && paths.is_empty() {
+        let mut replies = Vec::new();
+        server.pump(|event| {
+            if let HttpEvent::Request { token, request, .. } = event {
+                paths.push(request.path.to_owned());
+                replies.push(token);
+            }
+        });
+        for token in replies {
+            assert!(server.respond(token, 200, &[], b"ok"));
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(paths.len(), 1, "the un-pulled request survived the iteration: {paths:?}");
+    assert!(server.respond(deferred, 200, &[], b"resumed"));
+
+    let mut received = Vec::new();
+    let mut peer = if paths[0] == "/first" { second } else { first };
+    read_until_response(&mut server, &mut peer, &mut received);
+    assert!(received.ends_with(b"resumed"), "{received:?}");
+}
+
+#[test]
+fn two_reads_queue_one_ready_connection() {
+    let (mut server, addr) = server();
+    let mut client = std::net::TcpStream::connect(addr).unwrap();
+    client.set_nonblocking(true).unwrap();
+    client.write_all(b"GET /split HTTP/1.1\r\n").unwrap();
+
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && server.http.ready_len() == 0 {
+        server.drive();
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(server.http.ready_len(), 1);
+
+    client.write_all(b"Host: x\r\n\r\n").unwrap();
+    let mut drives = 0;
+    while Instant::now() < deadline && drives < 20 {
+        server.drive();
+        assert_eq!(server.http.ready_len(), 1, "one entry however many reads arrive");
+        drives += 1;
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    let mut path = None;
+    server.pump(|event| {
+        if let HttpEvent::Request { request, responder, .. } = event {
+            path = Some(request.path.to_owned());
+            assert!(responder.respond(200, &[], b"ok"));
+        }
+    });
+    assert_eq!(path.as_deref(), Some("/split"));
+    assert_eq!(server.http.ready_len(), 0);
+}
+
+#[test]
+fn a_pending_request_reports_work_and_holds_off_the_sweep() {
+    let addr = unused_addr();
+    let mut server = Http::with_config(
+        HttpConfig::default().with_idle_timeout(Duration::from_millis(200).into()),
+    );
+    server.listen(&Endpoint::Tcp(addr));
+    let mut client = std::net::TcpStream::connect(addr).unwrap();
+    client.set_nonblocking(true).unwrap();
+    client.write_all(b"GET /slow HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
+
+    let deadline = Instant::now() + TIMEOUT;
+    let mut arrived = false;
+    while Instant::now() < deadline && !arrived {
+        arrived = server.drive();
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert!(arrived, "the client never reached the server");
+    // An event nobody pulled is work, iteration after iteration.
+    assert!(server.drive(), "un-pulled events must keep the caller awake");
+
+    let mut token = None;
+    while Instant::now() < deadline && token.is_none() {
+        server.drive();
+        while let Some(event) = server.http.next_event(&mut server.net) {
+            if let HttpEvent::Request { token: pulled, .. } = event {
+                token = Some(pulled);
+                break
+            }
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+    let token = token.expect("no request arrived");
+
+    // Inbound bytes keep resetting the idle sweep while the response is owed.
+    let until = Instant::now() + Duration::from_millis(600);
+    let mut bytes = Vec::new();
+    while Instant::now() < until {
+        client.write_all(b"X").unwrap();
+        server.pump(|_| {});
+        assert!(!read_available(&mut client, &mut bytes), "the sweep took a busy connection");
+        thread::sleep(Duration::from_millis(20));
+    }
+    assert!(server.respond(token, 200, &[], b"ok"));
+}
+
+#[test]
+fn work_is_reported_after_an_inline_answer_stops_the_pull() {
+    let (mut server, addr) = server();
+    let mut client = std::net::TcpStream::connect(addr).unwrap();
+    client.set_nonblocking(true).unwrap();
+    client
+        .write_all(b"GET /one HTTP/1.1\r\nHost: x\r\n\r\nGET /two HTTP/1.1\r\nHost: x\r\n\r\n")
+        .unwrap();
+
+    // Answer the first request inline and stop pulling, which leaves the
+    // pipelined one behind it to be picked up by the tick.
+    let deadline = Instant::now() + TIMEOUT;
+    let mut answered = false;
+    while Instant::now() < deadline && !answered {
+        server.drive();
+        while let Some(event) = server.http.next_event(&mut server.net) {
+            if let HttpEvent::Request { request, responder, .. } = event {
+                assert_eq!(request.path, "/one");
+                assert!(responder.respond(200, &[], b"one"));
+                answered = true;
+                break
+            }
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert!(answered, "no request arrived");
+
+    assert!(server.drive(), "the request behind the answered one is work");
+    match server.http.next_event(&mut server.net) {
+        Some(HttpEvent::Request { request, responder, .. }) => {
+            assert_eq!(request.path, "/two");
+            assert!(responder.respond(200, &[], b"two"));
+        }
+        _ => panic!("the pipelined request was not delivered"),
+    }
+}
+
+#[test]
+fn a_blocking_drive_wakes_for_the_idle_sweep() {
+    let addr = unused_addr();
+    let mut server = Http::with_config(
+        HttpConfig::default().with_idle_timeout(Duration::from_millis(500).into()),
+    );
+    server.listen(&Endpoint::Tcp(addr));
+    let _client = std::net::TcpStream::connect(addr).unwrap();
+    let deadline = Instant::now() + TIMEOUT;
+    let mut accepted = false;
+    while Instant::now() < deadline && !accepted {
+        server.pump(|event| accepted |= matches!(event, HttpEvent::Accepted { .. }));
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert!(accepted, "the client was never accepted");
+
+    // The sweep of that connection is the only deadline the network has, so
+    // an uncapped drive waits for it and no longer. The late connection is
+    // the test's own deadline: a drive that ignored the sweep would wake on
+    // it instead, well past the bound below, rather than hang.
+    thread::spawn(move || {
+        thread::sleep(Duration::from_secs(3));
+        drop(std::net::TcpStream::connect(addr));
+    });
+    let started = Instant::now();
+    server.net.drive(None, &mut [server.http.as_service()], |_| {});
+    let waited = started.elapsed();
+    assert!(waited >= Duration::from_millis(100), "returned at once: {waited:?}");
+    assert!(waited < Duration::from_secs(2), "the sweep deadline was not folded: {waited:?}");
+}
+
+#[test]
+fn a_blocking_drive_wakes_for_a_connection() {
+    let addr = unused_addr();
+    let mut server = Http::with_config(HttpConfig::default().without_idle_timeout());
+    server.listen(&Endpoint::Tcp(addr));
+
+    // Nothing is due, so an uncapped drive blocks until a client arrives. The
+    // second connection is the test's own deadline: it wakes the poll even if
+    // the first one never lands, so a regression fails instead of hanging.
+    thread::spawn(move || {
+        thread::sleep(Duration::from_millis(200));
+        let early = std::net::TcpStream::connect(addr);
+        thread::sleep(Duration::from_secs(3));
+        let late = std::net::TcpStream::connect(addr);
+        drop((early, late));
+    });
+    let started = Instant::now();
+    let worked = server.net.drive(None, &mut [server.http.as_service()], |_| {});
+    let waited = started.elapsed();
+    assert!(worked, "an accepted connection is work");
+    assert!(waited >= Duration::from_millis(150), "the drive did not block: {waited:?}");
+    assert!(waited < Duration::from_secs(2), "the drive missed the connection: {waited:?}");
+
+    let mut accepted = false;
+    while let Some(event) = server.http.next_event(&mut server.net) {
+        accepted |= matches!(event, HttpEvent::Accepted { .. });
+    }
+    assert!(accepted, "the connection that woke the poll was not delivered");
+}
+
+#[test]
+fn a_request_from_a_client_that_left_is_dropped() {
+    let (mut server, addr) = server();
+    let mut client = std::net::TcpStream::connect(addr).unwrap();
+    client.write_all(b"GET /gone HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
+    client.shutdown(std::net::Shutdown::Both).unwrap();
+    drop(client);
+    // The request and the end of stream are both queued before the server
+    // reads, so one iteration sees the whole story.
+    thread::sleep(Duration::from_millis(50));
+
+    let mut order = Vec::new();
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && !order.contains(&"disconnected") {
+        server.pump(|event| {
+            order.push(match event {
+                HttpEvent::Accepted { .. } => "accepted",
+                HttpEvent::Request { .. } => "request",
+                HttpEvent::Disconnected { .. } => "disconnected",
+                _ => "other",
+            });
+        });
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(order, ["accepted", "disconnected"], "a request nobody can answer was delivered");
+}
+
+#[test]
+#[should_panic(expected = "drive the network with StreamNetwork::drive")]
+fn polling_a_network_that_has_services_is_refused() {
+    let mut net = StreamNetwork::default();
+    let group = net.add_group(http_group());
+    let _http = HttpService::new(&mut net, group, HttpConfig::default());
+    net.poll_with(|_| {});
+}
+
+#[test]
+fn an_accepted_connection_is_announced_before_its_first_request() {
+    let (mut server, addr) = server();
+    let mut client = std::net::TcpStream::connect(addr).unwrap();
+    client.set_nonblocking(true).unwrap();
+    client.write_all(b"GET /first HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
+
+    let mut order = Vec::new();
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && order.len() < 2 {
+        let mut replies = Vec::new();
+        server.pump(|event| match event {
+            HttpEvent::Accepted { .. } => order.push("accepted"),
+            HttpEvent::Request { token, .. } => {
+                order.push("request");
+                replies.push(token);
+            }
+            _ => {}
+        });
+        for token in replies {
+            assert!(server.respond(token, 200, &[], b"ok"));
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(order, ["accepted", "request"]);
+}
+
+#[test]
+fn two_services_on_one_network_keep_their_own_events() {
+    let mut net = StreamNetwork::default();
+    let first_group = net.add_group(ConnectionGroupConfig { name: "first", ..http_group() });
+    let second_group = net.add_group(ConnectionGroupConfig { name: "second", ..http_group() });
+    let mut first = HttpService::new(&mut net, first_group, HttpConfig::default());
+    let mut second = HttpService::new(&mut net, second_group, HttpConfig::default());
+    let first_addr = unused_addr();
+    let second_addr = unused_addr();
+    first.listen(&mut net, Endpoint::Tcp(first_addr)).unwrap();
+    second.listen(&mut net, Endpoint::Tcp(second_addr)).unwrap();
+
+    let mut to_first = std::net::TcpStream::connect(first_addr).unwrap();
+    let mut to_second = std::net::TcpStream::connect(second_addr).unwrap();
+    to_first.write_all(b"GET /first HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
+    to_second.write_all(b"GET /second HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
+
+    let mut first_paths = Vec::new();
+    let mut second_paths = Vec::new();
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && (first_paths.is_empty() || second_paths.is_empty()) {
+        net.drive(
+            Some(Duration::ZERO.into()),
+            &mut [first.as_service(), second.as_service()],
+            |event| panic!("no unclaimed group exists: {:?}", event_group(&event)),
+        );
+        while let Some(event) = first.next_event(&mut net) {
+            if let HttpEvent::Request { request, responder, .. } = event {
+                first_paths.push(request.path.to_owned());
+                assert!(responder.respond(200, &[], b"first"));
+            }
+        }
+        while let Some(event) = second.next_event(&mut net) {
+            if let HttpEvent::Request { request, responder, .. } = event {
+                second_paths.push(request.path.to_owned());
+                assert!(responder.respond(200, &[], b"second"));
+            }
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(first_paths, ["/first"]);
+    assert_eq!(second_paths, ["/second"]);
+
+    first.close(&mut net);
+    second.close(&mut net);
+}
+
+fn event_group(event: &StreamEvent<'_>) -> &'static str {
+    match event {
+        StreamEvent::Accepted { .. } => "accepted",
+        StreamEvent::Connected { .. } => "connected",
+        StreamEvent::Message { .. } => "message",
+        StreamEvent::Disconnected { .. } => "disconnected",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Service lifecycle
+
+#[test]
+fn close_returns_the_group_to_raw_use() {
+    let mut net = StreamNetwork::default();
+    let group = net.add_group(http_group());
+    let other_group = net.add_group(http_group());
+    let mut http = HttpService::new(&mut net, group, HttpConfig::default());
+    let mut other = HttpService::new(&mut net, other_group, HttpConfig::default());
+    http.listen(&mut net, Endpoint::Tcp(unused_addr())).unwrap();
+    http.close(&mut net);
+
+    // The remaining service alone passes validation.
+    net.drive(Some(Duration::ZERO.into()), &mut [other.as_service()], |_| {});
+
+    let addr = unused_addr();
+    net.listen(group, Endpoint::Tcp(addr)).unwrap();
+    let mut client = std::net::TcpStream::connect(addr).unwrap();
+    client.write_all(b"raw bytes").unwrap();
+    let mut raw = Vec::new();
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && raw.is_empty() {
+        net.drive(Some(Duration::ZERO.into()), &mut [other.as_service()], |event| {
+            if let StreamEvent::Message { group: event_group, payload, .. } = event {
+                assert_eq!(event_group, group);
+                raw.push(payload.to_vec());
+            }
+        });
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(raw, [b"raw bytes".to_vec()]);
+    other.close(&mut net);
+}
+
+#[test]
+fn close_hangs_up_on_connections_and_listeners() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("closed.sock");
+    let mut net = StreamNetwork::default();
+    let group = net.add_group(http_group());
+    let mut http = HttpService::new(&mut net, group, HttpConfig::default());
+    http.listen(&mut net, Endpoint::Unix(path.clone())).unwrap();
+    assert!(path.exists());
+
+    let mut client = std::os::unix::net::UnixStream::connect(&path).unwrap();
+    client.write_all(b"GET /x HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
+    let deadline = Instant::now() + TIMEOUT;
+    let mut accepted = false;
+    while Instant::now() < deadline && !accepted {
+        net.drive(Some(Duration::ZERO.into()), &mut [http.as_service()], |_| {});
+        while let Some(event) = http.next_event(&mut net) {
+            accepted |= matches!(event, HttpEvent::Accepted { .. });
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert!(accepted);
+
+    http.close(&mut net);
+    assert!(!path.exists(), "the socket file outlived its listener");
+    assert!(std::os::unix::net::UnixStream::connect(&path).is_err());
+    client.set_nonblocking(true).unwrap();
+    let mut bytes = Vec::new();
+    let deadline = Instant::now() + TIMEOUT;
+    let mut closed = false;
+    while Instant::now() < deadline && !closed {
+        closed = read_available(&mut client, &mut bytes);
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert!(closed, "the peer never saw the end of the stream");
+}
+
+#[test]
+#[should_panic(expected = "call HttpService::close before dropping it")]
+fn a_service_dropped_without_closing_is_reported() {
+    let mut net = StreamNetwork::default();
+    let group = net.add_group(http_group());
+    let http = HttpService::new(&mut net, group, HttpConfig::default());
+    drop(http);
+    net.drive(Some(Duration::ZERO.into()), &mut [], |_| {});
+}
+
+#[test]
+fn dropping_a_service_and_its_network_together_is_harmless() {
+    let mut net = StreamNetwork::default();
+    let group = net.add_group(http_group());
+    let mut http = HttpService::new(&mut net, group, HttpConfig::default());
+    http.listen(&mut net, Endpoint::Tcp(unused_addr())).unwrap();
+    net.drive(Some(Duration::ZERO.into()), &mut [http.as_service()], |_| {});
+    drop(http);
+    drop(net);
+}
+
+#[test]
+#[should_panic(expected = "HTTP frames its own messages and needs a raw-framed group")]
+fn a_service_refuses_a_length_prefixed_group() {
+    let mut net = StreamNetwork::default();
+    let group = net.add_group(ConnectionGroupConfig::default());
+    let _http = HttpService::new(&mut net, group, HttpConfig::default());
 }

--- a/crates/flux-network/tests/http.rs
+++ b/crates/flux-network/tests/http.rs
@@ -1161,7 +1161,6 @@ fn a_pipelined_request_waits_for_the_pending_response() {
         thread::sleep(Duration::from_millis(1));
     }
     assert!(paths.is_empty(), "one request in flight per connection: {paths:?}");
-    assert_eq!(server.http.ready_len(), 0, "a connection owing a response is never queued");
 
     assert!(server.respond(token, 200, &[], b"one"));
     let deadline = Instant::now() + TIMEOUT;
@@ -1179,142 +1178,6 @@ fn a_pipelined_request_waits_for_the_pending_response() {
         thread::sleep(Duration::from_millis(1));
     }
     assert_eq!(paths, ["/two"]);
-}
-
-/// Serves two pipelined requests, answering the first inline or by token, and
-/// reports the cursors left once the second request has been pulled.
-fn cursors_after_two_requests(inline: bool) -> (usize, usize, Option<usize>) {
-    let (mut server, addr) = server();
-    let mut client = std::net::TcpStream::connect(addr).unwrap();
-    client.set_nonblocking(true).unwrap();
-    client
-        .write_all(b"GET /one HTTP/1.1\r\nHost: x\r\n\r\nGET /two HTTP/1.1\r\nHost: x\r\n\r\n")
-        .unwrap();
-
-    let deadline = Instant::now() + TIMEOUT;
-    let mut answered = None;
-    let mut second = None;
-    while Instant::now() < deadline && second.is_none() {
-        let mut deferred = None;
-        server.pump(|event| {
-            if let HttpEvent::Request { token, request, responder } = event {
-                if answered.is_none() {
-                    assert_eq!(request.path, "/one");
-                    if inline {
-                        assert!(responder.respond(200, &[], b"one"));
-                    } else {
-                        deferred = Some(token);
-                    }
-                    answered = Some(token);
-                } else {
-                    assert_eq!(request.path, "/two");
-                    second = Some(token);
-                }
-            }
-        });
-        if let Some(token) = deferred {
-            assert!(server.respond(token, 200, &[], b"one"));
-        }
-        thread::sleep(Duration::from_millis(1));
-    }
-    server.http.cursors(second.expect("the second request never arrived")).unwrap()
-}
-
-#[test]
-fn inline_and_deferred_responses_consume_alike() {
-    assert_eq!(cursors_after_two_requests(true), cursors_after_two_requests(false));
-}
-
-/// Serves two pipelined requests, answers the first inline and leaves the
-/// pull, then makes one service access and checks what it reclaimed. The
-/// second request is the larger of the two, which keeps the answered prefix
-/// under half the buffer, so a reclamation without a compaction is legible in
-/// the cursors.
-fn an_inline_answer_reclaims_at(access: impl FnOnce(&mut Http)) {
-    let (mut server, addr) = server();
-    let mut client = std::net::TcpStream::connect(addr).unwrap();
-    client.set_nonblocking(true).unwrap();
-    let first = padded_request("/one", 64);
-    let mut wire = first.clone();
-    wire.extend_from_slice(&padded_request("/two", 192));
-    client.write_all(&wire).unwrap();
-
-    let deadline = Instant::now() + TIMEOUT;
-    let mut answered = None;
-    while Instant::now() < deadline && answered.is_none() {
-        server.drive();
-        while let Some(event) = server.http.next_event(&mut server.net) {
-            if let HttpEvent::Request { token, request, responder } = event {
-                assert_eq!(request.path, "/one");
-                assert!(responder.respond(200, &[], b""));
-                answered = Some(token);
-                break
-            }
-        }
-        thread::sleep(Duration::from_millis(1));
-    }
-    let token = answered.expect("no request arrived");
-
-    // The event borrowed the connection, so the answer moved `consumed` and
-    // nothing else: `start` sits where the parse left it and the connection
-    // is out of the ready queue.
-    assert_eq!(server.http.cursors(token), Some((0, first.len(), None)));
-    assert_eq!(server.http.ready_len(), 0);
-
-    access(&mut server);
-
-    let (start, consumed, _) = server.http.cursors(token).expect("the connection went");
-    assert_eq!(start, consumed, "one service access reclaims what the answer consumed");
-    assert_eq!(start, first.len(), "the pipelined request holds off the compaction");
-}
-
-#[test]
-fn an_inline_answer_reclaims_at_the_next_pull() {
-    an_inline_answer_reclaims_at(|server| {
-        // A pull applies the bookkeeping before it parses anything, so the
-        // request behind the answered one is what it delivers.
-        assert!(server.http.next_event(&mut server.net).is_some());
-    });
-}
-
-#[test]
-fn an_inline_answer_reclaims_at_the_next_drive() {
-    an_inline_answer_reclaims_at(|server| {
-        server.drive();
-    });
-}
-
-#[test]
-fn a_by_token_answer_reclaims_before_it_returns() {
-    let (mut server, addr) = server();
-    let mut client = std::net::TcpStream::connect(addr).unwrap();
-    client.set_nonblocking(true).unwrap();
-    let first = padded_request("/one", 64);
-    let mut wire = first.clone();
-    wire.extend_from_slice(&padded_request("/two", 192));
-    client.write_all(&wire).unwrap();
-
-    let (token, path) = pull_deferred_request(&mut server);
-    assert_eq!(path, "/one");
-    // Parsed and owing a response: nothing is consumed, and a connection that
-    // owes a response is never queued.
-    assert_eq!(server.http.cursors(token), Some((0, 0, Some(first.len()))));
-    assert_eq!(server.http.ready_len(), 0);
-
-    assert!(server.respond(token, 200, &[], b""));
-
-    // Nothing borrows the connection, so the answer reclaims and requeues
-    // with no driver call in between.
-    assert_eq!(
-        server.http.cursors(token),
-        Some((first.len(), first.len(), None)),
-        "a by-token answer reclaims what it consumed"
-    );
-    assert_eq!(
-        server.http.ready_len(),
-        1,
-        "the connection is queued for the pipelined request behind the answer"
-    );
 }
 
 /// Serves two pipelined requests, echoing each path back as its body and
@@ -1380,38 +1243,33 @@ fn serve_the_request_behind_an_answer(inline_first: bool) {
     client.write_all(&wire).unwrap();
 
     let deadline = Instant::now() + TIMEOUT;
-    let mut answered = None;
-    while Instant::now() < deadline && answered.is_none() {
+    let mut answered = false;
+    while Instant::now() < deadline && !answered {
         let mut deferred = None;
         server.drive();
         while let Some(event) = server.http.next_event(&mut server.net) {
             if let HttpEvent::Request { token, request, responder } = event {
                 assert_eq!(request.path, "/one", "{path}");
                 if inline_first {
-                    assert!(responder.respond(200, &[], b""));
+                    assert!(responder.respond(200, &[], b"one"));
                 } else {
                     drop(responder);
                     deferred = Some(token);
                 }
-                answered = Some(token);
+                answered = true;
                 break
             }
         }
         if let Some(token) = deferred {
-            assert!(server.respond(token, 200, &[], b""));
+            assert!(server.respond(token, 200, &[], b"one"));
         }
         thread::sleep(Duration::from_millis(1));
     }
-    let token = answered.expect("no request arrived");
+    assert!(answered, "no request arrived");
 
-    // The answer queues the connection itself, or the driver call that
-    // applies an inline answer's bookkeeping does.
-    while Instant::now() < deadline && server.http.ready_len() == 0 {
-        server.drive();
-        thread::sleep(Duration::from_millis(1));
-    }
-    assert_eq!(server.http.ready_len(), 1, "the pipelined request is queued: {path}");
-    assert!(server.drive(), "a queued request is work, iteration after iteration: {path}");
+    // A connection holding the request behind an answered one is work,
+    // whichever way the answer was given.
+    assert!(server.drive(), "the request behind the answered one is work: {path}");
 
     let mut pulled = false;
     while Instant::now() < deadline && !pulled {
@@ -1420,7 +1278,7 @@ fn serve_the_request_behind_an_answer(inline_first: bool) {
                 assert_eq!(request.method, "POST", "{path}");
                 assert_eq!(request.path, "/two", "{path}");
                 assert_eq!(request.body, b"body".as_slice(), "{path}");
-                assert!(responder.respond(200, &[], b""));
+                assert!(responder.respond(200, &[], b"two"));
                 pulled = true;
                 break
             }
@@ -1432,10 +1290,15 @@ fn serve_the_request_behind_an_answer(inline_first: bool) {
     }
     assert!(pulled, "the pipelined request was never served: {path}");
 
-    // Both answered and reclaimed, the connection holds nothing and waits.
-    server.drive();
-    assert_eq!(server.http.cursors(token), Some((0, 0, None)), "{path}");
-    assert_eq!(server.http.ready_len(), 0, "{path}");
+    // Both answers reach the client, which the connection outlives.
+    let mut received = Vec::new();
+    while Instant::now() < deadline && !received.ends_with(b"two") {
+        server.pump(|_| {});
+        assert!(!read_available(&mut client, &mut received), "the connection closed: {path}");
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert!(received.ends_with(b"two"), "{path}: {received:?}");
+    assert_eq!(received.windows(3).filter(|w| *w == b"one").count(), 1, "{path}");
 }
 
 #[test]
@@ -1445,7 +1308,7 @@ fn a_pipelined_request_is_served_after_either_answer_path() {
 }
 
 #[test]
-fn a_refused_second_response_consumes_nothing() {
+fn a_second_response_to_one_request_is_refused() {
     let (mut server, addr) = server();
     let mut client = std::net::TcpStream::connect(addr).unwrap();
     client.set_nonblocking(true).unwrap();
@@ -1453,9 +1316,7 @@ fn a_refused_second_response_consumes_nothing() {
 
     let (token, _) = pull_deferred_request(&mut server);
     assert!(server.respond(token, 200, &[], b"first"));
-    let answered = server.http.cursors(token).unwrap();
     assert!(!server.respond(token, 200, &[], b"second"), "a request is answered once");
-    assert_eq!(server.http.cursors(token).unwrap(), answered);
 
     let mut received = Vec::new();
     read_until_response(&mut server, &mut client, &mut received);
@@ -1491,15 +1352,10 @@ fn answered_bytes_cost_the_connection_nothing() {
         }
         thread::sleep(Duration::from_millis(1));
     }
-    let token = token.expect("no request arrived");
-    assert_eq!(server.http.cursors(token), Some((0, request.len(), None)));
+    assert!(token.is_some(), "no request arrived");
 
     // The next request arrives before the pull that would reclaim them.
     client.write_all(&padded_request("/second", 60)).unwrap();
-    while Instant::now() < deadline && server.http.ready_len() == 0 {
-        server.drive();
-        thread::sleep(Duration::from_millis(1));
-    }
 
     let mut paths = Vec::new();
     let deadline = Instant::now() + Duration::from_secs(2);
@@ -1569,20 +1425,16 @@ fn a_pending_request_survives_a_compaction() {
     }
     assert_eq!(pulled, ["/one", "/two"]);
     let pending = pending.unwrap();
-    assert_eq!(server.http.cursors(pending), Some((64, 64, Some(128))));
 
-    // A fourth request would outgrow the limit, so the answered prefix goes
-    // and every cursor moves down with it, the pending request included.
+    // A fourth request outgrows what the limit leaves, so it is read only
+    // once the answered prefix goes — which happens under the pending
+    // request, whose parsed bytes move down with the buffer. Answering it
+    // from rebased cursors is what lets the last two requests through.
     client.write_all(&padded_request("/four", 96)).unwrap();
-    while Instant::now() < deadline && server.http.cursors(pending) != Some((0, 0, Some(64))) {
+    for _ in 0..20 {
         server.drive();
         thread::sleep(Duration::from_millis(1));
     }
-    assert_eq!(
-        server.http.cursors(pending),
-        Some((0, 0, Some(64))),
-        "the cursors were not rebased"
-    );
 
     assert!(server.respond(pending, 200, &[], b""));
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -1615,11 +1467,12 @@ fn pipelined_requests_stay_ranged_across_a_compaction() {
         )
         .unwrap();
     }
-    let one = wire.len() / 3;
     client.write_all(&wire).unwrap();
 
+    // Three requests of one size: answering the first two puts the answered
+    // prefix past half the buffer, so the third is parsed from a buffer whose
+    // prefix has been dropped, and every range it carries is rebased.
     let mut seen = Vec::new();
-    let mut compacted = false;
     let deadline = Instant::now() + TIMEOUT;
     while Instant::now() < deadline && seen.len() < 3 {
         let mut replies = Vec::new();
@@ -1635,18 +1488,12 @@ fn pipelined_requests_stay_ranged_across_a_compaction() {
             }
         });
         for token in replies {
-            // The third request is parsed from a buffer whose answered prefix
-            // has been dropped: its cursors are rebased onto what is left.
-            if seen.len() == 3 {
-                assert_eq!(server.http.cursors(token), Some((0, 0, Some(one))));
-                compacted = true;
-            }
             assert!(server.respond(token, 200, &[], b"ok"));
         }
         thread::sleep(Duration::from_millis(1));
     }
 
-    assert!(compacted, "the buffer never compacted");
+    assert_eq!(seen.len(), 3, "not every request was served");
     for (index, (method, path, header, body)) in seen.iter().enumerate() {
         assert_eq!(method, "POST");
         assert_eq!(path, &format!("/path-{index}"));
@@ -1703,37 +1550,37 @@ fn a_caller_may_stop_pulling_and_resume_later() {
 }
 
 #[test]
-fn two_reads_queue_one_ready_connection() {
+fn a_request_split_across_reads_is_delivered_once_complete() {
     let (mut server, addr) = server();
     let mut client = std::net::TcpStream::connect(addr).unwrap();
     client.set_nonblocking(true).unwrap();
     client.write_all(b"GET /split HTTP/1.1\r\n").unwrap();
 
-    let deadline = Instant::now() + TIMEOUT;
-    while Instant::now() < deadline && server.http.ready_len() == 0 {
-        server.drive();
+    // Half a head is no request, however many iterations read it.
+    for _ in 0..20 {
+        server.pump(|event| {
+            assert!(!matches!(event, HttpEvent::Request { .. }), "half a head was delivered");
+        });
         thread::sleep(Duration::from_millis(1));
     }
-    assert_eq!(server.http.ready_len(), 1);
 
     client.write_all(b"Host: x\r\n\r\n").unwrap();
-    let mut drives = 0;
-    while Instant::now() < deadline && drives < 20 {
-        server.drive();
-        assert_eq!(server.http.ready_len(), 1, "one entry however many reads arrive");
-        drives += 1;
+    let deadline = Instant::now() + TIMEOUT;
+    let mut path = None;
+    while Instant::now() < deadline && path.is_none() {
+        server.pump(|event| {
+            if let HttpEvent::Request { request, responder, .. } = event {
+                path = Some(request.path.to_owned());
+                assert!(responder.respond(200, &[], b"ok"));
+            }
+        });
         thread::sleep(Duration::from_millis(1));
     }
-
-    let mut path = None;
-    server.pump(|event| {
-        if let HttpEvent::Request { request, responder, .. } = event {
-            path = Some(request.path.to_owned());
-            assert!(responder.respond(200, &[], b"ok"));
-        }
-    });
     assert_eq!(path.as_deref(), Some("/split"));
-    assert_eq!(server.http.ready_len(), 0);
+
+    let mut received = Vec::new();
+    read_until_response(&mut server, &mut client, &mut received);
+    assert!(received.ends_with(b"ok"), "{received:?}");
 }
 
 #[test]

--- a/crates/flux-network/tests/tcp_multi_client_backpressure.rs
+++ b/crates/flux-network/tests/tcp_multi_client_backpressure.rs
@@ -1,8 +1,9 @@
 use std::{
     io::Read,
     net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener},
+    sync::mpsc::{self, Receiver, Sender, TryRecvError},
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use flux_network::stream::{SendBehavior, TcpConnector};
@@ -10,12 +11,19 @@ use mio::Token;
 
 const FRAME_HEADER_SIZE: usize = core::mem::size_of::<u32>() + core::mem::size_of::<u64>();
 
-fn spawn_frame_collector(read_delay: Duration) -> (SocketAddr, thread::JoinHandle<Vec<Vec<u8>>>) {
+/// A collector that reads frames until the connection closes, announcing the
+/// arrival of `marker` on the channel it returns.
+fn spawn_frame_collector(
+    read_delay: Duration,
+    marker: Vec<u8>,
+) -> (SocketAddr, Receiver<()>, thread::JoinHandle<Vec<Vec<u8>>>) {
     let listener = TcpListener::bind(SocketAddr::from((IpAddr::V4(Ipv4Addr::LOCALHOST), 0)))
         .expect("failed to bind test listener");
     let addr = listener.local_addr().expect("failed to fetch listener addr");
+    let (arrived, arrival) = mpsc::channel();
 
     let handle = thread::spawn(move || {
+        let arrived: Sender<()> = arrived;
         let (mut stream, _) = listener.accept().expect("failed to accept connection");
         if !read_delay.is_zero() {
             thread::sleep(read_delay);
@@ -33,6 +41,9 @@ fn spawn_frame_collector(read_delay: Duration) -> (SocketAddr, thread::JoinHandl
                     if stream.read_exact(&mut payload).is_err() {
                         break;
                     }
+                    if payload == marker {
+                        let _ = arrived.send(());
+                    }
                     frames.push(payload);
                 }
                 Err(_) => break,
@@ -42,13 +53,26 @@ fn spawn_frame_collector(read_delay: Duration) -> (SocketAddr, thread::JoinHandl
         frames
     });
 
-    (addr, handle)
+    (addr, arrival, handle)
 }
 
-fn pump(conn: &mut TcpConnector, for_how_long: Duration) {
-    let deadline = std::time::Instant::now() + for_how_long;
-    while std::time::Instant::now() < deadline {
+/// Drives the connector until every collector has announced its marker.
+///
+/// How long the queued bytes take to drain depends on the receiver, so the
+/// arrivals are what the test waits for; the deadline is only there to fail
+/// loudly instead of hanging.
+fn pump_until_arrivals(conn: &mut TcpConnector, arrivals: &[&Receiver<()>]) {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut arrived = vec![false; arrivals.len()];
+    while !arrived.iter().all(|arrived| *arrived) {
+        assert!(Instant::now() < deadline, "markers never arrived: {arrived:?}");
         while conn.poll_with(|_| {}) {}
+        for (index, arrival) in arrivals.iter().enumerate() {
+            arrived[index] |= match arrival.try_recv() {
+                Ok(()) => true,
+                Err(TryRecvError::Empty | TryRecvError::Disconnected) => false,
+            };
+        }
         thread::sleep(Duration::from_millis(1));
     }
 }
@@ -61,8 +85,12 @@ fn send_payload(conn: &mut TcpConnector, token: Token, payload: &[u8]) {
 
 #[test]
 fn queued_messages_flush_on_second_connection_after_backpressure() {
-    let (fast_addr, fast_handle) = spawn_frame_collector(Duration::from_millis(0));
-    let (slow_addr, slow_handle) = spawn_frame_collector(Duration::from_millis(700));
+    let marker = b"marker-after-backpressure".to_vec();
+    let keepalive = b"fast-keepalive".to_vec();
+    let (fast_addr, fast_arrival, fast_handle) =
+        spawn_frame_collector(Duration::from_millis(0), keepalive.clone());
+    let (slow_addr, slow_arrival, slow_handle) =
+        spawn_frame_collector(Duration::from_millis(700), marker.clone());
 
     let mut conn = TcpConnector::default().with_socket_buf_size(1024);
     let fast_token = conn.connect(fast_addr).expect("failed to connect to fast collector");
@@ -74,24 +102,23 @@ fn queued_messages_flush_on_second_connection_after_backpressure() {
     let big = vec![7_u8; 8 * 1024 * 1024];
     send_payload(&mut conn, slow_token, &big);
 
-    let marker = b"marker-after-backpressure".to_vec();
     send_payload(&mut conn, slow_token, &marker);
-    send_payload(&mut conn, fast_token, b"fast-keepalive");
+    send_payload(&mut conn, fast_token, &keepalive);
 
     // The slow side starts reading after the delay. If token handling is correct,
     // queued frames should eventually flush and marker should be observed.
-    pump(&mut conn, Duration::from_secs(5));
+    pump_until_arrivals(&mut conn, &[&fast_arrival, &slow_arrival]);
     drop(conn);
 
     let fast_frames = fast_handle.join().expect("fast collector thread panicked");
     let slow_frames = slow_handle.join().expect("slow collector thread panicked");
 
     assert!(
-        fast_frames.iter().any(|f| f == b"fast-keepalive"),
+        fast_frames.contains(&keepalive),
         "sanity check failed: fast collector did not receive data"
     );
     assert!(
-        slow_frames.iter().any(|f| f == &marker),
+        slow_frames.contains(&marker),
         "slow collector never received marker after backpressure was released"
     );
 }

--- a/crates/flux-timing/src/repeater.rs
+++ b/crates/flux-timing/src/repeater.rs
@@ -42,6 +42,13 @@ impl Repeater {
         }
     }
 
+    /// The instant from which the next [`Self::fired_at`] fires, for a caller
+    /// folding this repeater into a poll timeout.
+    #[inline]
+    pub fn next_fire(&self) -> Instant {
+        self.last_acted + self.interval
+    }
+
     #[inline]
     pub fn interval(&self) -> Duration {
         self.interval
@@ -98,5 +105,15 @@ mod tests {
         assert!(repeater.fired_at(Instant(10)));
         assert!(!repeater.fired_at(Instant(19)));
         assert!(repeater.fired_at(Instant(20)));
+    }
+
+    #[test]
+    fn next_fire_is_the_instant_the_next_fire_happens_at() {
+        let mut repeater = Repeater::every(Duration(10));
+        assert_eq!(repeater.next_fire(), Instant(10));
+        assert!(repeater.fired_at(Instant(12)));
+        assert_eq!(repeater.next_fire(), Instant(22));
+        assert!(!repeater.fired_at(Instant(21)));
+        assert!(repeater.fired_at(repeater.next_fire()));
     }
 }


### PR DESCRIPTION
This PR builds on #138. It adds network-scheduled services and replaces `HttpNetwork` with `HttpService`, an HTTP protocol layer over one `ConnectionGroup`. Five commits.

## Service scheduling

A service owns one `ConnectionGroup` and is scheduled by its network. `StreamNetwork::drive(max_timeout, services, unclaimed_handler)` runs one iteration: it folds network and service deadlines into the poll timeout, routes events by group ownership, then ticks services in slice order. Ticks receive the time after the poll wait.

The scheduling trait is private. Public callers pass opaque `ServiceRef`s made by `as_service()`, keeping the scheduling interface closed while allowing more service implementations later.

Each call validates the complete service slice before doing work. Omitting or duplicating a service whose group is claimed is therefore a configuration error, independent of which events arrive. Events for unclaimed groups go to the supplied handler. `poll_with` remains available for networks containing only unclaimed groups.

## HttpService

`HttpService::new(&mut net, group, config)` claims a raw-framed group. The service owns HTTP parsing and connection state; transport and queue policy remain in `ConnectionGroupConfig`.

HTTP events are now pull-based. `next_event(&mut net)` returns lifecycle, request and response events from ready connections. A request borrows its bytes from the connection buffer and carries a `Responder` for an inline answer. Dropping the responder defers the answer to `HttpService::respond(&mut net, token, ...)`.

Pulling lets a tile cap its work per iteration without losing readiness. `tick` continues to report work while an event remains available, including after a caller stops pulling early.

Answered input is tracked with cursors. It stops counting against connection limits immediately, while the buffer is compacted only when the consumed prefix reaches half its length. Inline answers reclaim on the next pull or network tick, after the event borrow ends; by-token answers hold no such borrow and reclaim before returning. A benchmark covers the compaction policy.

`close(self, &mut net)` closes the group and returns it empty and unclaimed. If a service is dropped while its network continues to run, the next driver call reports the missing owner. Dropping the service and network together during teardown remains harmless.

## Verification

Integration tests cover HTTP behavior through the public API over TCP and Unix sockets. Private unit tests pin cursor accounting, compaction, ready-queue behavior and the different reclamation points of inline and by-token answers without exposing representation accessors. Driver tests cover group claims, validation, deadline folding, event routing, tick order, post-poll time and did-work reporting.

One commit fixes the pre-existing `queued_messages_flush_on_second_connection_after_backpressure` race. The test previously waited five seconds for a marker that can arrive at that boundary under load. It now waits for an explicit marker from each collector, with a deadline only to bound failure.

Two review follow-ups document and test the answer-path reclamation rule, then move cursor and ready-queue assertions into private unit tests. `HttpService` exposes no representation accessors for testing.

## Scope

Driving from a caller-owned poll follows in A4. `listen` still returns `io::Result<()>`; reporting its bound endpoint follows later in the stack.

## Known test flakes

`stream_network_client_is_wire_compatible_with_tcp_connector_server` and the new loopback unit tests still guess unused TCP ports. That race is fixed later when `listen` reports the endpoint it bound. If one fails in CI, rerun the job.

Base: #138. Next: A4, driving the network from a caller-owned poll.

Refer: #143

Assisted-by: Claude Code:claude-fable-5
Assisted-by: Codex:gpt-5
