### PR TITLE
flux-network: drive the stream network from a caller-owned poll

### DIFF
--- a/crates/flux-network/src/lib.rs
+++ b/crates/flux-network/src/lib.rs
@@ -1,4 +1,8 @@
 pub mod http;
 
 pub mod stream;
+/// The mio a network is built on. An External-mode caller reaches `Poll`,
+/// `Registry`, `Waker`, `Events` and `event::Event` through here, so the poll
+/// it drives and the sockets flux registers on it are the same mio.
+pub use mio;
 pub use mio::Token;

--- a/crates/flux-network/src/stream/mod.rs
+++ b/crates/flux-network/src/stream/mod.rs
@@ -1,3 +1,93 @@
+//! Poll-driven byte-stream networking: TCP and Unix-domain sockets in one
+//! [`StreamNetwork`], with protocol layers as services inside it.
+//!
+//! # Poll ownership
+//! A tile hosting sockets owns exactly one poll, so which side holds it is a
+//! construction-time mode of the network.
+//!
+//! **Owned** — [`StreamNetwork::default`] — creates a poll of its own and
+//! drives it: one call per iteration, [`StreamNetwork::drive`], runs
+//! maintenance, folds every deadline, polls once, routes each event to the
+//! service owning its group and ticks each service. [`StreamNetwork::waker`]
+//! hands out a [`mio::Waker`] for that poll, on a reserved token whose wakes
+//! the loop swallows.
+//!
+//! **External** — [`StreamNetwork::with_registry`] — is built over a registry
+//! cloned from the caller's poll and a token base, and never polls. The
+//! caller polls, and makes the three calls a caller-held poll requires:
+//! [`StreamNetwork::next_deadline`] to fold into its own timeout,
+//! [`StreamNetwork::handle_event`] per readiness event, and
+//! [`StreamNetwork::tick`] once per iteration. Sources of the caller's own
+//! live in the same poll on tokens below the base — its waker included — and
+//! `handle_event` hands their events back untouched. Deadlines are folded as
+//! [`flux_timing::Instant`]s, which the caller turns into the timeout of its
+//! poll.
+//!
+//! Each mode has exactly one way of being driven — an Owned network by
+//! [`StreamNetwork::drive`], an External one by the three calls — and asking a
+//! network for the other's panics.
+//!
+//! Both modes deliver readiness and maintenance events before ticking
+//! services. Owned runs maintenance before its poll; External handles the
+//! poll's events first and runs maintenance in [`StreamNetwork::tick`]. Their
+//! order across different connections may therefore differ and is not a
+//! correctness guarantee.
+//!
+//! ```no_run
+//! use flux_network::{
+//!     Token, mio,
+//!     http::{HttpConfig, HttpEvent, HttpService},
+//!     stream::{Endpoint, Framing, ConnectionGroupConfig, StreamNetwork},
+//! };
+//! use flux_timing::Instant;
+//!
+//! // The tile's own poll, which every source it hosts shares.
+//! let mut poll = mio::Poll::new()?;
+//! let mut net = StreamNetwork::with_registry(poll.registry().try_clone()?, Token(1024));
+//! // The tile registers this waker with flux's park Signal; its token is the
+//! // caller's, below the base, so the network never takes it for its own.
+//! let _waker = mio::Waker::new(poll.registry(), Token(0))?;
+//!
+//! let group = net.add_group(ConnectionGroupConfig {
+//!     name: "api",
+//!     framing: Framing::Raw,
+//!     ..ConnectionGroupConfig::default()
+//! });
+//! let mut api = HttpService::new(&mut net, group, HttpConfig::default());
+//! api.listen(&mut net, Endpoint::Unix("/run/flux/api.sock".into()))?;
+//!
+//! let mut events = mio::Events::with_capacity(128);
+//! loop {
+//!     let mut services = [api.as_service()];
+//!     let timeout = net
+//!         .next_deadline(&services)
+//!         .map(|deadline| deadline.saturating_sub(Instant::now()).into());
+//!     poll.poll(&mut events, timeout)?;
+//!
+//!     let mut worked = false;
+//!     for event in &events {
+//!         let ours = net.handle_event(event, &mut services, |_| {});
+//!         worked |= ours;
+//!         if !ours {
+//!             // A source of the caller's own: the waker, or a socket it
+//!             // registered on this poll itself.
+//!         }
+//!     }
+//!     worked |= net.tick(&mut services, |_| {});
+//!     drop(services);
+//!
+//!     while let Some(event) = api.next_event(&mut net) {
+//!         if let HttpEvent::Request { request, responder, .. } = event {
+//!             responder.respond(200, &[], request.path.as_bytes());
+//!         }
+//!         worked = true;
+//!     }
+//!     let _ = worked; // the tile ORs this into SpineAdapter::mark_work
+//! #   break;
+//! }
+//! # Ok::<(), std::io::Error>(())
+//! ```
+
 mod connector;
 mod endpoint;
 mod network;

--- a/crates/flux-network/src/stream/network.rs
+++ b/crates/flux-network/src/stream/network.rs
@@ -6,7 +6,7 @@ use std::{
 
 use flux_communication::Timer;
 use flux_timing::{Duration, Instant, Nanos, Repeater};
-use mio::{Events, Interest, Poll, Registry, Token, event::Event};
+use mio::{Events, Interest, Poll, Registry, Token, Waker, event::Event};
 use tracing::{debug, error, info, warn};
 
 use super::{
@@ -27,6 +27,11 @@ const INITIAL_SEND_BUFFER_SIZE: usize = 32 * 1024;
 const DEFAULT_MAX_FRAME_SIZE: usize = 64 * 1024 * 1024;
 const DEFAULT_BACKLOG_WARN_BYTES: usize = 64 * 1024 * 1024;
 const BACKLOG_WARNING_INTERVAL_SECS: u64 = 10;
+// Reserved for Owned-mode wakeups; allocation stops before it.
+const WAKER_TOKEN: Token = Token(usize::MAX);
+const EXTERNAL_POLLS: &str =
+    "poll this external network yourself, then call next_deadline, handle_event and tick";
+const OWNED_POLLS: &str = "this network polls itself: use StreamNetwork::drive";
 
 /// Identifies a set of connections using the same application protocol and
 /// socket configuration.
@@ -353,12 +358,17 @@ struct PendingDisconnect {
     peer: Peer,
 }
 
+/// Everything the network holds that never polls: it registers its sockets on
+/// the registry it was given, whoever owns the poll behind it.
 struct NetworkState {
-    poll: Poll,
+    registry: Registry,
     groups: Vec<GroupState>,
     listeners: Vec<Listener>,
     connections: Vec<Connection>,
     pending_disconnects: Vec<PendingDisconnect>,
+    /// The lowest token this network allocates. Every lower token belongs to
+    /// a source the caller registered on its own poll.
+    token_base: Token,
     next_token: usize,
     /// Frames staged for the next socket write, each as a contiguous
     /// `[header][payload]` for length-prefixed groups or bare bytes for raw
@@ -366,24 +376,33 @@ struct NetworkState {
     send_buffer: Vec<u8>,
 }
 
-impl Default for NetworkState {
-    fn default() -> Self {
+impl NetworkState {
+    fn new(registry: Registry, token_base: Token) -> Self {
         Self {
-            poll: Poll::new().expect("couldn't set up a poll for the stream network"),
+            registry,
             groups: Vec::with_capacity(INITIAL_GROUP_CAPACITY),
             listeners: Vec::with_capacity(INITIAL_LISTENER_CAPACITY),
             connections: Vec::with_capacity(INITIAL_CONNECTION_CAPACITY),
             pending_disconnects: Vec::with_capacity(INITIAL_CONNECTION_CAPACITY),
-            next_token: 0,
+            token_base,
+            next_token: token_base.0,
             send_buffer: Vec::with_capacity(INITIAL_SEND_BUFFER_SIZE),
         }
     }
-}
 
-impl NetworkState {
+    /// Whether `token` is one this network allocated: at or above its base,
+    /// and below the high-water mark of its allocation. Tokens are never
+    /// reused, so anything outside that range is a source the caller
+    /// registered on its own poll — its waker included, wherever the caller
+    /// put it.
+    fn is_ours(&self, token: Token) -> bool {
+        (self.token_base.0..self.next_token).contains(&token.0)
+    }
+
     fn next_token(&mut self) -> Token {
         let token = Token(self.next_token);
-        self.next_token = self.next_token.checked_add(1).expect("stream token space exhausted");
+        assert!(token != WAKER_TOKEN, "stream token space exhausted");
+        self.next_token += 1;
         token
     }
 
@@ -397,7 +416,7 @@ impl NetworkState {
         }
         let mut socket = ListenSocket::bind(endpoint)?;
         let token = self.next_token();
-        self.poll.registry().register(&mut socket, token, Interest::READABLE)?;
+        self.registry.register(&mut socket, token, Interest::READABLE)?;
         self.listeners.push(Listener { token, group, socket });
         Ok(())
     }
@@ -441,7 +460,7 @@ impl NetworkState {
         if let Some(size) = socket_buf_size {
             set_socket_buf_size(&socket, size);
         }
-        if let Err(err) = self.poll.registry().register(&mut socket, token, Interest::WRITABLE) {
+        if let Err(err) = self.registry.register(&mut socket, token, Interest::WRITABLE) {
             warn!(?err, %peer, "couldn't register connecting stream");
             let _ = socket.shutdown(Shutdown::Both);
             return;
@@ -457,7 +476,7 @@ impl NetworkState {
         for index in (0..self.listeners.len()).rev() {
             if self.listeners[index].group == group {
                 let mut listener = self.listeners.swap_remove(index);
-                let _ = self.poll.registry().deregister(&mut listener.socket);
+                let _ = self.registry.deregister(&mut listener.socket);
             }
         }
         for index in (0..self.connections.len()).rev() {
@@ -539,7 +558,7 @@ impl NetworkState {
             let Err(err) = socket.set_nodelay()
         {
             warn!(?err, %peer, "couldn't set nodelay on tcp stream");
-            let _ = self.poll.registry().deregister(&mut socket);
+            let _ = self.registry.deregister(&mut socket);
             let _ = socket.shutdown(Shutdown::Both);
             return false;
         }
@@ -547,12 +566,12 @@ impl NetworkState {
             let Err(err) = socket.set_keepalive()
         {
             warn!(?err, %peer, "couldn't set keepalive on tcp stream");
-            let _ = self.poll.registry().deregister(&mut socket);
+            let _ = self.registry.deregister(&mut socket);
             let _ = socket.shutdown(Shutdown::Both);
             return false;
         }
         socket.set_user_timeout(config.tcp.user_timeout_ms);
-        if let Err(err) = self.poll.registry().reregister(&mut socket, token, Interest::READABLE) {
+        if let Err(err) = self.registry.reregister(&mut socket, token, Interest::READABLE) {
             warn!(?err, %peer, "couldn't register connected stream");
             let _ = socket.shutdown(Shutdown::Both);
             return false;
@@ -565,15 +584,10 @@ impl NetworkState {
                 write_frame_header(&mut header, message.len(), Nanos::now());
                 header
             });
-            if stream.write_frame(
-                self.poll.registry(),
-                header.as_ref(),
-                message,
-                config,
-                &mut timers,
-            ) == StreamState::Disconnected
+            if stream.write_frame(&self.registry, header.as_ref(), message, config, &mut timers) ==
+                StreamState::Disconnected
             {
-                stream.close(self.poll.registry());
+                stream.close(&self.registry);
                 self.connections[index].timers = timers;
                 return false;
             }
@@ -622,9 +636,7 @@ impl NetworkState {
                     continue;
                 }
                 socket.set_user_timeout(config.tcp.user_timeout_ms);
-                if let Err(err) =
-                    self.poll.registry().register(&mut socket, token, Interest::READABLE)
-                {
+                if let Err(err) = self.registry.register(&mut socket, token, Interest::READABLE) {
                     warn!(?err, %peer, "couldn't register accepted stream");
                     let _ = socket.shutdown(Shutdown::Both);
                     continue;
@@ -640,14 +652,14 @@ impl NetworkState {
                         header
                     });
                     if stream.write_frame(
-                        self.poll.registry(),
+                        &self.registry,
                         header.as_ref(),
                         message,
                         config,
                         &mut timers,
                     ) == StreamState::Disconnected
                     {
-                        stream.close(self.poll.registry());
+                        stream.close(&self.registry);
                         continue;
                     }
                 }
@@ -699,7 +711,7 @@ impl NetworkState {
             let connection = &mut self.connections[index];
             let ConnectionState::Connected(stream) = &mut connection.state else { unreachable!() };
             let state = stream.poll_with(
-                self.poll.registry(),
+                &self.registry,
                 event,
                 config,
                 &mut connection.timers,
@@ -723,12 +735,12 @@ impl NetworkState {
         match old_state {
             ConnectionState::Disconnected => false,
             ConnectionState::Connecting(mut socket) => {
-                let _ = self.poll.registry().deregister(&mut socket);
+                let _ = self.registry.deregister(&mut socket);
                 let _ = socket.shutdown(Shutdown::Both);
                 false
             }
             ConnectionState::Connected(mut stream) => {
-                stream.close(self.poll.registry());
+                stream.close(&self.registry);
                 true
             }
         }
@@ -835,7 +847,7 @@ impl NetworkState {
         let connection = &mut self.connections[index];
         let ConnectionState::Connected(stream) = &mut connection.state else { unreachable!() };
         let state = stream.write_frame(
-            self.poll.registry(),
+            &self.registry,
             None,
             &self.send_buffer,
             config,
@@ -1009,24 +1021,82 @@ impl NetworkState {
 /// A group is either **service-owned** — a protocol layer claimed it and the
 /// network routes its events to that service — or an **unclaimed group**, whose
 /// events reach the handler passed to [`Self::drive`] as they arrive.
+///
+/// Who owns the poll is fixed at construction. [`StreamNetwork::default`]
+/// makes an **Owned** network, which creates its own poll, drives it in
+/// [`Self::drive`] and hands out a [`Self::waker`] for it.
+/// [`Self::with_registry`] makes an **External** one, which registers on a
+/// registry cloned from the caller's poll and never polls: the caller polls
+/// and makes the three calls [`Self::next_deadline`], [`Self::handle_event`]
+/// and [`Self::tick`]. The [`crate::stream`] module documents the External
+/// loop in full.
 pub struct StreamNetwork {
-    events: Events,
+    poll: PollMode,
     state: NetworkState,
     /// Whether a service owns the group at each index.
     claimed: Vec<bool>,
 }
 
+/// Who owns the poll the network's sockets are registered with.
+enum PollMode {
+    /// The network made the poll and drives it in [`StreamNetwork::drive`].
+    /// `waker_taken` records that its one waker has been handed out.
+    Owned { poll: Poll, events: Events, waker_taken: bool },
+    /// The caller polls; the network only registers on the registry it was
+    /// handed, and never blocks.
+    External,
+}
+
+/// Builds an Owned-mode network: it creates the poll, drives it in
+/// [`Self::drive`] and hands out a [`Self::waker`] for it.
 impl Default for StreamNetwork {
     fn default() -> Self {
+        let poll = Poll::new().expect("couldn't set up a poll for the stream network");
+        let registry = poll
+            .registry()
+            .try_clone()
+            .expect("couldn't clone the registry of the stream network poll");
         Self {
-            events: Events::with_capacity(EVENTS_CAPACITY),
-            state: NetworkState::default(),
+            poll: PollMode::Owned {
+                poll,
+                events: Events::with_capacity(EVENTS_CAPACITY),
+                waker_taken: false,
+            },
+            state: NetworkState::new(registry, Token(0)),
             claimed: Vec::with_capacity(INITIAL_GROUP_CAPACITY),
         }
     }
 }
 
 impl StreamNetwork {
+    /// Builds a network on a poll the caller owns: External mode.
+    ///
+    /// `registry` is a `try_clone` of that poll's registry, which is where
+    /// the network registers its listeners and connections; it never polls,
+    /// so [`Self::drive`] and [`Self::waker`] are refused. The caller polls
+    /// and makes the three calls a caller-held poll requires:
+    /// [`Self::next_deadline`] to fold into its own timeout,
+    /// [`Self::handle_event`] per readiness event and [`Self::tick`] once per
+    /// iteration. The [`crate::stream`] module documents that loop in full.
+    ///
+    /// Tokens are allocated upward from `token_base`; every token the caller
+    /// uses for a source of its own — its waker included — must stay below
+    /// it, or above everything this network has allocated, which is what
+    /// makes [`Self::handle_event`] able to hand those events back.
+    ///
+    /// One External network per poll is the model. A second network's tokens
+    /// climb from a base of their own, and this one cannot tell a token above
+    /// its own high-water mark from one it will allocate next; give two
+    /// networks two polls.
+    #[must_use]
+    pub fn with_registry(registry: Registry, token_base: Token) -> Self {
+        Self {
+            poll: PollMode::External,
+            state: NetworkState::new(registry, token_base),
+            claimed: Vec::with_capacity(INITIAL_GROUP_CAPACITY),
+        }
+    }
+
     /// Adds a protocol group and returns its handle.
     #[must_use = "the group handle identifies listeners and outbound endpoints"]
     pub fn add_group(&mut self, config: ConnectionGroupConfig) -> ConnectionGroup {
@@ -1083,11 +1153,6 @@ impl StreamNetwork {
         self.release_group(group);
     }
 
-    /// The earliest instant the network's own timers need a driver call at.
-    pub(crate) fn next_deadline(&self) -> Option<Instant> {
-        self.state.next_deadline()
-    }
-
     /// Adds a listener to `group`.
     ///
     /// An [`Endpoint::Unix`] listener creates its socket file with mode `0777`
@@ -1107,8 +1172,9 @@ impl StreamNetwork {
         self.state.connect(group, endpoint)
     }
 
-    /// Runs one iteration of the network: maintenance, one poll, event
-    /// delivery and one tick per service. Returns whether anything happened.
+    /// Runs one iteration of an Owned-mode network: maintenance, one poll,
+    /// event delivery and one tick per service. Returns whether anything
+    /// happened.
     ///
     /// The poll blocks for `max_timeout` at the longest, and for less when the
     /// network's own timers or a service's [`ServiceRef`] deadline fall sooner;
@@ -1116,7 +1182,8 @@ impl StreamNetwork {
     /// service-owned group go to that service, the rest to `unclaimed_handler`,
     /// which borrows each payload for the duration of the call. Protocol
     /// events the services produced are pulled from the services
-    /// afterwards.
+    /// afterwards. A wake from [`Self::waker`] returns from the poll and is
+    /// not work of its own.
     ///
     /// The poll wait is where an iteration spends its time, so the ticks that
     /// follow it are given the time after it: a timer a tick starts runs from
@@ -1124,9 +1191,11 @@ impl StreamNetwork {
     /// in the same iteration rather than the next.
     ///
     /// # Panics
-    /// Every service-owned group must appear exactly once among `services`. A
-    /// group whose service is missing or doubled is a configuration error and
-    /// panics before the call does anything else.
+    /// A network built with [`Self::with_registry`] is driven from the
+    /// caller's poll and refuses this call. Every service-owned group must
+    /// appear exactly once among `services`; a group whose service is missing
+    /// or doubled is a configuration error and panics before the call does
+    /// anything else.
     pub fn drive<F>(
         &mut self,
         max_timeout: Option<Duration>,
@@ -1136,30 +1205,30 @@ impl StreamNetwork {
     where
         F: for<'a> FnMut(StreamEvent<'a>),
     {
+        assert!(matches!(self.poll, PollMode::Owned { .. }), "{EXTERNAL_POLLS}");
         let now = Instant::now();
         self.validate(services);
 
-        let mut routed = false;
-        {
-            let claimed = &self.claimed;
-            let mut route = |event: StreamEvent<'_>| {
-                route_event(claimed, services, &mut unclaimed_handler, &mut routed, event);
-            };
-            self.state.drain_pending_disconnects(&mut route);
-        }
-        let reconnected = self.state.maybe_reconnect(now);
-
+        let mut worked = self.maintenance(now, services, &mut unclaimed_handler);
         let timeout = self.poll_timeout(max_timeout, services, now);
-        match self.state.poll.poll(&mut self.events, timeout) {
+        let PollMode::Owned { poll, events, .. } = &mut self.poll else {
+            unreachable!("the mode is checked above");
+        };
+        match poll.poll(events, timeout) {
             Ok(()) => {
-                let claimed = &self.claimed;
-                let mut route = |event: StreamEvent<'_>| {
-                    route_event(claimed, services, &mut unclaimed_handler, &mut routed, event);
-                };
-                for event in &self.events {
-                    self.state.handle_event(event, &mut route);
+                for event in &*events {
+                    // A wake asks the poll to return and nothing more, so it
+                    // reaches neither a service nor the did-work result.
+                    if event.token() != WAKER_TOKEN {
+                        worked |= route_ready(
+                            &mut self.state,
+                            &self.claimed,
+                            event,
+                            services,
+                            &mut unclaimed_handler,
+                        );
+                    }
                 }
-                self.state.drain_pending_disconnects(&mut route);
             }
             Err(err) if err.kind() == io::ErrorKind::Interrupted => {}
             Err(err) => flux_utils::safe_panic!("couldn't poll the stream network: {err}"),
@@ -1167,24 +1236,175 @@ impl StreamNetwork {
 
         // The instant this iteration began is older than the poll wait it has
         // just come out of, which may have been the whole of a timeout.
-        let tick_now = Instant::now();
-        let mut pullable = false;
-        for service in services.iter_mut() {
-            pullable |= service.tick(self, tick_now);
-        }
-        routed || reconnected || pullable
+        let pullable = self.tick_services(services, Instant::now());
+        worked || pullable
     }
 
-    /// Runs one nonblocking iteration of a network holding unclaimed groups
-    /// only.
+    /// The earliest instant this network or one of `services` needs a call at:
+    /// the fold of the network's own timers with every service deadline.
+    ///
+    /// An External-mode caller folds only its own timers against this and
+    /// converts the result into the timeout of its poll; `None` leaves that
+    /// poll free to block until a socket is ready.
+    ///
+    /// # Panics
+    /// An Owned-mode network folds its deadlines inside [`Self::drive`], and
+    /// refuses this call. Every service-owned group must appear exactly once
+    /// among `services`, as for [`Self::drive`] — an omitted service is a
+    /// configuration error the first call reports, not one that waits for a
+    /// deadline to be missed.
+    pub fn next_deadline(&self, services: &[ServiceRef<'_>]) -> Option<Instant> {
+        assert!(matches!(self.poll, PollMode::External), "{OWNED_POLLS}");
+        self.validate(services);
+        self.fold_deadline(services)
+    }
+
+    /// Takes one readiness event from the caller's poll, reporting whether it
+    /// was this network's.
+    ///
+    /// The network's tokens run from the base it was built with up to the
+    /// high-water mark of its allocation. A token outside that range belongs
+    /// to a source the caller registered — its waker included — and is handed
+    /// straight back as `false`, untouched and unlogged. A token inside it is
+    /// this network's: the event is routed to the service owning its group, or
+    /// to `unclaimed_handler`, along with any disconnect that handling it
+    /// produced, and the call reports `true`. A token the network no longer
+    /// knows is one of its own that closed since the poll returned: ours,
+    /// and ignored.
+    ///
+    /// `true` means this network owns the token, not that routing produced an
+    /// event. Folding it into a did-work signal, as the [`crate::stream`] loop
+    /// does, is conservative: stale or otherwise non-producing readiness may
+    /// count as one busy iteration.
+    ///
+    /// # Panics
+    /// An Owned-mode network polls itself, and refuses this call. An event of
+    /// this network's validates `services` before it is routed, exactly as
+    /// [`Self::drive`] does; an event of the caller's is handed back without
+    /// looking at them, since [`Self::next_deadline`] and [`Self::tick`]
+    /// validate every iteration anyway.
+    pub fn handle_event<F>(
+        &mut self,
+        event: &Event,
+        services: &mut [ServiceRef<'_>],
+        mut unclaimed_handler: F,
+    ) -> bool
+    where
+        F: for<'a> FnMut(StreamEvent<'a>),
+    {
+        assert!(matches!(self.poll, PollMode::External), "{OWNED_POLLS}");
+        if !self.state.is_ours(event.token()) {
+            return false;
+        }
+        self.validate(services);
+        route_ready(&mut self.state, &self.claimed, event, services, &mut unclaimed_handler);
+        true
+    }
+
+    /// Runs the iteration work that owns no poll: the maintenance due now —
+    /// pending disconnects, routed to their services, and reconnect attempts —
+    /// then one tick per service in slice order. Returns whether anything
+    /// happened, a service with protocol events left to pull included.
+    ///
+    /// A transport event maintenance produces reaches its service before that
+    /// service's tick, so protocol state never lags transport state by an
+    /// iteration. An External-mode caller makes this call once per iteration,
+    /// after handing over every event its poll returned.
+    ///
+    /// # Panics
+    /// An Owned-mode network runs these phases inside [`Self::drive`], and
+    /// refuses this call. Every service-owned group must appear exactly once
+    /// among `services`, as for [`Self::drive`].
+    pub fn tick<F>(&mut self, services: &mut [ServiceRef<'_>], mut unclaimed_handler: F) -> bool
+    where
+        F: for<'a> FnMut(StreamEvent<'a>),
+    {
+        assert!(matches!(self.poll, PollMode::External), "{OWNED_POLLS}");
+        let now = Instant::now();
+        self.validate(services);
+        let worked = self.maintenance(now, services, &mut unclaimed_handler);
+        let pullable = self.tick_services(services, now);
+        worked || pullable
+    }
+
+    /// A waker for this network's own poll, on a token the event loop
+    /// swallows: waking it makes a blocked [`Self::drive`] return, and counts
+    /// as no work of its own. Under `flux/park` a tile hands this waker to
+    /// `SpineAdapter::register_waker`, after which spine work interrupts the
+    /// poll.
+    ///
+    /// A wake is delivered only while the waker that sent it is alive, so it
+    /// belongs somewhere that outlives the poll it wakes —
+    /// `register_waker` takes ownership of it, which is that somewhere.
+    ///
+    /// # Panics
+    /// A network hands out one waker: a poll takes a single one, and asking
+    /// twice panics. An External-mode network has no poll of its own, and
+    /// refuses the call: build the waker on the caller's poll instead, on one
+    /// of the caller's own tokens.
+    pub fn waker(&mut self) -> io::Result<Waker> {
+        let PollMode::Owned { poll, waker_taken, .. } = &mut self.poll else {
+            panic!(
+                "this network is driven from a caller-owned poll: build the waker on that poll, \
+                 on a token below the base the network was built with"
+            );
+        };
+        assert!(
+            !*waker_taken,
+            "a stream network hands out one waker; keep the first (SpineAdapter::register_waker \
+             stores it for the process lifetime)"
+        );
+        let waker = Waker::new(poll.registry(), WAKER_TOKEN)?;
+        *waker_taken = true;
+        Ok(waker)
+    }
+
+    /// Runs the maintenance due at `now`: the disconnects left pending by
+    /// work outside a driver call, routed to their services, and one reconnect
+    /// attempt per outbound endpoint whose group is due one.
+    fn maintenance<F>(
+        &mut self,
+        now: Instant,
+        services: &mut [ServiceRef<'_>],
+        unclaimed_handler: &mut F,
+    ) -> bool
+    where
+        F: for<'a> FnMut(StreamEvent<'a>),
+    {
+        let mut routed = false;
+        {
+            let claimed = &self.claimed;
+            let mut route = |event: StreamEvent<'_>| {
+                route_event(claimed, services, unclaimed_handler, &mut routed, event);
+            };
+            self.state.drain_pending_disconnects(&mut route);
+        }
+        let reconnected = self.state.maybe_reconnect(now);
+        routed || reconnected
+    }
+
+    /// Ticks every service once, in slice order, reporting whether any of them
+    /// has protocol events left to pull.
+    fn tick_services(&mut self, services: &mut [ServiceRef<'_>], now: Instant) -> bool {
+        let mut pullable = false;
+        for service in services.iter_mut() {
+            pullable |= service.tick(self, now);
+        }
+        pullable
+    }
+
+    /// Runs one nonblocking iteration of an Owned-mode network holding
+    /// unclaimed groups only.
     ///
     /// # Panics
     /// A network with services is driven with [`Self::drive`], which is what
-    /// delivers their events; polling it without them panics.
+    /// delivers their events; polling it without them panics. So does a
+    /// network built with [`Self::with_registry`], which owns no poll.
     pub fn poll_with<F>(&mut self, handler: F)
     where
         F: for<'a> FnMut(StreamEvent<'a>),
     {
+        assert!(matches!(self.poll, PollMode::Owned { .. }), "{EXTERNAL_POLLS}");
         if let Some(index) = self.claimed.iter().position(|claimed| *claimed) {
             panic!(
                 "connection group {index} has a service — drive the network with \
@@ -1218,6 +1438,16 @@ impl StreamNetwork {
         }
     }
 
+    /// The earliest instant the network's own timers or one of `services`
+    /// needs a call at, taking the service set as given.
+    fn fold_deadline(&self, services: &[ServiceRef<'_>]) -> Option<Instant> {
+        self.state
+            .next_deadline()
+            .into_iter()
+            .chain(services.iter().filter_map(|service| service.next_deadline()))
+            .min()
+    }
+
     /// Folds the caller's cap, the network's own timers and every service's
     /// deadline into the timeout of one poll.
     fn poll_timeout(
@@ -1226,11 +1456,7 @@ impl StreamNetwork {
         services: &[ServiceRef<'_>],
         now: Instant,
     ) -> Option<std::time::Duration> {
-        let deadline = self
-            .next_deadline()
-            .into_iter()
-            .chain(services.iter().filter_map(|service| service.next_deadline()))
-            .min();
+        let deadline = self.fold_deadline(services);
         let timeout = match (max_timeout, deadline.map(|deadline| deadline.saturating_sub(now))) {
             (Some(max), Some(next)) => Some(max.min(next)),
             (max, next) => max.or(next),
@@ -1315,6 +1541,28 @@ impl StreamNetwork {
     pub fn remove(&mut self, token: Token) -> bool {
         self.state.remove(token)
     }
+}
+
+/// Routes one readiness event of a socket this network owns, together with
+/// the disconnects handling it produced, and reports whether anything reached
+/// a service or the unclaimed handler.
+fn route_ready<F>(
+    state: &mut NetworkState,
+    claimed: &[bool],
+    event: &Event,
+    services: &mut [ServiceRef<'_>],
+    unclaimed_handler: &mut F,
+) -> bool
+where
+    F: for<'a> FnMut(StreamEvent<'a>),
+{
+    let mut routed = false;
+    let mut route = |event: StreamEvent<'_>| {
+        route_event(claimed, services, unclaimed_handler, &mut routed, event);
+    };
+    state.handle_event(event, &mut route);
+    state.drain_pending_disconnects(&mut route);
+    routed
 }
 
 /// Hands one event to the service owning its group, or to the unclaimed handler

--- a/crates/flux-network/src/stream/service.rs
+++ b/crates/flux-network/src/stream/service.rs
@@ -67,7 +67,7 @@ mod tests {
     };
 
     use flux_timing::{Duration, Instant};
-    use mio::Token;
+    use mio::{Events, Poll, Token};
 
     use super::{ServiceRef, private::ServiceDriver};
     use crate::stream::{
@@ -174,6 +174,33 @@ mod tests {
             framing: Framing::Raw,
             ..ConnectionGroupConfig::default()
         })
+    }
+
+    /// A poll the test owns, and the External-mode network registered on it.
+    struct External {
+        poll: Poll,
+        events: Events,
+    }
+
+    impl External {
+        fn build() -> (Self, StreamNetwork) {
+            let poll = Poll::new().unwrap();
+            let network =
+                StreamNetwork::with_registry(poll.registry().try_clone().unwrap(), Token(100));
+            (Self { poll, events: Events::with_capacity(16) }, network)
+        }
+
+        /// One iteration of the loop a caller-held poll requires.
+        fn iterate(&mut self, network: &mut StreamNetwork, probe: &mut Probe) -> bool {
+            let mut services = [probe.as_service()];
+            let _ = network.next_deadline(&services);
+            self.poll.poll(&mut self.events, Some(std::time::Duration::from_millis(1))).unwrap();
+            let mut worked = false;
+            for event in &self.events {
+                worked |= network.handle_event(event, &mut services, |_| {});
+            }
+            worked | network.tick(&mut services, |_| {})
+        }
     }
 
     /// Drives one service until it has seen what the test waits for.
@@ -291,6 +318,37 @@ mod tests {
         // next drive delivers it as maintenance, before any tick.
         assert!(network.disconnect(accepted));
         network.drive(Some(Duration::ZERO), &mut [probe.as_service()], |_| {});
+
+        assert!(
+            matches!(probe.steps.as_slice(), [Step::Disconnected(token), Step::Tick(_)]
+                if *token == accepted),
+            "{:?}",
+            probe.steps
+        );
+        drop(client);
+    }
+
+    #[test]
+    fn an_external_tick_delivers_a_maintenance_disconnect_before_the_tick() {
+        let (mut external, mut network) = External::build();
+        let group = raw_group(&mut network, "kicked");
+        let addr = unused_addr();
+        network.listen(group, Endpoint::Tcp(addr)).unwrap();
+        network.claim_group(group);
+        let mut probe = Probe::new(group);
+        let client = StdTcpStream::connect(addr).unwrap();
+
+        let deadline = std::time::Instant::now() + PATIENCE;
+        while std::time::Instant::now() < deadline && probe.accepted().is_none() {
+            external.iterate(&mut network, &mut probe);
+        }
+        let accepted = probe.accepted().expect("the service never accepted the client");
+        probe.steps.clear();
+
+        // Disconnecting outside a driver call leaves the event pending, so the
+        // maintenance the next tick runs delivers it, before that tick.
+        assert!(network.disconnect(accepted));
+        assert!(network.tick(&mut [probe.as_service()], |_| {}));
 
         assert!(
             matches!(probe.steps.as_slice(), [Step::Disconnected(token), Step::Tick(_)]

--- a/crates/flux-network/tests/external_mode.rs
+++ b/crates/flux-network/tests/external_mode.rs
@@ -1,0 +1,611 @@
+//! The network on a poll its caller owns: the three calls, the classification
+//! of foreign tokens, the waker of each mode, and the misuse each mode
+//! refuses.
+
+use std::{
+    collections::BTreeSet,
+    io::{self, Read, Write},
+    net::{Ipv4Addr, SocketAddr, TcpStream},
+    sync::{Arc, Mutex},
+    thread,
+    time::{Duration, Instant},
+};
+
+use flux_network::{
+    Token,
+    http::{HttpConfig, HttpEvent, HttpService},
+    stream::{ConnectionGroupConfig, Endpoint, Framing, ServiceRef, StreamEvent, StreamNetwork},
+};
+use mio::{Events, Interest, Poll, Waker};
+
+const TIMEOUT: Duration = Duration::from_secs(10);
+/// How long one iteration of a test loop is allowed to wait in the poll.
+const POLL_SLICE: Duration = Duration::from_millis(1);
+/// Where the network's own tokens start. Everything below is the caller's.
+const TOKEN_BASE: Token = Token(1000);
+/// A token of the caller's own, for a source the network never sees.
+const FOREIGN: Token = Token(7);
+
+/// A loopback address no listener holds. The probe binding is released before
+/// the address is handed out, and a port this run has already given away is
+/// never given away again.
+fn unused_addr() -> SocketAddr {
+    static TAKEN: Mutex<BTreeSet<u16>> = Mutex::new(BTreeSet::new());
+    let mut probes = Vec::new();
+    loop {
+        let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let addr = listener.local_addr().unwrap();
+        if TAKEN.lock().unwrap().insert(addr.port()) {
+            return addr;
+        }
+        probes.push(listener);
+        assert!(probes.len() < 64, "no free loopback port");
+    }
+}
+
+fn raw_group(name: &'static str) -> ConnectionGroupConfig {
+    ConnectionGroupConfig {
+        name,
+        framing: Framing::Raw,
+        max_frame_size: usize::MAX,
+        backlog_warn_bytes: None,
+        ..ConnectionGroupConfig::default()
+    }
+}
+
+/// A poll the test owns, and the network registered on it.
+struct External {
+    poll: Poll,
+    events: Events,
+    net: StreamNetwork,
+}
+
+impl External {
+    fn new() -> Self {
+        let poll = Poll::new().unwrap();
+        let net = StreamNetwork::with_registry(poll.registry().try_clone().unwrap(), TOKEN_BASE);
+        Self { poll, events: Events::with_capacity(64), net }
+    }
+
+    /// One iteration of the loop a caller-held poll requires: fold the
+    /// deadlines into the poll timeout, hand over every event, tick once.
+    /// The timeout is capped so that a test never waits on a regression.
+    fn iterate<F>(&mut self, services: &mut [ServiceRef<'_>], mut unclaimed_handler: F) -> bool
+    where
+        F: for<'a> FnMut(StreamEvent<'a>),
+    {
+        let Self { poll, events, net } = self;
+        let timeout = net
+            .next_deadline(services)
+            .map(|deadline| Duration::from(deadline.saturating_sub(flux_timing::Instant::now())))
+            .map_or(POLL_SLICE, |wait| wait.min(POLL_SLICE));
+        poll.poll(events, Some(timeout)).unwrap();
+        let mut worked = false;
+        for event in &*events {
+            worked |= net.handle_event(event, services, &mut unclaimed_handler);
+        }
+        worked | net.tick(services, &mut unclaimed_handler)
+    }
+}
+
+fn client_at(addr: SocketAddr) -> TcpStream {
+    let client = TcpStream::connect(addr).unwrap();
+    client.set_nonblocking(true).unwrap();
+    client
+}
+
+/// Reads what is there, reporting whether more may be waiting.
+fn read_available(stream: &mut impl Read, out: &mut Vec<u8>) -> bool {
+    let mut buf = [0; 8192];
+    match stream.read(&mut buf) {
+        Ok(0) => false,
+        Ok(read) => {
+            out.extend_from_slice(&buf[..read]);
+            read == buf.len()
+        }
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => false,
+        Err(err) => panic!("read failed: {err}"),
+    }
+}
+
+fn response_len(bytes: &[u8]) -> Option<usize> {
+    let head = bytes.windows(4).position(|window| window == b"\r\n\r\n")? + 4;
+    let text = std::str::from_utf8(&bytes[..head]).unwrap();
+    let length = text
+        .lines()
+        .find_map(|line| line.strip_prefix("Content-Length: "))
+        .unwrap()
+        .parse::<usize>()
+        .unwrap();
+    (bytes.len() >= head + length).then_some(head + length)
+}
+
+/// An HTTP service listening on `addr`, inside a network on the test's poll.
+fn served(ext: &mut External, addr: SocketAddr, config: HttpConfig) -> HttpService {
+    let group = ext.net.add_group(raw_group("http"));
+    let mut http = HttpService::new(&mut ext.net, group, config);
+    http.listen(&mut ext.net, Endpoint::Tcp(addr)).unwrap();
+    http
+}
+
+// ---------------------------------------------------------------------------
+// The three calls
+
+#[test]
+fn an_external_network_serves_over_the_three_calls() {
+    let mut ext = External::new();
+    let addr = unused_addr();
+    let mut http = served(&mut ext, addr, HttpConfig::default());
+    let mut client = client_at(addr);
+    client.write_all(b"GET /over-there HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
+
+    let mut paths = Vec::new();
+    let mut received = Vec::new();
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && response_len(&received).is_none() {
+        ext.iterate(&mut [http.as_service()], |_| panic!("no unclaimed group exists"));
+        while let Some(event) = http.next_event(&mut ext.net) {
+            if let HttpEvent::Request { request, responder, .. } = event {
+                paths.push(request.path.to_owned());
+                assert!(responder.respond(200, &[], b"served"));
+            }
+        }
+        while read_available(&mut client, &mut received) {}
+    }
+
+    assert_eq!(paths, ["/over-there"]);
+    assert!(received.ends_with(b"served"), "{}", String::from_utf8_lossy(&received));
+    http.close(&mut ext.net);
+}
+
+#[test]
+fn a_foreign_source_keeps_its_events_and_its_connections() {
+    let mut ext = External::new();
+    let addr = unused_addr();
+    let mut http = served(&mut ext, addr, HttpConfig::default());
+
+    // A listener of the caller's own, on a token below the network's base.
+    let foreign_addr = unused_addr();
+    let mut foreign = mio::net::TcpListener::bind(foreign_addr).unwrap();
+    ext.poll.registry().register(&mut foreign, FOREIGN, Interest::READABLE).unwrap();
+
+    let _to_foreign = client_at(foreign_addr);
+    let _to_network = client_at(addr);
+
+    let mut ours = 0;
+    let mut theirs = 0;
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && (ours == 0 || theirs == 0) {
+        let mut services = [http.as_service()];
+        let _ = ext.net.next_deadline(&services);
+        ext.poll.poll(&mut ext.events, Some(POLL_SLICE)).unwrap();
+        for event in &ext.events {
+            if ext.net.handle_event(event, &mut services, |_| {}) {
+                assert_ne!(event.token(), FOREIGN, "the network claimed the caller's token");
+                ours += 1;
+            } else {
+                assert_eq!(event.token(), FOREIGN, "the network disowned a token of its own");
+                theirs += 1;
+            }
+        }
+        ext.net.tick(&mut services, |_| {});
+    }
+
+    assert!(ours > 0, "the network never saw an event of its own");
+    assert!(theirs > 0, "the caller's listener never became readable");
+    // Untouched means untouched: the connection is still there to accept.
+    assert!(foreign.accept().is_ok(), "the network accepted the caller's connection");
+    http.close(&mut ext.net);
+}
+
+#[test]
+fn a_foreign_event_is_handed_back_before_the_services_are_checked() {
+    let mut ext = External::new();
+    let group = ext.net.add_group(raw_group("http"));
+    let _http = HttpService::new(&mut ext.net, group, HttpConfig::default());
+
+    // A wake of the caller's own, on a token below the network's base.
+    let waker = Waker::new(ext.poll.registry(), FOREIGN).unwrap();
+    waker.wake().unwrap();
+    ext.poll.poll(&mut ext.events, Some(TIMEOUT)).unwrap();
+    let event = ext.events.iter().next().expect("the wake was not delivered");
+
+    // The empty slice omits the service owning the group, which any call of
+    // the network's own reports; an event of the caller's is handed back
+    // without the services being looked at.
+    assert!(!ext.net.handle_event(event, &mut [], |_| {}));
+}
+
+#[test]
+#[should_panic(expected = "service-owned group 0 has no service")]
+fn an_own_event_is_checked_against_the_services_before_it_is_routed() {
+    let mut ext = External::new();
+    let addr = unused_addr();
+    let _http = served(&mut ext, addr, HttpConfig::default());
+    let _client = client_at(addr);
+
+    // The listener becomes readable on a token of the network's own, and the
+    // same empty slice is a configuration error that event reports.
+    let deadline = Instant::now() + TIMEOUT;
+    loop {
+        assert!(Instant::now() < deadline, "the listener never became readable");
+        ext.poll.poll(&mut ext.events, Some(POLL_SLICE)).unwrap();
+        if let Some(event) = ext.events.iter().next() {
+            ext.net.handle_event(event, &mut [], |_| {});
+        }
+    }
+}
+
+#[test]
+fn a_tick_reports_a_request_no_one_pulled() {
+    let mut ext = External::new();
+    let addr = unused_addr();
+    let mut http = served(&mut ext, addr, HttpConfig::default());
+    let mut client = client_at(addr);
+
+    let deadline = Instant::now() + TIMEOUT;
+    let mut accepted = false;
+    while Instant::now() < deadline && !accepted {
+        ext.iterate(&mut [http.as_service()], |_| {});
+        while let Some(event) = http.next_event(&mut ext.net) {
+            accepted |= matches!(event, HttpEvent::Accepted { .. });
+        }
+    }
+    assert!(accepted, "the client was never accepted");
+    assert!(
+        !ext.net.tick(&mut [http.as_service()], |_| {}),
+        "everything was pulled, so nothing is work"
+    );
+
+    // Nothing pulls from here on: the request must be work for as long as it
+    // is left there.
+    client.write_all(b"GET /unpulled HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
+    let mut pullable = false;
+    while Instant::now() < deadline && !pullable {
+        ext.iterate(&mut [http.as_service()], |_| {});
+        // No event arrives inside a tick of its own, and the network has no
+        // outbound endpoint to reconnect, so `true` is the service's alone.
+        pullable = ext.net.tick(&mut [http.as_service()], |_| {});
+    }
+    assert!(pullable, "the request never became work");
+
+    let mut paths = Vec::new();
+    while let Some(event) = http.next_event(&mut ext.net) {
+        if let HttpEvent::Request { request, .. } = event {
+            paths.push(request.path.to_owned());
+        }
+    }
+    assert_eq!(paths, ["/unpulled"]);
+    http.close(&mut ext.net);
+}
+
+#[test]
+fn a_tick_attempts_the_reconnect_that_is_due() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("late");
+    let mut ext = External::new();
+    let group = ext.net.add_group(ConnectionGroupConfig {
+        reconnect_interval: flux_timing::Duration::from_millis(20),
+        ..raw_group("outbound")
+    });
+
+    // Nothing is listening yet, so the first attempt fails and the group is
+    // left with a retry due every interval.
+    let token = ext.net.connect(group, Endpoint::Unix(path.clone()));
+    for _ in 0..3 {
+        ext.iterate(&mut [], |_| panic!("nothing is connected yet"));
+    }
+
+    let listener = std::os::unix::net::UnixListener::bind(&path).unwrap();
+    let mut connected = false;
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && !connected {
+        ext.iterate(&mut [], |event| {
+            connected |= matches!(event, StreamEvent::Connected { token: at, .. } if at == token);
+        });
+    }
+
+    assert!(connected, "no tick ever retried the endpoint");
+    drop(listener);
+}
+
+#[test]
+fn a_late_event_for_a_gone_connection_is_still_ours() {
+    let mut ext = External::new();
+    let group = ext.net.add_group(raw_group("stale"));
+    let addr = unused_addr();
+    ext.net.listen(group, Endpoint::Tcp(addr)).unwrap();
+    let mut client = client_at(addr);
+
+    let deadline = Instant::now() + TIMEOUT;
+    let mut accepted = None;
+    while Instant::now() < deadline && accepted.is_none() {
+        ext.iterate(&mut [], |event| {
+            if let StreamEvent::Accepted { token, .. } = event {
+                accepted = Some(token);
+            }
+        });
+    }
+    let accepted = accepted.expect("the client was never accepted");
+    client.write_all(b"late").unwrap();
+
+    // The caller owns the loop, so a connection can go between the poll and
+    // the event it returned: what arrives is ours, and gone.
+    let mut handled = false;
+    while Instant::now() < deadline && !handled {
+        ext.poll.poll(&mut ext.events, Some(POLL_SLICE)).unwrap();
+        for event in &ext.events {
+            if event.token() != accepted {
+                continue;
+            }
+            assert!(ext.net.remove(accepted));
+            assert!(
+                ext.net.handle_event(event, &mut [], |_| panic!(
+                    "a gone connection delivered an event"
+                )),
+                "a stale token of the network's own was disowned"
+            );
+            handled = true;
+        }
+    }
+    assert!(handled, "the connection never became readable");
+}
+
+// ---------------------------------------------------------------------------
+// Deadlines
+
+#[test]
+fn next_deadline_folds_the_services_idle_sweep() {
+    let mut ext = External::new();
+    let addr = unused_addr();
+    let idle = flux_timing::Duration::from_millis(500);
+    let mut http = served(&mut ext, addr, HttpConfig::default().with_idle_timeout(idle));
+    assert!(
+        ext.net.next_deadline(&[http.as_service()]).is_none(),
+        "nothing is due before a connection exists"
+    );
+
+    let _client = client_at(addr);
+    let deadline = Instant::now() + TIMEOUT;
+    let mut accepted = false;
+    while Instant::now() < deadline && !accepted {
+        ext.iterate(&mut [http.as_service()], |_| {});
+        while let Some(event) = http.next_event(&mut ext.net) {
+            accepted |= matches!(event, HttpEvent::Accepted { .. });
+        }
+    }
+    assert!(accepted, "the client was never accepted");
+
+    let folded = ext.net.next_deadline(&[http.as_service()]).expect("the sweep of that connection");
+    let left = Duration::from(folded.saturating_sub(flux_timing::Instant::now()));
+    assert!(left <= Duration::from(idle), "later than the sweep: {left:?}");
+    assert!(left > Duration::ZERO, "the sweep is already past: {left:?}");
+    http.close(&mut ext.net);
+}
+
+#[test]
+#[should_panic(expected = "service-owned group 0 has no service")]
+fn next_deadline_validates_before_it_folds() {
+    let mut ext = External::new();
+    let group = ext.net.add_group(raw_group("http"));
+    let _http = HttpService::new(&mut ext.net, group, HttpConfig::default());
+
+    // No socket has moved and no event has arrived: an omitted service is a
+    // configuration error the first fold reports all the same.
+    let _ = ext.net.next_deadline(&[]);
+}
+
+// ---------------------------------------------------------------------------
+// Wakers
+
+#[test]
+fn a_wake_returns_from_a_blocking_drive_without_work() {
+    let mut net = StreamNetwork::default();
+    let group = net.add_group(raw_group("raw"));
+    let addr = unused_addr();
+    net.listen(group, Endpoint::Tcp(addr)).unwrap();
+    // A waker delivers only while it is alive, so the test holds one end of
+    // it for as long as the drive it wakes.
+    let waker = Arc::new(net.waker().unwrap());
+    let woken = Arc::clone(&waker);
+
+    // The late connection is the test's own deadline: a drive that missed
+    // the wake returns on it, well past the bound below, rather than hang.
+    thread::spawn(move || {
+        thread::sleep(Duration::from_millis(200));
+        woken.wake().unwrap();
+        thread::sleep(Duration::from_secs(3));
+        drop(std::net::TcpStream::connect(addr));
+    });
+
+    let started = Instant::now();
+    let mut delivered = 0;
+    let worked = net.drive(None, &mut [], |_| delivered += 1);
+    let waited = started.elapsed();
+
+    assert!(!worked, "a wake is not work of its own");
+    assert_eq!(delivered, 0, "the wake reached the handler");
+    assert!(waited >= Duration::from_millis(100), "the drive never blocked: {waited:?}");
+    assert!(waited < Duration::from_secs(2), "the wake did not return from the poll: {waited:?}");
+    drop(waker);
+}
+
+#[test]
+fn an_external_waker_is_the_callers_own() {
+    let mut ext = External::new();
+    let waker = Arc::new(Waker::new(ext.poll.registry(), FOREIGN).unwrap());
+    let woken = Arc::clone(&waker);
+    thread::spawn(move || {
+        thread::sleep(Duration::from_millis(100));
+        woken.wake().unwrap();
+    });
+
+    // The timeout is the test's own deadline: a wake that never arrives ends
+    // the poll with nothing in it rather than hanging.
+    let started = Instant::now();
+    ext.poll.poll(&mut ext.events, Some(TIMEOUT)).unwrap();
+    assert!(started.elapsed() < Duration::from_secs(5), "the poll was not woken");
+
+    let mut seen = 0;
+    for event in &ext.events {
+        assert_eq!(event.token(), FOREIGN);
+        assert!(
+            !ext.net.handle_event(event, &mut [], |_| {}),
+            "the network took the caller's wake for its own"
+        );
+        seen += 1;
+    }
+    assert_eq!(seen, 1, "the wake never arrived");
+    drop(waker);
+}
+
+// ---------------------------------------------------------------------------
+// Mode misuse
+
+#[test]
+#[should_panic(expected = "poll this external network yourself")]
+fn driving_a_network_on_a_caller_owned_poll_is_refused() {
+    let mut ext = External::new();
+    ext.net.drive(Some(flux_timing::Duration::ZERO), &mut [], |_| {});
+}
+
+#[test]
+#[should_panic(expected = "poll this external network yourself")]
+fn polling_a_network_on_a_caller_owned_poll_is_refused() {
+    let mut ext = External::new();
+    ext.net.poll_with(|_| {});
+}
+
+#[test]
+#[should_panic(expected = "this network polls itself")]
+fn handing_an_owned_network_an_event_is_refused() {
+    // Any event will do: the mode is settled before the token is looked at.
+    let mut poll = Poll::new().unwrap();
+    let waker = Waker::new(poll.registry(), FOREIGN).unwrap();
+    waker.wake().unwrap();
+    let mut events = Events::with_capacity(4);
+    poll.poll(&mut events, Some(TIMEOUT)).unwrap();
+    let event = events.iter().next().expect("the wake was not delivered");
+
+    let mut net = StreamNetwork::default();
+    net.handle_event(event, &mut [], |_| {});
+}
+
+#[test]
+#[should_panic(expected = "this network polls itself")]
+fn asking_an_owned_network_for_a_deadline_is_refused() {
+    let net = StreamNetwork::default();
+    let _ = net.next_deadline(&[]);
+}
+
+#[test]
+#[should_panic(expected = "this network polls itself")]
+fn ticking_an_owned_network_is_refused() {
+    let mut net = StreamNetwork::default();
+    net.tick(&mut [], |_| {});
+}
+
+#[test]
+#[should_panic(expected = "build the waker on that poll")]
+fn a_waker_for_a_caller_owned_poll_is_refused() {
+    let mut ext = External::new();
+    let _ = ext.net.waker();
+}
+
+#[test]
+#[should_panic(expected = "hands out one waker")]
+fn a_network_hands_out_one_waker() {
+    let mut net = StreamNetwork::default();
+    let _first = net.waker().unwrap();
+    let _second = net.waker().unwrap();
+}
+
+#[test]
+fn a_caller_waker_at_the_top_of_the_token_space_is_not_ours() {
+    let mut ext = External::new();
+    // The token the network reserves for a waker of its own is one no
+    // allocation reaches, so the caller may put its waker there too.
+    let waker = Arc::new(Waker::new(ext.poll.registry(), Token(usize::MAX)).unwrap());
+    let woken = Arc::clone(&waker);
+    thread::spawn(move || {
+        thread::sleep(Duration::from_millis(100));
+        woken.wake().unwrap();
+    });
+
+    let started = Instant::now();
+    ext.poll.poll(&mut ext.events, Some(TIMEOUT)).unwrap();
+    assert!(started.elapsed() < Duration::from_secs(5), "the poll was not woken");
+
+    let mut seen = 0;
+    for event in &ext.events {
+        assert_eq!(event.token(), Token(usize::MAX));
+        assert!(
+            !ext.net.handle_event(event, &mut [], |_| {}),
+            "the network took the caller's wake for a stale token of its own"
+        );
+        seen += 1;
+    }
+    assert_eq!(seen, 1, "the wake never arrived");
+    drop(waker);
+}
+
+#[test]
+#[should_panic(expected = "stream token space exhausted")]
+fn allocation_stops_below_the_reserved_waker_token() {
+    let poll = Poll::new().unwrap();
+    let mut net =
+        StreamNetwork::with_registry(poll.registry().try_clone().unwrap(), Token(usize::MAX - 1));
+    let group = net.add_group(raw_group("edge"));
+    net.listen(group, Endpoint::Tcp(unused_addr())).unwrap();
+    // The next token would be the one the waker reserves.
+    net.listen(group, Endpoint::Tcp(unused_addr())).unwrap();
+}
+
+#[test]
+fn handle_event_delivers_the_disconnect_it_produced() {
+    let mut ext = External::new();
+    let group = ext
+        .net
+        .add_group(ConnectionGroupConfig { socket_buf_size: Some(1024), ..raw_group("drained") });
+    let addr = unused_addr();
+    ext.net.listen(group, Endpoint::Tcp(addr)).unwrap();
+    let mut client = client_at(addr);
+
+    // No tick runs anywhere in this test: everything the network reports has
+    // to come out of the events handed to it.
+    let mut accepted = None;
+    let mut disconnected = None;
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && accepted.is_none() {
+        ext.poll.poll(&mut ext.events, Some(POLL_SLICE)).unwrap();
+        for event in &ext.events {
+            ext.net.handle_event(event, &mut [], |event| {
+                if let StreamEvent::Accepted { token, .. } = event {
+                    accepted = Some(token);
+                }
+            });
+        }
+    }
+    let accepted = accepted.expect("the client was never accepted");
+
+    // A backlog the socket cannot swallow, so the queue is still there when
+    // the close is asked for and the drain happens under a writable event.
+    assert!(ext.net.send_with(accepted, |out| out.resize(4 * 1024 * 1024, 7)));
+    assert!(ext.net.disconnect_when_drained(accepted));
+
+    let mut drained = Vec::new();
+    while Instant::now() < deadline && disconnected.is_none() {
+        ext.poll.poll(&mut ext.events, Some(POLL_SLICE)).unwrap();
+        for event in &ext.events {
+            ext.net.handle_event(event, &mut [], |event| {
+                if let StreamEvent::Disconnected { token, .. } = event {
+                    disconnected = Some(token);
+                }
+            });
+        }
+        while read_available(&mut client, &mut drained) {}
+    }
+
+    assert_eq!(disconnected, Some(accepted), "the disconnect waited for a tick");
+    assert_eq!(drained.len(), 4 * 1024 * 1024, "the backlog was not written before the close");
+}

--- a/crates/flux-network/tests/http.rs
+++ b/crates/flux-network/tests/http.rs
@@ -10,7 +10,9 @@ use std::{
 use flux_network::{
     Token,
     http::{HttpConfig, HttpEvent, HttpService},
-    stream::{ConnectionGroupConfig, Endpoint, Framing, Peer, StreamEvent, StreamNetwork},
+    stream::{
+        ConnectionGroupConfig, Endpoint, Framing, Peer, ServiceRef, StreamEvent, StreamNetwork,
+    },
 };
 
 const TIMEOUT: Duration = Duration::from_secs(10);
@@ -47,33 +49,94 @@ fn http_group() -> ConnectionGroupConfig {
     }
 }
 
+/// Who owns the poll a network is driven from.
+#[derive(Clone, Copy)]
+enum Mode {
+    /// The network's own, driven by `drive`.
+    Owned,
+    /// The test's own, driven by the three calls it requires.
+    External,
+}
+
+/// The poll a network is driven from, and what one iteration of it is.
+struct Driver {
+    /// The test's own poll, in External mode; `None` when the network polls.
+    poll: Option<(mio::Poll, mio::Events)>,
+}
+
+impl Driver {
+    /// A network of `mode`, and the driver that runs its iterations.
+    fn build(mode: Mode) -> (Self, StreamNetwork) {
+        match mode {
+            Mode::Owned => (Self { poll: None }, StreamNetwork::default()),
+            Mode::External => {
+                let poll = mio::Poll::new().unwrap();
+                let net =
+                    StreamNetwork::with_registry(poll.registry().try_clone().unwrap(), Token(1000));
+                (Self { poll: Some((poll, mio::Events::with_capacity(64))) }, net)
+            }
+        }
+    }
+
+    /// One nonblocking iteration: one `drive`, or the three calls a
+    /// caller-held poll requires.
+    fn iterate<F>(
+        &mut self,
+        net: &mut StreamNetwork,
+        services: &mut [ServiceRef<'_>],
+        mut unclaimed_handler: F,
+    ) -> bool
+    where
+        F: for<'a> FnMut(StreamEvent<'a>),
+    {
+        let Some((poll, events)) = &mut self.poll else {
+            return net.drive(Some(Duration::ZERO.into()), services, unclaimed_handler);
+        };
+        // The fold is what an External caller turns into its poll timeout;
+        // this one polls without waiting, and calls it for the same
+        // validation every iteration owes the network.
+        let _ = net.next_deadline(services);
+        poll.poll(events, Some(Duration::ZERO)).unwrap();
+        let mut worked = false;
+        for event in &*events {
+            worked |= net.handle_event(event, services, &mut unclaimed_handler);
+        }
+        worked | net.tick(services, &mut unclaimed_handler)
+    }
+}
+
 /// A network carrying one HTTP service, driven and pulled as one.
 struct Http {
     net: StreamNetwork,
-    http: HttpService,
+    service: HttpService,
+    driver: Driver,
 }
 
 impl Http {
-    fn build(group: ConnectionGroupConfig, config: HttpConfig) -> Self {
-        let mut net = StreamNetwork::default();
+    fn build(mode: Mode, group: ConnectionGroupConfig, config: HttpConfig) -> Self {
+        let (driver, mut net) = Driver::build(mode);
         let group = net.add_group(group);
-        let http = HttpService::new(&mut net, group, config);
-        Self { net, http }
+        let service = HttpService::new(&mut net, group, config);
+        Self { net, service, driver }
     }
 
     fn new() -> Self {
-        Self::build(http_group(), HttpConfig::default())
+        Self::new_in(Mode::Owned)
+    }
+
+    fn new_in(mode: Mode) -> Self {
+        Self::build(mode, http_group(), HttpConfig::default())
     }
 
     fn with_config(config: HttpConfig) -> Self {
-        Self::build(http_group(), config)
+        Self::build(Mode::Owned, http_group(), config)
     }
 
     /// One iteration: drive the network, then pull every protocol event.
     fn pump(&mut self, mut handler: impl for<'a> FnMut(HttpEvent<'a>)) {
         self.drive();
         let mut pulled = 0;
-        while let Some(event) = self.http.next_event(&mut self.net) {
+        while let Some(event) = self.service.next_event(&mut self.net) {
             handler(event);
             pulled += 1;
             assert!(pulled < 10_000, "the pull loop delivered the same work forever");
@@ -82,15 +145,16 @@ impl Http {
 
     /// One iteration of the network alone, leaving the events to be pulled.
     fn drive(&mut self) -> bool {
-        self.net.drive(Some(Duration::ZERO.into()), &mut [self.http.as_service()], |_| {})
+        let Self { net, service, driver } = self;
+        driver.iterate(net, &mut [service.as_service()], |_| {})
     }
 
     fn listen(&mut self, endpoint: &Endpoint) {
-        self.http.listen(&mut self.net, endpoint.clone()).unwrap();
+        self.service.listen(&mut self.net, endpoint.clone()).unwrap();
     }
 
     fn connect(&mut self, endpoint: Endpoint) -> Token {
-        self.http.connect(&mut self.net, endpoint)
+        self.service.connect(&mut self.net, endpoint)
     }
 
     fn respond(
@@ -100,7 +164,7 @@ impl Http {
         headers: &[(&str, &str)],
         body: &[u8],
     ) -> bool {
-        self.http.respond(&mut self.net, token, status, headers, body)
+        self.service.respond(&mut self.net, token, status, headers, body)
     }
 
     fn request(
@@ -111,15 +175,15 @@ impl Http {
         headers: &[(&str, &str)],
         body: &[u8],
     ) -> bool {
-        self.http.request(&mut self.net, token, method, path, headers, body)
+        self.service.request(&mut self.net, token, method, path, headers, body)
     }
 
     fn disconnect(&mut self, token: Token) -> bool {
-        self.http.disconnect(&mut self.net, token)
+        self.service.disconnect(&mut self.net, token)
     }
 
     fn remove(&mut self, token: Token) -> bool {
-        self.http.remove(&mut self.net, token)
+        self.service.remove(&mut self.net, token)
     }
 }
 
@@ -137,6 +201,49 @@ macro_rules! over_both_transports {
         fn $unix() {
             let dir = tempfile::tempdir().unwrap();
             $body(&Endpoint::Unix(dir.path().join("s")));
+        }
+    };
+}
+
+/// Runs one test body over both transports and both poll-ownership modes: the
+/// four tests one behaviour has to pass however the network is driven.
+macro_rules! over_transports_and_modes {
+    ($body:ident, $tcp:ident, $tcp_external:ident, $unix:ident, $unix_external:ident) => {
+        #[test]
+        fn $tcp() {
+            $body(Mode::Owned, &Endpoint::Tcp(unused_addr()));
+        }
+
+        #[test]
+        fn $tcp_external() {
+            $body(Mode::External, &Endpoint::Tcp(unused_addr()));
+        }
+
+        #[test]
+        fn $unix() {
+            let dir = tempfile::tempdir().unwrap();
+            $body(Mode::Owned, &Endpoint::Unix(dir.path().join("s")));
+        }
+
+        #[test]
+        fn $unix_external() {
+            let dir = tempfile::tempdir().unwrap();
+            $body(Mode::External, &Endpoint::Unix(dir.path().join("s")));
+        }
+    };
+}
+
+/// Runs one test body under both poll-ownership modes.
+macro_rules! over_both_modes {
+    ($body:ident, $owned:ident, $external:ident) => {
+        #[test]
+        fn $owned() {
+            $body(Mode::Owned);
+        }
+
+        #[test]
+        fn $external() {
+            $body(Mode::External);
         }
     };
 }
@@ -190,7 +297,11 @@ fn response_len(bytes: &[u8]) -> Option<usize> {
 }
 
 fn server_at(endpoint: &Endpoint) -> Http {
-    let mut server = Http::new();
+    server_at_in(Mode::Owned, endpoint)
+}
+
+fn server_at_in(mode: Mode, endpoint: &Endpoint) -> Http {
+    let mut server = Http::new_in(mode);
     server.listen(endpoint);
     server
 }
@@ -200,13 +311,15 @@ fn server() -> (Http, SocketAddr) {
     (server_at(&Endpoint::Tcp(addr)), addr)
 }
 
-over_both_transports!(
+over_transports_and_modes!(
     get_keepalive_two_requests,
     get_keepalive_two_requests_tcp,
-    get_keepalive_two_requests_unix
+    get_keepalive_two_requests_tcp_external,
+    get_keepalive_two_requests_unix,
+    get_keepalive_two_requests_unix_external
 );
-fn get_keepalive_two_requests(endpoint: &Endpoint) {
-    let mut server = server_at(endpoint);
+fn get_keepalive_two_requests(mode: Mode, endpoint: &Endpoint) {
+    let mut server = server_at_in(mode, endpoint);
     let mut client = connect_client(endpoint);
     let deadline = Instant::now() + TIMEOUT;
     let mut first = Vec::new();
@@ -250,9 +363,15 @@ fn get_keepalive_two_requests(endpoint: &Endpoint) {
     assert!(second.ends_with(b"two"));
 }
 
-over_both_transports!(post_echo_body, post_echo_body_tcp, post_echo_body_unix);
-fn post_echo_body(endpoint: &Endpoint) {
-    let mut server = server_at(endpoint);
+over_transports_and_modes!(
+    post_echo_body,
+    post_echo_body_tcp,
+    post_echo_body_tcp_external,
+    post_echo_body_unix,
+    post_echo_body_unix_external
+);
+fn post_echo_body(mode: Mode, endpoint: &Endpoint) {
+    let mut server = server_at_in(mode, endpoint);
     let body = vec![42; 4096];
     let mut client = connect_client(endpoint);
     client
@@ -335,6 +454,7 @@ fn post_binary_body_lone_lf() {
 fn connection_close_large_body() {
     let addr = unused_addr();
     let mut server = Http::build(
+        Mode::Owned,
         ConnectionGroupConfig { socket_buf_size: Some(1024), ..http_group() },
         HttpConfig::default(),
     );
@@ -414,9 +534,15 @@ fn caller_connection_close_header_sent() {
     assert!(text.ends_with("ok"));
 }
 
-over_both_transports!(pipelined_requests, pipelined_requests_tcp, pipelined_requests_unix);
-fn pipelined_requests(endpoint: &Endpoint) {
-    let mut server = server_at(endpoint);
+over_transports_and_modes!(
+    pipelined_requests,
+    pipelined_requests_tcp,
+    pipelined_requests_tcp_external,
+    pipelined_requests_unix,
+    pipelined_requests_unix_external
+);
+fn pipelined_requests(mode: Mode, endpoint: &Endpoint) {
+    let mut server = server_at_in(mode, endpoint);
     let mut client = connect_client(endpoint);
     client
         .write_all(b"GET /one HTTP/1.1\r\nHost: x\r\n\r\nGET /two HTTP/1.1\r\nHost: x\r\n\r\n")
@@ -442,14 +568,16 @@ fn pipelined_requests(endpoint: &Endpoint) {
     assert!(received.ends_with(b"/two"));
 }
 
-over_both_transports!(
+over_transports_and_modes!(
     client_server_roundtrip,
     client_server_roundtrip_tcp,
-    client_server_roundtrip_unix
+    client_server_roundtrip_tcp_external,
+    client_server_roundtrip_unix,
+    client_server_roundtrip_unix_external
 );
-fn client_server_roundtrip(endpoint: &Endpoint) {
-    let mut server = server_at(endpoint);
-    let mut client = Http::new();
+fn client_server_roundtrip(mode: Mode, endpoint: &Endpoint) {
+    let mut server = server_at_in(mode, endpoint);
+    let mut client = Http::new_in(mode);
     let token = client.connect(endpoint.clone());
     let mut sent = false;
     let mut bodies = Vec::new();
@@ -1197,7 +1325,7 @@ fn serve_two_pipelined_requests(inline_first: bool) -> (Vec<String>, Vec<u8>) {
     while Instant::now() < deadline && !received.ends_with(b"/two") {
         let mut deferred = None;
         server.drive();
-        while let Some(event) = server.http.next_event(&mut server.net) {
+        while let Some(event) = server.service.next_event(&mut server.net) {
             if let HttpEvent::Request { token, request, responder } = event {
                 let path = request.path.to_owned();
                 if pulled.is_empty() && !inline_first {
@@ -1247,7 +1375,7 @@ fn serve_the_request_behind_an_answer(inline_first: bool) {
     while Instant::now() < deadline && !answered {
         let mut deferred = None;
         server.drive();
-        while let Some(event) = server.http.next_event(&mut server.net) {
+        while let Some(event) = server.service.next_event(&mut server.net) {
             if let HttpEvent::Request { token, request, responder } = event {
                 assert_eq!(request.path, "/one", "{path}");
                 if inline_first {
@@ -1273,7 +1401,7 @@ fn serve_the_request_behind_an_answer(inline_first: bool) {
 
     let mut pulled = false;
     while Instant::now() < deadline && !pulled {
-        while let Some(event) = server.http.next_event(&mut server.net) {
+        while let Some(event) = server.service.next_event(&mut server.net) {
             if let HttpEvent::Request { request, responder, .. } = event {
                 assert_eq!(request.method, "POST", "{path}");
                 assert_eq!(request.path, "/two", "{path}");
@@ -1343,7 +1471,7 @@ fn answered_bytes_cost_the_connection_nothing() {
     let mut token = None;
     while Instant::now() < deadline && token.is_none() {
         server.drive();
-        while let Some(event) = server.http.next_event(&mut server.net) {
+        while let Some(event) = server.service.next_event(&mut server.net) {
             if let HttpEvent::Request { token: pulled, responder, .. } = event {
                 assert!(responder.respond(200, &[], b""));
                 token = Some(pulled);
@@ -1411,7 +1539,7 @@ fn a_pending_request_survives_a_compaction() {
     while Instant::now() < deadline && pulled.len() < 2 {
         server.drive();
         while pulled.len() < 2 {
-            let Some(event) = server.http.next_event(&mut server.net) else { break };
+            let Some(event) = server.service.next_event(&mut server.net) else { break };
             if let HttpEvent::Request { token, request, responder } = event {
                 pulled.push(request.path.to_owned());
                 if pulled.len() == 1 {
@@ -1517,7 +1645,7 @@ fn a_caller_may_stop_pulling_and_resume_later() {
     let mut deferred = None;
     while Instant::now() < deadline && deferred.is_none() {
         server.drive();
-        if let Some(HttpEvent::Request { token, .. }) = server.http.next_event(&mut server.net) {
+        if let Some(HttpEvent::Request { token, .. }) = server.service.next_event(&mut server.net) {
             deferred = Some(token);
         }
         thread::sleep(Duration::from_millis(1));
@@ -1607,7 +1735,7 @@ fn a_pending_request_reports_work_and_holds_off_the_sweep() {
     let mut token = None;
     while Instant::now() < deadline && token.is_none() {
         server.drive();
-        while let Some(event) = server.http.next_event(&mut server.net) {
+        while let Some(event) = server.service.next_event(&mut server.net) {
             if let HttpEvent::Request { token: pulled, .. } = event {
                 token = Some(pulled);
                 break
@@ -1644,7 +1772,7 @@ fn work_is_reported_after_an_inline_answer_stops_the_pull() {
     let mut answered = false;
     while Instant::now() < deadline && !answered {
         server.drive();
-        while let Some(event) = server.http.next_event(&mut server.net) {
+        while let Some(event) = server.service.next_event(&mut server.net) {
             if let HttpEvent::Request { request, responder, .. } = event {
                 assert_eq!(request.path, "/one");
                 assert!(responder.respond(200, &[], b"one"));
@@ -1657,7 +1785,7 @@ fn work_is_reported_after_an_inline_answer_stops_the_pull() {
     assert!(answered, "no request arrived");
 
     assert!(server.drive(), "the request behind the answered one is work");
-    match server.http.next_event(&mut server.net) {
+    match server.service.next_event(&mut server.net) {
         Some(HttpEvent::Request { request, responder, .. }) => {
             assert_eq!(request.path, "/two");
             assert!(responder.respond(200, &[], b"two"));
@@ -1691,7 +1819,7 @@ fn a_blocking_drive_wakes_for_the_idle_sweep() {
         drop(std::net::TcpStream::connect(addr));
     });
     let started = Instant::now();
-    server.net.drive(None, &mut [server.http.as_service()], |_| {});
+    server.net.drive(None, &mut [server.service.as_service()], |_| {});
     let waited = started.elapsed();
     assert!(waited >= Duration::from_millis(100), "returned at once: {waited:?}");
     assert!(waited < Duration::from_secs(2), "the sweep deadline was not folded: {waited:?}");
@@ -1714,14 +1842,14 @@ fn a_blocking_drive_wakes_for_a_connection() {
         drop((early, late));
     });
     let started = Instant::now();
-    let worked = server.net.drive(None, &mut [server.http.as_service()], |_| {});
+    let worked = server.net.drive(None, &mut [server.service.as_service()], |_| {});
     let waited = started.elapsed();
     assert!(worked, "an accepted connection is work");
     assert!(waited >= Duration::from_millis(150), "the drive did not block: {waited:?}");
     assert!(waited < Duration::from_secs(2), "the drive missed the connection: {waited:?}");
 
     let mut accepted = false;
-    while let Some(event) = server.http.next_event(&mut server.net) {
+    while let Some(event) = server.service.next_event(&mut server.net) {
         accepted |= matches!(event, HttpEvent::Accepted { .. });
     }
     assert!(accepted, "the connection that woke the poll was not delivered");
@@ -1790,9 +1918,13 @@ fn an_accepted_connection_is_announced_before_its_first_request() {
     assert_eq!(order, ["accepted", "request"]);
 }
 
-#[test]
-fn two_services_on_one_network_keep_their_own_events() {
-    let mut net = StreamNetwork::default();
+over_both_modes!(
+    two_services_on_one_network_keep_their_own_events,
+    two_services_on_one_network_keep_their_own_events_owned,
+    two_services_on_one_network_keep_their_own_events_external
+);
+fn two_services_on_one_network_keep_their_own_events(mode: Mode) {
+    let (mut driver, mut net) = Driver::build(mode);
     let first_group = net.add_group(ConnectionGroupConfig { name: "first", ..http_group() });
     let second_group = net.add_group(ConnectionGroupConfig { name: "second", ..http_group() });
     let mut first = HttpService::new(&mut net, first_group, HttpConfig::default());
@@ -1811,11 +1943,9 @@ fn two_services_on_one_network_keep_their_own_events() {
     let mut second_paths = Vec::new();
     let deadline = Instant::now() + TIMEOUT;
     while Instant::now() < deadline && (first_paths.is_empty() || second_paths.is_empty()) {
-        net.drive(
-            Some(Duration::ZERO.into()),
-            &mut [first.as_service(), second.as_service()],
-            |event| panic!("no unclaimed group exists: {:?}", event_group(&event)),
-        );
+        driver.iterate(&mut net, &mut [first.as_service(), second.as_service()], |event| {
+            panic!("no unclaimed group exists: {:?}", event_group(&event))
+        });
         while let Some(event) = first.next_event(&mut net) {
             if let HttpEvent::Request { request, responder, .. } = event {
                 first_paths.push(request.path.to_owned());


### PR DESCRIPTION
This PR builds on #139. It adds the External poll mode from ADR 0001: a `StreamNetwork` that registers on the caller's poll and never polls itself. One commit.

## Poll ownership

Poll ownership is fixed when the network is constructed. `StreamNetwork::default()` creates an Owned network driven by one `drive` call per iteration. `StreamNetwork::with_registry(registry, token_base)` creates an External network driven through the caller's poll:

```rust
let mut net = StreamNetwork::with_registry(poll.registry().try_clone()?, Token(1024));

let timeout = net
    .next_deadline(&services)
    .map(|deadline| deadline.saturating_sub(Instant::now()).into());
poll.poll(&mut events, timeout)?;

for event in &events {
    let ours = net.handle_event(event, &mut services, |_| {});
    worked |= ours;
    if !ours {
        // Handle a source registered by the caller.
    }
}
worked |= net.tick(&mut services, |_| {});
```

Each mode has one driving interface. Owned networks refuse `next_deadline`, `handle_event` and `tick`; External networks refuse `drive`, `poll_with` and `waker`.

Both modes deliver readiness and maintenance events before ticking services. Owned runs maintenance before its poll; External handles the poll's events first and runs maintenance in `tick`. Ordering across different connections may therefore differ and is not a correctness guarantee.

## Tokens and wakers

An External network allocates tokens upward from `token_base` without reuse. `handle_event` returns `true` for a token in that range, including a stale token whose connection has closed, and `false` for a caller-owned source. Folding this ownership result into a work signal is conservative: stale or otherwise non-producing readiness may count as one busy iteration.

Caller-owned tokens stay below the base. One External network is supported per poll because tokens above its current high-water mark cannot be distinguished from future allocations.

An Owned network can provide one `mio::Waker` on the reserved token `Token(usize::MAX)`. Waking it interrupts a blocked `drive` without counting as work. External callers create a waker on their own poll and token.

`flux_network::mio` re-exports the mio types used by the network, so callers can construct the exact `Poll`, `Registry`, `Event` and `Waker` types required by the API.

## Verification

External-mode tests cover the three-call loop, deadline folding, reconnects, foreign and stale events, validation order, mode misuse, wakers, token bounds and disconnect delivery. The HTTP suite runs its baseline behavior over Owned and External polls, with both TCP and Unix sockets.

The loopback tests, this PR's included, still guess unused TCP ports. That race is fixed later in the stack when `listen` reports the endpoint it bound; rerun the job if it appears in CI.

Workspace tests, Clippy with warnings denied, the nightly formatting check and `cargo doc` pass at this tip with no new warnings.

Base: #139. Next: A5, connection admission and half-close.

Refer: #143

Assisted-by: Claude Code:claude-fable-5
Assisted-by: Codex:gpt-5
