### PR TITLE
perf(disk): pre-size read-to-end buffers asynchronously

### DIFF
--- a/crates/flux-disk/src/lib.rs
+++ b/crates/flux-disk/src/lib.rs
@@ -19,6 +19,7 @@ use std::{
     collections::VecDeque,
     ffi::CString,
     io,
+    mem::MaybeUninit,
     os::unix::ffi::OsStrExt,
     path::{Path, PathBuf},
 };
@@ -35,9 +36,9 @@ const PENDING_WARNING_INTERVAL_SECS: u64 = 10;
 /// and writes are transparently continued from where the previous chunk
 /// ended.
 const MAX_OP_BYTES: usize = 1 << 30;
-/// First buffer size for [`DiskIo::read_to_end`]; doubled every time it
-/// fills before end-of-file.
+/// Minimum and fallback buffer capacity for [`DiskIo::read_to_end`].
 const READ_TO_END_CHUNK: usize = 64 * 1024;
+const EMPTY_PATH: &[u8] = b"\0";
 
 /// Identifies one open (or opening) file. Tokens are never reused.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -196,6 +197,7 @@ pub enum DiskEvent<'a> {
 enum PendingOp {
     Open { path: CString, flags: i32, mode: libc::mode_t },
     Read { offset: u64, len: usize, to_end: bool },
+    ReadToEnd { offset: u64 },
     Write { buf: Vec<u8>, offset: u64 },
     Sync { data_only: bool },
     Close,
@@ -204,6 +206,7 @@ enum PendingOp {
 enum InFlightOp {
     Open { path: CString, flags: i32, mode: libc::mode_t },
     Read { buf: Vec<u8>, offset: u64, wanted: usize, have: usize, to_end: bool },
+    Statx { offset: u64, statx: Box<MaybeUninit<libc::statx>> },
     Write { buf: Vec<u8>, offset: u64, written: usize },
     Sync { data_only: bool },
     Close,
@@ -331,7 +334,7 @@ impl DiskIo {
     /// Returns `false` for unknown or closing tokens.
     pub fn read_to_end(&mut self, file: FileToken, offset: u64) -> bool {
         let Some(state) = self.usable_file_mut(file) else { return false };
-        state.queue.push_back(PendingOp::Read { offset, len: READ_TO_END_CHUNK, to_end: true });
+        state.queue.push_back(PendingOp::ReadToEnd { offset });
         self.note_enqueued();
         true
     }
@@ -473,9 +476,9 @@ impl DiskIo {
         buf
     }
 
-    fn take_buffer_sized(&mut self, len: usize) -> Vec<u8> {
+    fn take_buffer_with_capacity(&mut self, len: usize) -> Vec<u8> {
         let mut buf = self.take_buffer();
-        buf.resize(len, 0);
+        buf.reserve(len);
         buf
     }
 
@@ -512,7 +515,9 @@ impl DiskIo {
                 let Some(head) = file.queue.front() else { break };
                 let ready = match head {
                     PendingOp::Open { .. } => true,
-                    PendingOp::Read { .. } | PendingOp::Write { .. } => file.fd.is_some(),
+                    PendingOp::Read { .. } |
+                    PendingOp::ReadToEnd { .. } |
+                    PendingOp::Write { .. } => file.fd.is_some(),
                     PendingOp::Sync { .. } | PendingOp::Close => {
                         file.fd.is_some() && file.in_flight == 0
                     }
@@ -533,12 +538,15 @@ impl DiskIo {
         let op = match op {
             PendingOp::Open { path, flags, mode } => InFlightOp::Open { path, flags, mode },
             PendingOp::Read { offset, len, to_end } => InFlightOp::Read {
-                buf: self.take_buffer_sized(len),
+                buf: self.take_buffer_with_capacity(len),
                 offset,
                 wanted: len,
                 have: 0,
                 to_end,
             },
+            PendingOp::ReadToEnd { offset } => {
+                InFlightOp::Statx { offset, statx: Box::new(MaybeUninit::uninit()) }
+            }
             PendingOp::Write { buf, offset } => InFlightOp::Write { buf, offset, written: 0 },
             PendingOp::Sync { data_only } => InFlightOp::Sync { data_only },
             PendingOp::Close => InFlightOp::Close,
@@ -564,10 +572,21 @@ impl DiskIo {
             InFlightOp::Read { buf, offset, wanted, have, .. } => {
                 let fd = fd.expect("read dispatched without an open fd");
                 let chunk = (*wanted - *have).min(MAX_OP_BYTES) as u32;
-                // SAFETY: `have < wanted == buf.len()`, so the pointer stays
-                // inside the buffer's allocation.
+                // SAFETY: `have < wanted <= buf.capacity()`, so the pointer
+                // stays inside the buffer's allocation.
                 let ptr = unsafe { buf.as_mut_ptr().add(*have) };
                 opcode::Read::new(types::Fd(fd), ptr, chunk).offset(*offset + *have as u64).build()
+            }
+            InFlightOp::Statx { statx, .. } => {
+                let fd = fd.expect("statx dispatched without an open fd");
+                opcode::Statx::new(
+                    types::Fd(fd),
+                    EMPTY_PATH.as_ptr().cast(),
+                    statx.as_mut_ptr().cast(),
+                )
+                .flags(libc::AT_STATX_SYNC_AS_STAT | libc::AT_EMPTY_PATH)
+                .mask(libc::STATX_SIZE)
+                .build()
             }
             InFlightOp::Write { buf, offset, written } => {
                 let fd = fd.expect("write dispatched without an open fd");
@@ -665,6 +684,9 @@ impl DiskIo {
             InFlightOp::Read { .. } | InFlightOp::Write { .. } => {
                 self.complete_transfer(user_data, file_index, entry.op, result, handler);
             }
+            InFlightOp::Statx { offset, statx } => {
+                self.complete_statx(user_data, file_index, offset, statx, result);
+            }
             InFlightOp::Sync { .. } => {
                 self.finish_op(slot, file_index);
                 if result < 0 {
@@ -710,6 +732,55 @@ impl DiskIo {
         }
     }
 
+    fn complete_statx(
+        &mut self,
+        user_data: u64,
+        file_index: usize,
+        offset: u64,
+        statx: Box<MaybeUninit<libc::statx>>,
+        result: i32,
+    ) {
+        let len = if result == 0 {
+            // SAFETY: a successful statx completion writes the output struct.
+            let statx = unsafe { statx.assume_init() };
+            (statx.stx_mask & libc::STATX_SIZE != 0).then_some(statx.stx_size)
+        } else {
+            None
+        };
+        self.start_read_to_end(user_data, file_index, offset, len);
+    }
+
+    fn start_read_to_end(
+        &mut self,
+        user_data: u64,
+        file_index: usize,
+        offset: u64,
+        file_len: Option<u64>,
+    ) {
+        let wanted = Self::read_to_end_len(file_len, offset);
+        let token = self.files[file_index].token;
+        let slot = user_data as usize;
+        self.slab[slot] = Some(InFlight {
+            file: token,
+            op: InFlightOp::Read {
+                buf: self.take_buffer_with_capacity(wanted),
+                offset,
+                wanted,
+                have: 0,
+                to_end: true,
+            },
+        });
+        self.push_slot(user_data);
+    }
+
+    fn read_to_end_len(file_len: Option<u64>, offset: u64) -> usize {
+        file_len
+            .map(|len| len.saturating_sub(offset).saturating_add(1))
+            .and_then(|len| usize::try_from(len).ok())
+            .unwrap_or(READ_TO_END_CHUNK)
+            .max(READ_TO_END_CHUNK)
+    }
+
     /// Handles a read or write completion, transparently continuing after
     /// short transfers.
     fn complete_transfer<F>(
@@ -735,6 +806,10 @@ impl DiskIo {
                     return;
                 }
                 let have = have + result as usize;
+                // SAFETY: a successful read initialized exactly `result`
+                // bytes starting at the prior `have`, within the reserved
+                // read range.
+                unsafe { buf.set_len(have) };
                 if result == 0 || (have >= wanted && !to_end) {
                     self.finish_op(slot, file_index);
                     let eof = result == 0;
@@ -745,7 +820,7 @@ impl DiskIo {
                         // The buffer filled before end-of-file: grow it and
                         // keep reading.
                         wanted = wanted.saturating_mul(2);
-                        buf.resize(wanted, 0);
+                        buf.reserve(wanted - buf.len());
                     }
                     self.slab[slot] = Some(InFlight {
                         file: token,
@@ -800,6 +875,9 @@ impl DiskIo {
             let failed = match op {
                 PendingOp::Open { .. } => FailedOp::Open,
                 PendingOp::Read { offset, len, .. } => FailedOp::Read { offset, len },
+                PendingOp::ReadToEnd { offset } => {
+                    FailedOp::Read { offset, len: READ_TO_END_CHUNK }
+                }
                 PendingOp::Write { buf, offset } => {
                     let len = buf.len();
                     self.recycle(buf);
@@ -874,10 +952,13 @@ impl Drop for DiskIo {
 mod tests {
     use std::{
         fs,
+        os::fd::IntoRawFd,
         time::{Duration as StdDuration, Instant as StdInstant},
     };
 
-    use super::{DiskConfig, DiskEvent, DiskIo, FailedOp, FileToken, OpenOptions};
+    use super::{
+        DiskConfig, DiskEvent, DiskIo, FailedOp, FileToken, OpenOptions, READ_TO_END_CHUNK,
+    };
 
     fn overwrite() -> OpenOptions {
         OpenOptions::new().write(true).create(true).truncate(true)
@@ -968,7 +1049,16 @@ mod tests {
     }
 
     #[test]
-    fn read_to_end_returns_full_contents_across_buffer_growth() {
+    fn read_to_end_size_hint_uses_metadata_or_falls_back() {
+        assert_eq!(DiskIo::read_to_end_len(Some(200_000), 0), 200_001);
+        assert_eq!(DiskIo::read_to_end_len(Some(200_000), 199_990), READ_TO_END_CHUNK);
+        assert_eq!(DiskIo::read_to_end_len(Some(0), 0), READ_TO_END_CHUNK);
+        assert_eq!(DiskIo::read_to_end_len(Some(10), 20), READ_TO_END_CHUNK);
+        assert_eq!(DiskIo::read_to_end_len(None, 0), READ_TO_END_CHUNK);
+    }
+
+    #[test]
+    fn read_to_end_returns_full_contents_from_a_static_large_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("grown.bin");
         let data: Vec<u8> = (0..200_000u32).map(|i| i as u8).collect();
@@ -988,6 +1078,37 @@ mod tests {
             payload: data[199_990..].to_vec(),
             eof: true,
         }));
+    }
+
+    #[test]
+    fn read_to_end_grows_after_a_stale_statx_hint() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("grown.bin");
+        let data: Vec<u8> = (0..READ_TO_END_CHUNK * 3).map(|i| i as u8).collect();
+        fs::write(&path, &data).unwrap();
+        let mut disk = DiskIo::default();
+        let file = FileToken(0);
+        disk.files.push(super::File {
+            token: file,
+            path: path.clone(),
+            fd: Some(fs::File::open(&path).unwrap().into_raw_fd()),
+            closing: false,
+            write_cursor: 0,
+            in_flight: 1,
+            queue: std::collections::VecDeque::new(),
+        });
+        disk.slab.push(None);
+        disk.in_flight_count = 1;
+
+        // Start from a deliberately stale size captured before the file grew.
+        disk.start_read_to_end(0, 0, 0, Some(READ_TO_END_CHUNK as u64));
+
+        let mut events = Vec::new();
+        drive(&mut disk, &mut events, |events| {
+            events.iter().any(|event| matches!(event, Ev::Read { .. }))
+        });
+        assert!(events.contains(&Ev::Read { file, offset: 0, payload: data, eof: true }));
+        assert!(disk.is_idle());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- issue an fd-based asynchronous  before  so the first read is sized from current file metadata
- retain the 64 KiB fallback and geometric growth path when metadata is unavailable or stale
- read into spare  capacity and expose only bytes initialized by successful CQEs

## Metrics-server-a benchmark

Measured raw file contents loading into s only—no digest, decompression, or deserialization. A completed production slot was copied to a private temporary directory on the same ext4/md3 filesystem so cold-cache eviction affected only benchmark copies.

- dataset: 74 persisted telemetry files, 26,683,218 bytes
- host: AMD EPYC 8224P, Linux 6.8
- method: 12 alternating baseline/candidate rounds at  and idle I/O priority

|  loader | Baseline median | Candidate median | Change |
| --- | ---: | ---: | ---: |
| , cold | 46.435 ms (575 MB/s) | 26.881 ms (993 MB/s) | -42.1% |
| , warm | 33.339 ms (800 MB/s) | 8.813 ms (3,028 MB/s) | -73.6% |

The standard-library controls stayed within 5.4% cold and 3.9% warm across the two alternating binaries. Production overseer and data-gather services remained active after the run.

## Verification

- 
- 
- 
running 13 tests
test tests::open_options_validate_like_std ... ok
test tests::closing_unknown_and_empty_submissions_are_rejected ... ok
test tests::barriers_order_overlapping_writes ... ok
test tests::read_to_end_size_hint_uses_metadata_or_falls_back ... ok
test tests::cursor_can_append_to_an_existing_file ... ok
test tests::read_to_end_of_an_empty_file_is_empty_and_eof ... ok
test tests::failed_open_fails_queued_ops_and_retires_the_token ... ok
test tests::reads_report_payload_and_eof ... ok
test tests::drop_waits_for_submitted_writes ... ok
test tests::writes_sync_and_close_before_the_first_poll ... ok
test tests::read_to_end_returns_full_contents_from_a_static_large_file ... ok
test tests::read_to_end_grows_after_a_stale_statx_hint ... ok
test tests::tiny_ring_applies_backpressure_without_losing_ops ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s (13 passed)
- 
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
test end_to_end_send_receive_and_exit ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s


running 3 tests
test tests::test_mio_waker ... ok
test tests::test_sticky_behavior ... ok
test tests::test_park_unpark ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s


running 1 test
test all_shmem_files_reside_in_base_dir ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 4 tests
test locks_enum_variants_with_wincode_tags ... ok
test wire_compatibility::matching_tag_deserializes_across_enum_versions ... ok
test legacy_nested_type_hashes_are_stable ... ok
test wire_compatibility::missing_tag_fails_to_deserialize ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 32 tests
test queue::tests_basic::active_groups_round_trip ... ok
test queue::tests_basic::headersize ... ok
test queue::tests_basic::basic ... ok
test queue::tests_basic::dead_pid_slot_reclaimed ... ok
test queue::tests_basic::max_writable_msgs_matches_safe_writes_before_overwrite ... ok
test queue::tests_basic::pid_from_label_parsing ... ok
test queue::tests_basic::basic_shared ... ok
test queue::tests_collaborative::collaborative_basic ... ok
test queue::tests_collaborative::fast_forward_skips_backlog ... ok
test queue::tests_collaborative::collaborative_sped_past ... ok
test seqlock::tests::lock_size ... ok
test queue::tests_collaborative::collaborative_consume_race_with_write ... ok
test queue::tests_collaborative::fast_forward_no_gaps_with_multiple_consumers ... ok
test queue::tests_collaborative::collaborative_and_broadcast_coexist ... ok
test queue::tests_collaborative::collaborative_multiple_groups ... ok
test seqlock::tests::write_unpoison ... ok
test seqlock::tests::read_128 ... ok
test seqlock::tests::read_128_multi ... ok
test seqlock::tests::read_64 ... ok
test seqlock::tests::read_large ... ok
test seqlock::tests::read_16 ... ok
test seqlock::tests::read_32_multi ... ok
test seqlock::tests::read_32 ... ok
test seqlock::tests::read_large_multi ... ok
test seqlock::tests::read_16_multi ... ok
test seqlock::tests::read_64_multi ... ok
test queue::tests_basic::multithread_1_4 ... ok
test queue::tests_basic::multithread_2_4 ... ok
test queue::tests_basic::multithread_1_2 ... ok
test queue::tests_basic::multithread_4_4 ... ok
test queue::tests_basic::multithread_8_8 ... ok
test queue::tests_collaborative::perf_test_collaborative_consumers ... ok

test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 11.29s


running 9 tests
test tui::render::tests::truncate_str_ascii ... ok
test tui::tile_metrics::tests::empty_store_has_zero_rows ... ok
test tui::render::tests::truncate_str_multibyte_utf8 ... ok
test tui::render::tests::truncate_str_edge_cases ... ok
test tui::tile_metrics::tests::navigation_empty_store_does_not_panic ... ok
test tui::app::tests::rate_smoother_single_sample ... ok
test tui::app::tests::rate_smoother_averages_multiple_samples ... ok
test tui::app::tests::rate_smoother_zero_decay ... ok
test tui::app::tests::rate_smoother_independent_keys ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 3 tests
test performance_baseline_empty_scan ... ok
test performance_single_large_segment ... ok
test performance_scan_base_dir_50_segments ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 4 tests
test consumer_groups_empty_for_missing_or_data_segment ... ok
test data_segments_have_no_queue_stats ... ok
test consumer_groups_readable_from_shmem ... ok
test queue_stats_populated_during_discovery ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 52 tests
test destroy_all_cancel_hides_confirm ... ok
test list_cleanup_blocked_on_app_header ... ok
test enter_on_segment_opens_detail ... ok
test detail_cancel_cleanup_hides_confirm ... ok
test enter_on_app_header_still_toggles ... ok
test list_cleanup_blocked_for_alive_segment ... ok
test detail_view_back_returns_to_list ... ok
test home_end_navigation ... ok
test list_cancel_cleanup_hides_confirm ... ok
test page_up_page_down_navigation ... ok
test navigation_next_previous ... ok
test detail_view_hides_consumer_groups_when_empty ... ok
test destroy_all_noop_when_all_alive ... ok
test detail_cleanup_blocked_for_alive ... ok
test scan_base_dir_discovers_multiple_apps ... ok
test healthy_segment_has_no_poison ... ok
test list_status_bar_shows_cleanup_hint_for_dead ... ok
test scan_base_dir_discovers_preexisting_shmem ... ok
test destroy_all_shows_confirm_when_dead_exist ... ok
test detail_status_bar_shows_cleanup_hint_for_dead ... ok
test detail_view_renders_segment_info ... ok
test sort_mode_cycles_through_all_variants ... ok
test filter_mode_input_and_clear ... ok
test render_multiple_apps ... ok
test scan_base_dir_skips_stale_flinks ... ok
test detail_view_shows_write_pos_bar ... ok
test render_collapsed_app_hides_segments ... ok
test scan_on_empty_base_dir ... ok
test list_cleanup_shows_confirm_for_dead ... ok
test help_hint_visible_by_default ... ok
test empty_with_filter_shows_filter_message ... ok
test status_bar_shows_destroy_all_hint ... ok
test poisoned_segment_renders_skull_crossbones ... ok
test help_popup_toggle ... ok
test render_empty_app ... ok
test toggle_expand_collapse ... ok
test dead_segment_renders_skull ... ok
test empty_without_filter_shows_default_message ... ok
test render_single_app_expanded ... ok
test poisoned_detail_view_shows_poison_info ... ok
test detail_cleanup_shows_confirm_for_dead ... ok
test auto_scroll_shows_last_group_at_end ... ok
test detail_view_shows_consumer_groups ... ok
test d14_render_long_names ... ok
test title_bar_shows_zero_counts_when_empty ... ok
test title_bar_shows_segment_and_app_counts ... ok
test d15_single_segment ... ok
test performance_scan_base_dir_250_segments ... ok
test stress_test_many_entries ... ok
test filter_narrows_visible_segments ... ok
test app_filter_limits_to_one_app ... ok
test app_from_real_discovery ... ok

test result: ok. 52 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.27s


running 13 tests
test tests::read_to_end_size_hint_uses_metadata_or_falls_back ... ok
test tests::closing_unknown_and_empty_submissions_are_rejected ... ok
test tests::failed_open_fails_queued_ops_and_retires_the_token ... ok
test tests::barriers_order_overlapping_writes ... ok
test tests::cursor_can_append_to_an_existing_file ... ok
test tests::open_options_validate_like_std ... ok
test tests::reads_report_payload_and_eof ... ok
test tests::read_to_end_of_an_empty_file_is_empty_and_eof ... ok
test tests::writes_sync_and_close_before_the_first_poll ... ok
test tests::tiny_ring_applies_backpressure_without_losing_ops ... ok
test tests::drop_waits_for_submitted_writes ... ok
test tests::read_to_end_grows_after_a_stale_statx_hint ... ok
test tests::read_to_end_returns_full_contents_from_a_static_large_file ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 6 tests
test http::tests::header_lookup_is_case_insensitive ... ok
test tcp::network::tests::byte_queue_checks_hard_limit_without_overflowing ... ok
test tcp::network::tests::byte_queue_preserves_raw_unwritten_suffix ... ok
test tcp::network::tests::byte_queue_compacts_consumed_prefix_before_growing ... ok
test tcp::network::tests::byte_queue_preserves_every_unwritten_suffix ... ok
test tcp::network::tests::hard_limit_disconnects_when_queue_is_already_backed_up ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 23 tests
test client_chunked_response ... ok
test bare_lf_head_rejected ... ok
test caller_connection_close_header_sent ... ok
test pipelined_binary_bodies ... ok
test get_keepalive_two_requests ... ok
test client_binary_bodies ... ok
test client_server_roundtrip ... ok
test client_chunked_overflow ... ok
test client_chunked_malformed_trailers_rejected ... ok
test wrong_role_calls_return_false ... ok
test client_head_response_ignores_advisory_content_length ... ok
test server_disconnect_kicks ... ok
test post_echo_body ... ok
test pipelined_requests ... ok
test pending_buffer_cap_disconnects ... ok
test post_binary_body_lone_lf ... ok
test single_instance_serves_itself ... ok
test smuggling_rejected ... ok
test limits_and_errors ... ok
test connection_close_large_body ... ok
test idle_timeout_disconnects ... ok
test client_remove_stops_reconnect ... ok
test client_reconnect_after_close ... ok

test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.00s


running 1 test
test broadcast_burst_to_multiple_receivers ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.09s


running 1 test
test dcache_multi_stream ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.20s


running 1 test
test queued_messages_flush_on_second_connection_after_backpressure ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.00s


running 8 tests
test oversized_frame_disconnects_the_peer ... ok
test broadcast_serializes_once_for_multiple_connections ... ok
test tcp_network_is_wire_compatible_with_tcp_connector ... ok
test groups_route_events_and_messages ... ok
test disconnected_messages_are_dropped_and_token_survives_reconnect ... ok
test tcp_network_client_is_wire_compatible_with_tcp_connector_server ... ok
test hard_backlog_limit_disconnects_the_peer ... ok
test partial_header_and_payload_are_not_delivered_early ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s


running 5 tests
test http_get_smoke ... ok
test raw_roundtrip ... ok
test framed_and_raw_coexist ... ok
test raw_outbound_connect ... ok
test raw_disconnect_when_drained_flushes_queue ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.19s


running 1 test
test outbound_endpoint_reuses_telemetry_mappings_across_reconnects ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 4 tests
test disconnected_outbound_replays_backlog_by_default ... ok
test backlog_disconnect_is_reported ... ok
test tcp_roundtrip ... ok
test disconnected_outbound_can_drop_backlog ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.00s


running 36 tests
test allocator::counting::tests::counts_alloc_and_free ... ok
test allocator::counting::tests::realloc_counts_both_legs ... ok
test allocator::tests::delta_add_and_live ... ok
test allocator::tests::saturates_on_cross_thread_skew ... ok
test socket_clock::tests::identity ... ok
test socket_clock::tests::recalibrate_keeps_the_gap_between_sockets ... ok
test socket_clock::tests::per_node_clocks ... ok
test socket_clock::tests::recalibrate_corrects_a_fast_clock ... ok
test fxt::tests::koids_come_from_thread_ids_and_timestamps_are_absolute ... ok
test fxt::tests::no_counter_without_samples ... ok
test fxt::tests::marks_never_go_before_last_written ... ok
test fxt::tests::keeps_sample_before_change ... ok
test fxt::tests::repeated_samples_emitted_once ... ok
test fxt::tests::alloc_emits_memory_counter ... ok
test fxt::tests::perf_emits_counter_per_event ... ok
test fxt::tests::dumps_concatenate_into_one_trace ... ok
test socket_clock::tests::calibrate_wall_clock ... ok
test drainer::tests::retained_capacity_survives_a_dump ... ok
test perf::raw::tests::counts_loop_instructions ... ok
test perf::raw::tests::counts_cycles ... ok
test drainer::tests::a_hole_across_a_dump_records_no_missed_span ... ok
test drainer::tests::dump_reports_interval_loss_once ... ok
test drainer::tests::short_top_level_frames_are_discarded ... ok
test drainer::tests::dumps_partition_the_stream_and_keep_open_frames_whole ... ok
test drainer::tests::failed_dump_releases_nothing ... ok
test drainer::tests::hole_closes_spanning_frames_and_records_a_missed_span ... ok
test drainer::tests::ids_survive_a_dump_a_thread_is_quiet_for ... ok
test drainer::tests::retention_after_a_burst_does_not_scale_with_it ... ok
test reader::tests::exports_fxt_trace ... ok
test reader::tests::flamegraph_reader_resolves_names_cross_process ... ok
test reader::tests::drain_discovers_every_thread_ring ... ok
test reader::tests::overrun_is_reported_as_missed_events ... ok
test ring_drainer::tests::overrun_is_counted_exactly_and_indexing_resumes_at_the_head ... ok
test reader::tests::same_named_threads_do_not_share_a_ring ... ok
test ring_drainer::tests::take_at_falls_back_to_last_retained_on_a_hole ... ok
test timing::tests::timed_macro_expands_and_runs ... ok

test result: ok. 36 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.20s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 4 tests
test data::circular_buffer::tests::circular_iterators ... ok
test data::circular_buffer::tests::nth_back ... ok
test data::circular_buffer::tests::nth_mut ... ok
test data::circular_buffer::tests::test ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 15 tests
test nanos::tests::test_nanos_from_string_float_milliseconds ... ok
test nanos::tests::test_nanos_bincode_serialization ... ok
test nanos::tests::test_nanos_from_string_float_seconds ... ok
test repeater::tests::fired_at_uses_the_supplied_instant ... ok
test nanos::tests::test_nanos_from_number ... ok
test nanos::tests::test_nanos_from_string_milliseconds ... ok
test nanos::tests::test_nanos_from_string_microseconds ... ok
test nanos::tests::test_nanos_from_string_seconds ... ok
test duration::tests::as_nanos_scale_within_1ppm ... ok
test duration::tests::from_micros_matches_std ... ok
test duration::tests::from_nanos_matches_std ... ok
test duration::tests::from_millis_matches_std ... ok
test duration::tests::from_secs_matches_std ... ok
test duration::tests::from_secs_f64_matches_std ... ok
test duration::tests::from_std_roundtrip ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 35 tests
test arrayvec::tests::arraystr::copy_semantics ... ok
test arrayvec::tests::arraystr::display ... ok
test arrayvec::tests::arraystr::short_typename_generic ... ok
test arrayvec::tests::arraystr::from_str_truncate ... ok
test arrayvec::tests::copy ... ok
test arrayvec::tests::macro_empty ... ok
test arrayvec::tests::arraystr::short_typename_simple ... ok
test arrayvec::tests::macro_list ... ok
test arrayvec::tests::macro_repeat ... ok
test arrayvec::tests::macro_trailing_comma ... ok
test arrayvec::tests::simple ... ok
test arrayvec::wincode_tests::arraystr ... ok
test arrayvec::wincode_tests::arraystr_rejects_invalid_utf8 ... ok
test arrayvec::wincode_tests::simple ... ok
test arrayvec::wincode_tests::non_pod ... ok
test dcache::tests::cacheline_aligned_offsets ... ok
test dcache::tests::len_too_large ... ok
test dcache::tests::map_contiguous ... ok
test dcache::tests::map_lap_boundary ... ok
test dcache::tests::no_wrap ... ok
test dcache::tests::roundtrip ... ok
test dcache::tests::spsc ... ok
test shared_vector::tests::test_arc_sharing ... ok
test shared_vector::tests::test_custom_struct ... ok
test shared_vector::tests::test_clear_invalidates_indices ... ok
test shared_vector::tests::test_multiple_clears ... ok
test dcache::tests::mpmc ... ok
test shared_vector::tests::test_push_after_clear ... ok
test shared_vector::tests::test_new_shared_vector ... ok
test shared_vector::tests::test_push_and_get ... ok
test shared_vector::tests::test_push_multiple_items ... ok
test shared_vector::tests::test_latest_read ... ok
test shared_vector::tests::test_random_read ... ok
test shared_vector::tests::test_sequential_read ... ok
test shared_vector::tests::test_latest_read_with_clear ... ok

test result: ok. 35 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 7.15s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 12 tests
test test_add_variants ... ok
test test_base_enum ... ok
test test_combo_v2_to_v3 ... ok
test test_combo_v1_to_v2 ... ok
test test_modify_single_field ... ok
test test_modify_multi_field ... ok
test test_modify_unit_passthrough ... ok
test test_relay_id_discriminants_preserved ... ok
test test_remove_variants ... ok
test test_rename_multi_field ... ok
test test_rename_single_field ... ok
test test_rename_unit ... ok

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 7 tests
test test_base_struct ... ok
test test_chain_v1_to_v4 ... ok
test test_non_copy_with_lambda_add ... ok
test test_v2_to_v3_with_modify ... ok
test test_v1_to_v2 ... ok
test test_v3_to_v4_with_multiple_modify ... ok
test test_v4_to_v5_with_lambda_add ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 3 tests
test test_default_attrs ... ok
test test_default_attrs_additional_derive ... ok
test test_structs_are_copy ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 2 tests
test test_empty_chain ... ok
test test_empty_to_with_field ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 2 tests
test final_attrs_coexist_with_custom_enum_defaults ... ok
test final_attrs_apply_only_to_final_struct ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 3 tests
test decodes_and_migrates_an_old_enum_vector ... ok
test decodes_and_migrates_an_old_struct_vector ... ok
test rejects_an_unknown_hash ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 2 tests
test evolve::tests::evolve_struct_requires_a_lock_on_every_version ... ok
test evolve::tests::evolve_struct_accepts_locked_versions ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
test crates/flux/src/spine/adapter.rs - spine::adapter::SpineAdapter<S>::set_collaborative_group (line 325) ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
test crates/flux-network/src/http.rs - http (line 6) - compile ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 3 tests
test crates/flux-versioned-types-macros/src/evolve/mod.rs - evolve::evolve_struct (line 13) ... ignored
test crates/flux-versioned-types-macros/src/evolve_enum/mod.rs - evolve_enum::evolve_enum (line 18) ... ignored
test crates/flux-versioned-types-macros/src/rolling/mod.rs - rolling::roll_chain_into (line 13) ... ignored

test result: ok. 0 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s