### PR TITLE
flux-network: half-close the write side and cap accepted connections

### DIFF
--- a/crates/flux-network/src/stream/network.rs
+++ b/crates/flux-network/src/stream/network.rs
@@ -324,7 +324,25 @@ struct Connection {
     endpoint: Option<Endpoint>,
     state: ConnectionState,
     close_when_drained: bool,
+    /// How far the write side has got toward the half-close a caller asked
+    /// for.
+    write_side: WriteSide,
     timers: Option<NetworkTimers>,
+}
+
+/// The write side of a connected socket: what the half-close requested
+/// through [`StreamNetwork::shutdown_write_when_drained`] is waiting for, and
+/// whether it has happened.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum WriteSide {
+    /// Open, and carrying whatever the caller sends.
+    Open,
+    /// To be shut as soon as the queued bytes reach the peer. Sends are
+    /// refused from the request onward, so the queue only shrinks.
+    ShutWhenDrained,
+    /// Shut: the peer has read the end of the stream, and what it sends still
+    /// arrives.
+    Shut,
 }
 
 #[derive(Clone, Copy)]
@@ -434,6 +452,7 @@ impl NetworkState {
             endpoint: Some(endpoint),
             state: ConnectionState::Disconnected,
             close_when_drained: false,
+            write_side: WriteSide::Open,
             timers,
         });
         self.start_connect(self.connections.len() - 1);
@@ -673,6 +692,7 @@ impl NetworkState {
                 endpoint: None,
                 state: ConnectionState::Connected(stream),
                 close_when_drained: false,
+                write_side: WriteSide::Open,
                 timers,
             });
             info!(group = group_name, %peer, "connection accepted");
@@ -724,8 +744,15 @@ impl NetworkState {
         if state == StreamState::Disconnected {
             handler(StreamEvent::Disconnected { group, token, peer });
             self.disconnect_index(index, false);
-        } else if self.connections[index].close_when_drained && queue_empty {
-            self.disconnect_index(index, true);
+        } else if queue_empty {
+            // A connection asked for both closes outright: a peer about to
+            // lose the connection gains nothing from reading the end of the
+            // stream first.
+            if self.connections[index].close_when_drained {
+                self.disconnect_index(index, true);
+            } else if self.connections[index].write_side == WriteSide::ShutWhenDrained {
+                self.shut_write(index);
+            }
         }
     }
 
@@ -754,6 +781,7 @@ impl NetworkState {
         };
         let accepted = self.connections[index].endpoint.is_none();
         self.connections[index].close_when_drained = false;
+        self.connections[index].write_side = WriteSide::Open;
         let was_connected = self.close_connection_socket(index);
         if accepted {
             self.connections.swap_remove(index);
@@ -781,6 +809,7 @@ impl NetworkState {
         self.connections.iter().position(|connection| {
             connection.token == token &&
                 !connection.close_when_drained &&
+                connection.write_side == WriteSide::Open &&
                 matches!(connection.state, ConnectionState::Connected(_))
         })
     }
@@ -903,6 +932,7 @@ impl NetworkState {
             self.connections.iter().any(|connection| {
                 connection.group == group &&
                     !connection.close_when_drained &&
+                    connection.write_side == WriteSide::Open &&
                     matches!(connection.state, ConnectionState::Connected(_))
             })
     }
@@ -917,6 +947,7 @@ impl NetworkState {
             index -= 1;
             if self.connections[index].group != group ||
                 self.connections[index].close_when_drained ||
+                self.connections[index].write_side != WriteSide::Open ||
                 !matches!(self.connections[index].state, ConnectionState::Connected(_))
             {
                 continue;
@@ -991,6 +1022,38 @@ impl NetworkState {
         }
         self.connections[index].close_when_drained = true;
         true
+    }
+
+    fn shutdown_write_when_drained(&mut self, token: Token) -> bool {
+        let Some(index) = self.connections.iter().position(|connection| connection.token == token)
+        else {
+            return false;
+        };
+        let ConnectionState::Connected(stream) = &self.connections[index].state else {
+            return false;
+        };
+        let drained = stream.send_queue.is_empty();
+        match self.connections[index].write_side {
+            WriteSide::Open if drained => self.shut_write(index),
+            WriteSide::Open => self.connections[index].write_side = WriteSide::ShutWhenDrained,
+            WriteSide::ShutWhenDrained | WriteSide::Shut => {}
+        }
+        true
+    }
+
+    /// Shuts the write side of a connected socket, which stays registered and
+    /// readable: the peer reads the end of the stream, and what it sends
+    /// afterwards still arrives.
+    fn shut_write(&mut self, index: usize) {
+        let peer = self.connections[index].peer;
+        if let ConnectionState::Connected(stream) = &self.connections[index].state &&
+            let Err(err) = stream.socket.shutdown(Shutdown::Write)
+        {
+            // A peer that has gone already refuses the shutdown, and its own
+            // end of stream is on its way here.
+            debug!(?err, %peer, "couldn't shut the write side");
+        }
+        self.connections[index].write_side = WriteSide::Shut;
     }
 
     fn remove(&mut self, token: Token) -> bool {
@@ -1534,6 +1597,25 @@ impl StreamNetwork {
     /// `TCP_USER_TIMEOUT`; a Unix-domain peer has no such bound.
     pub fn disconnect_when_drained(&mut self, token: Token) -> bool {
         self.state.disconnect_when_drained(token)
+    }
+
+    /// Shuts the write side of a connection once its queued bytes have been
+    /// written, and keeps reading it: the peer reads the end of the stream,
+    /// while the bytes it sends afterwards still arrive as
+    /// [`StreamEvent::Message`] and its own close still arrives as
+    /// [`StreamEvent::Disconnected`]. Both transports of the [`Endpoint`] set
+    /// half-close. Returns `false` for unknown or disconnected tokens; a
+    /// connection whose write side is already shut, or already waiting to be,
+    /// is left as it is.
+    ///
+    /// Sends to such a token are rejected and queue nothing, so the queue
+    /// only shrinks from the call onward. [`Self::disconnect`] still closes
+    /// the connection outright at any point, and a token that is draining as
+    /// well ([`Self::disconnect_when_drained`]) closes when its queue empties
+    /// rather than half-closing. A TCP peer that never drains is bounded only
+    /// by `TCP_USER_TIMEOUT`; a Unix-domain peer has no such bound.
+    pub fn shutdown_write_when_drained(&mut self, token: Token) -> bool {
+        self.state.shutdown_write_when_drained(token)
     }
 
     /// Permanently removes a connection or outbound endpoint. Returns whether

--- a/crates/flux-network/src/stream/network.rs
+++ b/crates/flux-network/src/stream/network.rs
@@ -308,6 +308,9 @@ impl StreamEvent<'_> {
 struct GroupState {
     config: ConnectionGroupConfig,
     reconnector: Repeater,
+    /// Accepted connections this group currently holds, including those
+    /// draining or half-closed. Outbound connections do not count.
+    accepted: usize,
     /// Connections refused since the group was added because it was at its
     /// cap, and when the last of them was warned about.
     refused: u64,
@@ -516,6 +519,8 @@ impl NetworkState {
                 self.connections.swap_remove(index);
             }
         }
+        // Every accepted connection of the group was removed above.
+        self.groups[group.0].accepted = 0;
         self.pending_disconnects.retain(|event| event.group != group);
     }
 
@@ -647,7 +652,7 @@ impl NetworkState {
                 }
             };
             if let Some(max) = self.config(group).max_connections &&
-                self.accepted_connections(group) >= max
+                self.groups[group.0].accepted >= max
             {
                 // The refusal is all that happens to this connection: it
                 // is never registered, never read from and never written
@@ -719,20 +724,10 @@ impl NetworkState {
                 write_side: WriteSide::Open,
                 timers,
             });
+            self.groups[group.0].accepted += 1;
             info!(group = group_name, %peer, "connection accepted");
             handler(StreamEvent::Accepted { group, token, peer });
         }
-    }
-
-    /// How many connections `group` accepted and still holds. A connection
-    /// it is closing is one of them — draining or half-closed alike — while
-    /// an outbound endpoint of the group is a connection the network made
-    /// rather than accepted, and counts for nothing.
-    fn accepted_connections(&self, group: ConnectionGroup) -> usize {
-        self.connections
-            .iter()
-            .filter(|connection| connection.group == group && connection.endpoint.is_none())
-            .count()
     }
 
     /// Counts one refused connection, warning about the group at most once
@@ -843,6 +838,7 @@ impl NetworkState {
         let was_connected = self.close_connection_socket(index);
         if accepted {
             self.connections.swap_remove(index);
+            self.groups[event.group.0].accepted -= 1;
         }
         if notify && was_connected {
             self.pending_disconnects.push(event);
@@ -1120,7 +1116,10 @@ impl NetworkState {
             return false;
         };
         self.close_connection_socket(index);
-        self.connections.swap_remove(index);
+        let removed = self.connections.swap_remove(index);
+        if removed.endpoint.is_none() {
+            self.groups[removed.group.0].accepted -= 1;
+        }
         self.pending_disconnects.retain(|event| event.token != token);
         true
     }
@@ -1247,6 +1246,7 @@ impl StreamNetwork {
         self.state.groups.push(GroupState {
             config,
             reconnector,
+            accepted: 0,
             refused: 0,
             last_refusal_warning: None,
         });

--- a/crates/flux-network/src/stream/network.rs
+++ b/crates/flux-network/src/stream/network.rs
@@ -237,6 +237,13 @@ pub struct ConnectionGroupConfig {
     /// Largest accepted or emitted frame payload. For [`Framing::Raw`], this
     /// caps a single send and bounds each received read chunk.
     pub max_frame_size: usize,
+    /// Most accepted connections this group holds at once. A connection it
+    /// is closing counts as one of them — draining or half-closed alike —
+    /// while the outbound endpoints and listeners of the group count for
+    /// nothing. `None` sets no limit. At the cap, a pending connection is
+    /// accepted and dropped where it stands, without registration, bytes or
+    /// an event, and counted by [`StreamNetwork::refused_connections`].
+    pub max_connections: Option<usize>,
     /// Wire encoding used by this group.
     pub framing: Framing,
     /// Per-connection latency and allocation telemetry.
@@ -256,6 +263,7 @@ impl Default for ConnectionGroupConfig {
             backlog_warn_bytes: Some(DEFAULT_BACKLOG_WARN_BYTES),
             max_backlog_bytes: None,
             max_frame_size: DEFAULT_MAX_FRAME_SIZE,
+            max_connections: None,
             framing: Framing::LengthPrefixed,
             telemetry: TcpTelemetry::Disabled,
             tcp: TcpOptions::default(),
@@ -300,6 +308,10 @@ impl StreamEvent<'_> {
 struct GroupState {
     config: ConnectionGroupConfig,
     reconnector: Repeater,
+    /// Connections refused since the group was added because it was at its
+    /// cap, and when the last of them was warned about.
+    refused: u64,
+    last_refusal_warning: Option<Instant>,
 }
 
 struct Listener {
@@ -634,6 +646,18 @@ impl NetworkState {
                     break;
                 }
             };
+            if let Some(max) = self.config(group).max_connections &&
+                self.accepted_connections(group) >= max
+            {
+                // The refusal is all that happens to this connection: it
+                // is never registered, never read from and never written
+                // to, so the peer reads the end of the stream without ever
+                // being sent a byte. The backlog still has to be drained to
+                // `WouldBlock`, so the loop goes on.
+                let _ = socket.shutdown(Shutdown::Both);
+                self.refuse(group, peer, max);
+                continue;
+            }
             let token = self.next_token();
             let (stream, timers, group_name) = {
                 let config = self.config(group);
@@ -698,6 +722,40 @@ impl NetworkState {
             info!(group = group_name, %peer, "connection accepted");
             handler(StreamEvent::Accepted { group, token, peer });
         }
+    }
+
+    /// How many connections `group` accepted and still holds. A connection
+    /// it is closing is one of them — draining or half-closed alike — while
+    /// an outbound endpoint of the group is a connection the network made
+    /// rather than accepted, and counts for nothing.
+    fn accepted_connections(&self, group: ConnectionGroup) -> usize {
+        self.connections
+            .iter()
+            .filter(|connection| connection.group == group && connection.endpoint.is_none())
+            .count()
+    }
+
+    /// Counts one refused connection, warning about the group at most once
+    /// every [`BACKLOG_WARNING_INTERVAL_SECS`] seconds: a group at its cap
+    /// refuses as often as clients arrive, and the count is what says how
+    /// often that is.
+    fn refuse(&mut self, group: ConnectionGroup, peer: Peer, max: usize) {
+        let state = &mut self.groups[group.0];
+        state.refused += 1;
+        if state
+            .last_refusal_warning
+            .is_some_and(|last| last.elapsed() < Duration::from_secs(BACKLOG_WARNING_INTERVAL_SECS))
+        {
+            return;
+        }
+        warn!(
+            group = state.config.name,
+            %peer,
+            max_connections = max,
+            refused = state.refused,
+            "refusing a connection: the group is at its connection cap"
+        );
+        state.last_refusal_warning = Some(Instant::now());
     }
 
     fn handle_event<F>(&mut self, event: &Event, handler: &mut F)
@@ -1177,6 +1235,7 @@ impl StreamNetwork {
                 "on_connect_msg exceeds max_frame_size"
             );
         }
+        assert!(config.max_connections != Some(0), "max_connections must be nonzero");
         if let Some(max) = config.max_backlog_bytes {
             assert!(max > 0, "max_backlog_bytes must be nonzero");
             if let Some(warn) = config.backlog_warn_bytes {
@@ -1185,7 +1244,12 @@ impl StreamNetwork {
         }
         let group = ConnectionGroup(self.state.groups.len());
         let reconnector = Repeater::every(config.reconnect_interval);
-        self.state.groups.push(GroupState { config, reconnector });
+        self.state.groups.push(GroupState {
+            config,
+            reconnector,
+            refused: 0,
+            last_refusal_warning: None,
+        });
         self.claimed.push(false);
         group
     }
@@ -1616,6 +1680,17 @@ impl StreamNetwork {
     /// by `TCP_USER_TIMEOUT`; a Unix-domain peer has no such bound.
     pub fn shutdown_write_when_drained(&mut self, token: Token) -> bool {
         self.state.shutdown_write_when_drained(token)
+    }
+
+    /// How many connections `group` refused since it was added because it
+    /// was already holding its [`ConnectionGroupConfig::max_connections`] cap.
+    ///
+    /// # Panics
+    /// The group must be one this network added.
+    #[must_use]
+    pub fn refused_connections(&self, group: ConnectionGroup) -> u64 {
+        assert!(group.0 < self.state.groups.len(), "unknown connection group");
+        self.state.groups[group.0].refused
     }
 
     /// Permanently removes a connection or outbound endpoint. Returns whether

--- a/crates/flux-network/src/stream/network.rs
+++ b/crates/flux-network/src/stream/network.rs
@@ -352,8 +352,8 @@ enum WriteSide {
     /// To be shut as soon as the queued bytes reach the peer. Sends are
     /// refused from the request onward, so the queue only shrinks.
     ShutWhenDrained,
-    /// Shut: the peer has read the end of the stream, and what it sends still
-    /// arrives.
+    /// Shut: the peer can read the end of the stream, and what it sends
+    /// still arrives.
     Shut,
 }
 

--- a/crates/flux-network/tests/connection_cap.rs
+++ b/crates/flux-network/tests/connection_cap.rs
@@ -1,0 +1,443 @@
+//! The per-group connection cap: which connections hold a place in it, and
+//! what a client that arrives at a full group sees.
+
+use std::{
+    io::{self, Read, Write},
+    net::{Ipv4Addr, SocketAddr},
+    thread,
+    time::{Duration, Instant},
+};
+
+use flux_network::{
+    Token,
+    http::{HttpConfig, HttpEvent, HttpService},
+    stream::{
+        ConnectionGroup, ConnectionGroupConfig, Endpoint, Framing, StreamEvent, StreamNetwork,
+    },
+};
+
+const TIMEOUT: Duration = Duration::from_secs(10);
+const REQUEST: &[u8] = b"GET /hello HTTP/1.1\r\nHost: x\r\n\r\n";
+const BODY: &[u8] = b"hello";
+
+fn unused_addr() -> SocketAddr {
+    let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+    addr
+}
+
+/// Runs one test body over both transports: a loopback TCP address on an
+/// ephemeral port, and a Unix-domain socket path under a temporary directory
+/// that lives for the duration of the run.
+macro_rules! over_both_transports {
+    ($body:ident, $tcp:ident, $unix:ident) => {
+        #[test]
+        fn $tcp() {
+            $body(&Endpoint::Tcp(unused_addr()));
+        }
+
+        #[test]
+        fn $unix() {
+            let dir = tempfile::tempdir().unwrap();
+            $body(&Endpoint::Unix(dir.path().join("s")));
+        }
+    };
+}
+
+/// A nonblocking client socket speaking raw bytes to the network under test.
+trait ClientStream: Read + Write {}
+impl<T: Read + Write> ClientStream for T {}
+
+fn connect_client(endpoint: &Endpoint) -> Box<dyn ClientStream> {
+    match endpoint {
+        Endpoint::Tcp(addr) => {
+            let stream = std::net::TcpStream::connect(addr).unwrap();
+            stream.set_nonblocking(true).unwrap();
+            Box::new(stream)
+        }
+        Endpoint::Unix(path) => {
+            let stream = std::os::unix::net::UnixStream::connect(path).unwrap();
+            stream.set_nonblocking(true).unwrap();
+            Box::new(stream)
+        }
+    }
+}
+
+fn raw_group(name: &'static str) -> ConnectionGroupConfig {
+    ConnectionGroupConfig { name, framing: Framing::Raw, ..ConnectionGroupConfig::default() }
+}
+
+fn capped_group(name: &'static str, max: usize) -> ConnectionGroupConfig {
+    ConnectionGroupConfig { max_connections: Some(max), ..raw_group(name) }
+}
+
+/// Reads what the client can without blocking, reporting the end of the
+/// stream.
+///
+/// A refused connection is closed under bytes the client has already sent,
+/// which answers a read with a reset rather than a clean end; both mean the
+/// same thing here.
+fn read_available(client: &mut dyn Read, out: &mut Vec<u8>) -> bool {
+    let mut buffer = [0; 16 * 1024];
+    match client.read(&mut buffer) {
+        Ok(0) => true,
+        Ok(read) => {
+            out.extend_from_slice(&buffer[..read]);
+            false
+        }
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => false,
+        Err(err) if err.kind() == io::ErrorKind::ConnectionReset => true,
+        Err(err) => panic!("client read failed: {err}"),
+    }
+}
+
+/// A network under test, and the lifecycle events it delivered.
+struct Server {
+    network: StreamNetwork,
+    accepted: Vec<(ConnectionGroup, Token)>,
+    connected: Vec<Token>,
+    disconnected: Vec<Token>,
+}
+
+impl Server {
+    fn new() -> Self {
+        Self {
+            network: StreamNetwork::default(),
+            accepted: Vec::new(),
+            connected: Vec::new(),
+            disconnected: Vec::new(),
+        }
+    }
+
+    /// Adds a group and a listener for it.
+    fn listen(&mut self, config: ConnectionGroupConfig, endpoint: &Endpoint) -> ConnectionGroup {
+        let group = self.network.add_group(config);
+        self.network.listen(group, endpoint.clone()).unwrap();
+        group
+    }
+
+    /// Runs one iteration of the network, recording what it delivers.
+    fn pump(&mut self) {
+        let Self { network, accepted, connected, disconnected } = self;
+        network.poll_with(|event| match event {
+            StreamEvent::Accepted { group, token, .. } => accepted.push((group, token)),
+            StreamEvent::Connected { token, .. } => connected.push(token),
+            StreamEvent::Disconnected { token, .. } => disconnected.push(token),
+            StreamEvent::Message { .. } => {}
+        });
+    }
+
+    fn accepted_in(&self, group: ConnectionGroup) -> Vec<Token> {
+        self.accepted
+            .iter()
+            .filter(|(event_group, _)| *event_group == group)
+            .map(|(_, token)| *token)
+            .collect()
+    }
+
+    fn refused(&self, group: ConnectionGroup) -> u64 {
+        self.network.refused_connections(group)
+    }
+
+    /// Pumps until `group` has accepted `count` connections.
+    fn wait_for_accepts(&mut self, group: ConnectionGroup, count: usize) -> Vec<Token> {
+        let deadline = Instant::now() + TIMEOUT;
+        while Instant::now() < deadline && self.accepted_in(group).len() < count {
+            self.pump();
+            thread::sleep(Duration::from_millis(1));
+        }
+        let accepted = self.accepted_in(group);
+        assert_eq!(accepted.len(), count, "the group accepted the wrong number of connections");
+        accepted
+    }
+
+    /// Pumps until `count` connections have been reported closed.
+    fn wait_for_disconnects(&mut self, count: usize) {
+        let deadline = Instant::now() + TIMEOUT;
+        while Instant::now() < deadline && self.disconnected.len() < count {
+            self.pump();
+            thread::sleep(Duration::from_millis(1));
+        }
+        assert_eq!(self.disconnected.len(), count);
+    }
+
+    /// Asserts that the network closes `client` without sending it a byte.
+    fn expect_refusal(&mut self, client: &mut dyn Read) {
+        let deadline = Instant::now() + TIMEOUT;
+        let mut received = Vec::new();
+        while !read_available(client, &mut received) {
+            assert!(Instant::now() < deadline, "the connection was not refused");
+            self.pump();
+        }
+        assert!(received.is_empty(), "a refused connection was sent bytes: {received:?}");
+    }
+
+    /// Reads `client` to the end of its stream, driving the network meanwhile.
+    fn read_to_end_of_stream(&mut self, client: &mut dyn Read) -> Vec<u8> {
+        let deadline = Instant::now() + TIMEOUT;
+        let mut received = Vec::new();
+        while !read_available(client, &mut received) {
+            assert!(Instant::now() < deadline, "the peer did not see the end of the stream");
+            self.pump();
+        }
+        received
+    }
+}
+
+over_both_transports!(
+    a_client_arriving_at_the_cap_is_refused,
+    a_client_arriving_at_the_cap_is_refused_tcp,
+    a_client_arriving_at_the_cap_is_refused_unix
+);
+fn a_client_arriving_at_the_cap_is_refused(endpoint: &Endpoint) {
+    let mut server = Server::new();
+    let group = server.listen(capped_group("capped", 2), endpoint);
+
+    let mut first = connect_client(endpoint);
+    let mut second = connect_client(endpoint);
+    server.wait_for_accepts(group, 2);
+
+    let mut third = connect_client(endpoint);
+    server.expect_refusal(&mut *third);
+    assert_eq!(server.refused(group), 1);
+    assert_eq!(server.accepted_in(group).len(), 2, "the group accepted past its cap");
+
+    // The connections that hold the cap are untouched by the refusal.
+    assert!(!read_available(&mut *first, &mut Vec::new()));
+    assert!(!read_available(&mut *second, &mut Vec::new()));
+}
+
+over_both_transports!(
+    a_draining_connection_holds_its_place,
+    a_draining_connection_holds_its_place_tcp,
+    a_draining_connection_holds_its_place_unix
+);
+fn a_draining_connection_holds_its_place(endpoint: &Endpoint) {
+    let payload = vec![0x5A; 4 * 1024 * 1024];
+    let mut server = Server::new();
+    let group = server.listen(
+        ConnectionGroupConfig {
+            socket_buf_size: Some(4096),
+            max_frame_size: payload.len(),
+            backlog_warn_bytes: None,
+            ..capped_group("draining", 1)
+        },
+        endpoint,
+    );
+
+    let mut first = connect_client(endpoint);
+    let token = server.wait_for_accepts(group, 1)[0];
+    assert!(server.network.send_with(token, |out| out.extend_from_slice(&payload)));
+    assert!(server.network.disconnect_when_drained(token));
+
+    // The peer reads none of the backlog, so the connection is still
+    // draining when the next client arrives.
+    let mut second = connect_client(endpoint);
+    server.expect_refusal(&mut *second);
+    assert_eq!(server.refused(group), 1);
+
+    // Its place comes free when the drain finishes.
+    let received = server.read_to_end_of_stream(&mut *first);
+    assert_eq!(received.len(), payload.len());
+    server.wait_for_disconnects(1);
+
+    let _third = connect_client(endpoint);
+    server.wait_for_accepts(group, 2);
+    assert_eq!(server.refused(group), 1);
+}
+
+over_both_transports!(
+    a_half_closed_connection_holds_its_place,
+    a_half_closed_connection_holds_its_place_tcp,
+    a_half_closed_connection_holds_its_place_unix
+);
+fn a_half_closed_connection_holds_its_place(endpoint: &Endpoint) {
+    let mut server = Server::new();
+    let group = server.listen(capped_group("half-closed", 1), endpoint);
+
+    let mut first = connect_client(endpoint);
+    let token = server.wait_for_accepts(group, 1)[0];
+    assert!(server.network.shutdown_write_when_drained(token));
+    assert!(server.read_to_end_of_stream(&mut *first).is_empty());
+
+    // The peer has read the end of the stream, and the connection is still
+    // there to read what the peer sends.
+    let mut second = connect_client(endpoint);
+    server.expect_refusal(&mut *second);
+    assert_eq!(server.refused(group), 1);
+
+    drop(first);
+    server.wait_for_disconnects(1);
+    let _third = connect_client(endpoint);
+    server.wait_for_accepts(group, 2);
+    assert_eq!(server.refused(group), 1);
+}
+
+/// The accept loop drains the backlog whatever it makes of each connection:
+/// an edge-triggered listener is told about a pending connection once.
+#[test]
+fn a_refusal_leaves_none_of_the_backlog_unaccepted() {
+    let endpoint = Endpoint::Tcp(unused_addr());
+    let mut server = Server::new();
+    let group = server.listen(capped_group("backlog", 1), &endpoint);
+
+    let _first = connect_client(&endpoint);
+    server.wait_for_accepts(group, 1);
+
+    // Both arrive before the network looks at the listener again, so one
+    // readiness event has to answer both.
+    let mut second = connect_client(&endpoint);
+    let mut third = connect_client(&endpoint);
+    server.expect_refusal(&mut *second);
+    server.expect_refusal(&mut *third);
+    assert_eq!(server.refused(group), 2);
+}
+
+#[test]
+fn a_closed_connection_frees_its_place() {
+    let endpoint = Endpoint::Tcp(unused_addr());
+    let mut server = Server::new();
+    let group = server.listen(capped_group("freed", 1), &endpoint);
+
+    let first = connect_client(&endpoint);
+    server.wait_for_accepts(group, 1);
+    drop(first);
+    server.wait_for_disconnects(1);
+
+    let _second = connect_client(&endpoint);
+    server.wait_for_accepts(group, 2);
+    assert_eq!(server.refused(group), 0, "the group refused a client it had room for");
+}
+
+#[test]
+fn the_cap_belongs_to_one_group() {
+    let capped_endpoint = Endpoint::Tcp(unused_addr());
+    let open_endpoint = Endpoint::Tcp(unused_addr());
+    let mut server = Server::new();
+    let capped = server.listen(capped_group("capped", 1), &capped_endpoint);
+    let open = server.listen(raw_group("open"), &open_endpoint);
+
+    let _first = connect_client(&capped_endpoint);
+    server.wait_for_accepts(capped, 1);
+    let mut refused = connect_client(&capped_endpoint);
+    server.expect_refusal(&mut *refused);
+
+    let _open_clients = [connect_client(&open_endpoint), connect_client(&open_endpoint)];
+    server.wait_for_accepts(open, 2);
+    assert_eq!(server.refused(capped), 1);
+    assert_eq!(server.refused(open), 0);
+}
+
+#[test]
+fn an_outbound_endpoint_holds_no_place() {
+    let capped_endpoint = Endpoint::Tcp(unused_addr());
+    let remote_endpoint = Endpoint::Tcp(unused_addr());
+    let mut server = Server::new();
+    let remote = server.listen(raw_group("remote"), &remote_endpoint);
+    let capped = server.listen(
+        ConnectionGroupConfig {
+            reconnect_interval: flux_timing::Duration::from_millis(1),
+            ..capped_group("capped", 1)
+        },
+        &capped_endpoint,
+    );
+
+    // The capped group holds an outbound endpoint of its own: a connection
+    // it made rather than accepted, which the cap counts for nothing.
+    let outbound = server.network.connect(capped, remote_endpoint.clone());
+    server.wait_for_accepts(remote, 1);
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && !server.connected.contains(&outbound) {
+        server.pump();
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert!(server.connected.contains(&outbound), "the outbound endpoint never connected");
+
+    let _client = connect_client(&capped_endpoint);
+    server.wait_for_accepts(capped, 1);
+    assert_eq!(server.refused(capped), 0);
+}
+
+#[test]
+#[should_panic(expected = "max_connections must be nonzero")]
+fn a_cap_of_zero_is_rejected() {
+    let _ = StreamNetwork::default().add_group(capped_group("zero", 0));
+}
+
+/// One iteration of an HTTP server: drive the network, then answer every
+/// request pulled from the service.
+fn serve(network: &mut StreamNetwork, service: &mut HttpService) {
+    network.drive(Some(flux_timing::Duration::ZERO), &mut [service.as_service()], |_| {});
+    let mut requests = Vec::new();
+    while let Some(event) = service.next_event(network) {
+        if let HttpEvent::Request { token, .. } = event {
+            requests.push(token);
+        }
+    }
+    for token in requests {
+        assert!(service.respond(network, token, 200, &[], BODY));
+    }
+}
+
+/// The cap is the transport's, so a protocol layer above it needs nothing:
+/// an `HttpService` never hears of the connection its group refused.
+#[test]
+fn an_http_service_serves_its_clients_while_the_cap_refuses_another() {
+    let endpoint = Endpoint::Tcp(unused_addr());
+    let mut network = StreamNetwork::default();
+    let group = network.add_group(ConnectionGroupConfig {
+        name: "http",
+        framing: Framing::Raw,
+        max_frame_size: usize::MAX,
+        max_connections: Some(2),
+        ..ConnectionGroupConfig::default()
+    });
+    let mut service = HttpService::new(&mut network, group, HttpConfig::default());
+    service.listen(&mut network, endpoint.clone()).unwrap();
+
+    let mut served = [connect_client(&endpoint), connect_client(&endpoint)];
+    let mut answers = [Vec::new(), Vec::new()];
+    for client in &mut served {
+        client.write_all(REQUEST).unwrap();
+    }
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && !answers.iter().all(|answer| answer.ends_with(BODY)) {
+        serve(&mut network, &mut service);
+        for (client, answer) in served.iter_mut().zip(&mut answers) {
+            read_available(&mut **client, answer);
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert!(answers.iter().all(|answer| answer.ends_with(BODY)), "{answers:?}");
+
+    // The third client is closed by the transport, so its request never
+    // becomes a request the service sees.
+    let mut refused = connect_client(&endpoint);
+    refused.write_all(REQUEST).unwrap();
+    let mut answer = Vec::new();
+    let deadline = Instant::now() + TIMEOUT;
+    while !read_available(&mut *refused, &mut answer) {
+        assert!(Instant::now() < deadline, "the third client was served");
+        serve(&mut network, &mut service);
+    }
+    assert!(answer.is_empty(), "the refused client was answered: {answer:?}");
+    assert_eq!(network.refused_connections(group), 1);
+
+    // The clients holding the cap are unaffected: they are still served.
+    for (client, answer) in served.iter_mut().zip(&mut answers) {
+        answer.clear();
+        client.write_all(REQUEST).unwrap();
+    }
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && !answers.iter().all(|answer| answer.ends_with(BODY)) {
+        serve(&mut network, &mut service);
+        for (client, answer) in served.iter_mut().zip(&mut answers) {
+            read_available(&mut **client, answer);
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert!(answers.iter().all(|answer| answer.ends_with(BODY)), "{answers:?}");
+
+    service.close(&mut network);
+}

--- a/crates/flux-network/tests/connection_cap.rs
+++ b/crates/flux-network/tests/connection_cap.rs
@@ -310,6 +310,42 @@ fn a_closed_connection_frees_its_place() {
     assert_eq!(server.refused(group), 0, "the group refused a client it had room for");
 }
 
+/// The client is left where it is, so the place comes free because the network
+/// let the connection go rather than because the peer went.
+#[test]
+fn a_disconnected_connection_frees_its_place() {
+    let endpoint = Endpoint::Tcp(unused_addr());
+    let mut server = Server::new();
+    let group = server.listen(capped_group("disconnected", 1), &endpoint);
+
+    let _first = connect_client(&endpoint);
+    let token = server.wait_for_accepts(group, 1)[0];
+    assert!(server.network.disconnect(token));
+    server.wait_for_disconnects(1);
+
+    let _second = connect_client(&endpoint);
+    server.wait_for_accepts(group, 2);
+    assert_eq!(server.refused(group), 0, "the group refused a client it had room for");
+}
+
+/// A removed connection leaves no [`StreamEvent::Disconnected`] behind, so the
+/// place it held is freed by the removal itself.
+#[test]
+fn a_removed_connection_frees_its_place() {
+    let endpoint = Endpoint::Tcp(unused_addr());
+    let mut server = Server::new();
+    let group = server.listen(capped_group("removed", 1), &endpoint);
+
+    let _first = connect_client(&endpoint);
+    let token = server.wait_for_accepts(group, 1)[0];
+    assert!(server.network.remove(token));
+
+    let _second = connect_client(&endpoint);
+    server.wait_for_accepts(group, 2);
+    assert_eq!(server.refused(group), 0, "the group refused a client it had room for");
+    assert!(server.disconnected.is_empty(), "a removed connection was reported closed");
+}
+
 #[test]
 fn the_cap_belongs_to_one_group() {
     let capped_endpoint = Endpoint::Tcp(unused_addr());
@@ -327,6 +363,32 @@ fn the_cap_belongs_to_one_group() {
     server.wait_for_accepts(open, 2);
     assert_eq!(server.refused(capped), 1);
     assert_eq!(server.refused(open), 0);
+}
+
+/// The cap is the group's rather than a listener's: two listeners of one group
+/// draw on the same allowance, whichever transport each of them speaks.
+#[test]
+fn two_listeners_of_one_group_share_its_cap() {
+    let dir = tempfile::tempdir().unwrap();
+    let tcp = Endpoint::Tcp(unused_addr());
+    let unix = Endpoint::Unix(dir.path().join("s"));
+    let mut server = Server::new();
+    let group = server.listen(capped_group("shared", 1), &tcp);
+    server.network.listen(group, unix.clone()).unwrap();
+
+    let first = connect_client(&tcp);
+    server.wait_for_accepts(group, 1);
+
+    // The one place is filled, and the second listener has none of its own.
+    let mut refused = connect_client(&unix);
+    server.expect_refusal(&mut *refused);
+    assert_eq!(server.refused(group), 1);
+
+    drop(first);
+    server.wait_for_disconnects(1);
+    let _second = connect_client(&unix);
+    server.wait_for_accepts(group, 2);
+    assert_eq!(server.refused(group), 1, "the group refused a client it had room for");
 }
 
 #[test]
@@ -440,4 +502,55 @@ fn an_http_service_serves_its_clients_while_the_cap_refuses_another() {
     assert!(answers.iter().all(|answer| answer.ends_with(BODY)), "{answers:?}");
 
     service.close(&mut network);
+}
+
+/// One iteration of an HTTP server with nothing to answer, reporting whether
+/// the service accepted a client.
+fn drive_service(network: &mut StreamNetwork, service: &mut HttpService) -> bool {
+    network.drive(Some(flux_timing::Duration::ZERO), &mut [service.as_service()], |_| {});
+    let mut accepted = false;
+    while let Some(event) = service.next_event(network) {
+        accepted |= matches!(event, HttpEvent::Accepted { .. });
+    }
+    accepted
+}
+
+/// Closing a group empties it and hands it back reusable, so it listens again
+/// and admits a client: the places its connections held went with them.
+/// `HttpService::close` is the public way to close a group.
+#[test]
+fn a_closed_group_frees_the_places_it_held() {
+    let endpoint = Endpoint::Tcp(unused_addr());
+    let mut server = Server::new();
+    let group = server.network.add_group(capped_group("closed", 1));
+    let mut service = HttpService::new(&mut server.network, group, HttpConfig::default());
+    service.listen(&mut server.network, endpoint.clone()).unwrap();
+
+    let _first = connect_client(&endpoint);
+    let deadline = Instant::now() + TIMEOUT;
+    let mut accepted = false;
+    while Instant::now() < deadline && !accepted {
+        accepted = drive_service(&mut server.network, &mut service);
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert!(accepted, "the service never accepted a client");
+
+    // The one place is filled, which is what the next client meets.
+    let mut refused = connect_client(&endpoint);
+    let mut received = Vec::new();
+    let deadline = Instant::now() + TIMEOUT;
+    while !read_available(&mut *refused, &mut received) {
+        assert!(Instant::now() < deadline, "the connection was not refused");
+        drive_service(&mut server.network, &mut service);
+    }
+    assert!(received.is_empty(), "a refused connection was sent bytes: {received:?}");
+    assert_eq!(server.refused(group), 1);
+
+    service.close(&mut server.network);
+
+    let reopened_endpoint = Endpoint::Tcp(unused_addr());
+    server.network.listen(group, reopened_endpoint.clone()).unwrap();
+    let _client = connect_client(&reopened_endpoint);
+    server.wait_for_accepts(group, 1);
+    assert_eq!(server.refused(group), 1, "the group refused a client it had room for");
 }

--- a/crates/flux-network/tests/half_close.rs
+++ b/crates/flux-network/tests/half_close.rs
@@ -16,6 +16,8 @@ use mio::Token;
 
 const TIMEOUT: Duration = Duration::from_secs(10);
 const INBOUND: &[u8] = b"sent after the end of the stream";
+const BROADCAST: &[u8] = b"broadcast to the group";
+const RECONNECTED: &[u8] = b"sent after the reconnect";
 
 fn unused_addr() -> SocketAddr {
     let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
@@ -88,29 +90,53 @@ fn wait_for_accept(network: &mut StreamNetwork, group: ConnectionGroup) -> Token
     accepted.expect("connection was not accepted")
 }
 
-/// What the network delivered after the connection was accepted.
+/// What the network delivered while a test drove it.
 #[derive(Default)]
 struct Events {
-    messages: Vec<Vec<u8>>,
-    disconnected: usize,
+    messages: Vec<(Token, Vec<u8>)>,
+    accepted: Vec<Token>,
+    connected: Vec<Token>,
+    disconnected: Vec<Token>,
 }
 
 impl Events {
     /// Runs one iteration of the network, recording what it delivers.
     fn pump(&mut self, network: &mut StreamNetwork) {
+        let Self { messages, accepted, connected, disconnected } = self;
         network.poll_with(|event| match event {
-            StreamEvent::Message { payload, .. } => self.messages.push(payload.to_vec()),
-            StreamEvent::Disconnected { .. } => self.disconnected += 1,
-            StreamEvent::Accepted { .. } | StreamEvent::Connected { .. } => {
-                panic!("unexpected lifecycle event")
+            StreamEvent::Message { token, payload, .. } => {
+                messages.push((token, payload.to_vec()));
             }
+            StreamEvent::Accepted { token, .. } => accepted.push(token),
+            StreamEvent::Connected { token, .. } => connected.push(token),
+            StreamEvent::Disconnected { token, .. } => disconnected.push(token),
         });
     }
 
-    /// The inbound bytes as the peer wrote them: a raw-framed group delivers a
-    /// read chunk at a time, and chunks do not preserve message boundaries.
-    fn inbound(&self) -> Vec<u8> {
-        self.messages.concat()
+    /// Pumps until `done` holds, failing with `what` at the deadline.
+    fn wait_until(
+        &mut self,
+        network: &mut StreamNetwork,
+        done: impl Fn(&Self) -> bool,
+        what: &str,
+    ) {
+        let deadline = Instant::now() + TIMEOUT;
+        while !done(self) {
+            assert!(Instant::now() < deadline, "{what}");
+            self.pump(network);
+            thread::sleep(Duration::from_millis(1));
+        }
+    }
+
+    /// The bytes one connection delivered, as its peer wrote them: a raw-framed
+    /// group delivers a read chunk at a time, and chunks do not preserve
+    /// message boundaries.
+    fn inbound_from(&self, token: Token) -> Vec<u8> {
+        self.messages
+            .iter()
+            .filter(|(message_token, _)| *message_token == token)
+            .flat_map(|(_, payload)| payload.iter().copied())
+            .collect()
     }
 }
 
@@ -134,8 +160,13 @@ fn read_available(client: &mut dyn Read, out: &mut Vec<u8>) -> bool {
     }
 }
 
-/// Reads the client to the end of the stream, driving the network meanwhile.
-fn read_to_end_of_stream(network: &mut StreamNetwork, client: &mut dyn Read) -> Vec<u8> {
+/// Reads the client to the end of the stream, driving the network and
+/// recording what it delivers meanwhile.
+fn read_to_end_of_stream(
+    network: &mut StreamNetwork,
+    client: &mut dyn Read,
+    events: &mut Events,
+) -> Vec<u8> {
     let mut received = Vec::new();
     let deadline = Instant::now() + TIMEOUT;
     loop {
@@ -143,7 +174,7 @@ fn read_to_end_of_stream(network: &mut StreamNetwork, client: &mut dyn Read) -> 
             return received;
         }
         assert!(Instant::now() < deadline, "the peer did not see the end of the stream");
-        network.poll_with(|_| {});
+        events.pump(network);
     }
 }
 
@@ -160,29 +191,28 @@ fn half_close_ends_the_stream_and_keeps_reading(endpoint: &Endpoint) {
     assert!(network.shutdown_write_when_drained(token));
 
     // An empty queue shuts the write side there and then.
-    let received = read_to_end_of_stream(&mut network, &mut client);
+    let mut events = Events::default();
+    let received = read_to_end_of_stream(&mut network, &mut client, &mut events);
     assert!(received.is_empty(), "{received:?}");
 
     // The connection is still registered and readable, so what the peer
     // sends after the end of the stream still arrives.
     client.write_all(INBOUND).unwrap();
-    let mut events = Events::default();
-    let deadline = Instant::now() + TIMEOUT;
-    while Instant::now() < deadline && events.inbound() != INBOUND {
-        events.pump(&mut network);
-        thread::sleep(Duration::from_millis(1));
-    }
-    assert_eq!(events.inbound(), INBOUND);
-    assert_eq!(events.disconnected, 0, "the half-close ended the connection");
+    events.wait_until(
+        &mut network,
+        |events| events.inbound_from(token) == INBOUND,
+        "the inbound bytes did not arrive",
+    );
+    assert!(events.disconnected.is_empty(), "the half-close ended the connection");
 
     // And the peer's own close is still a disconnect.
     drop(client);
-    let deadline = Instant::now() + TIMEOUT;
-    while Instant::now() < deadline && events.disconnected == 0 {
-        events.pump(&mut network);
-        thread::sleep(Duration::from_millis(1));
-    }
-    assert_eq!(events.disconnected, 1);
+    events.wait_until(
+        &mut network,
+        |events| !events.disconnected.is_empty(),
+        "the peer's close was not reported",
+    );
+    assert_eq!(events.disconnected, [token]);
 }
 
 over_both_transports!(
@@ -213,10 +243,10 @@ fn queued_bytes_reach_the_peer_before_the_end_of_the_stream(endpoint: &Endpoint)
         thread::sleep(Duration::from_millis(1));
     }
 
-    let received = read_to_end_of_stream(&mut network, &mut client);
+    let received = read_to_end_of_stream(&mut network, &mut client, &mut events);
     assert_eq!(received.len(), payload.len(), "the end of the stream arrived early");
     assert!(received == payload, "the peer received bytes the network never sent");
-    assert_eq!(events.disconnected, 0, "the drain ended the connection");
+    assert!(events.disconnected.is_empty(), "the drain ended the connection");
 }
 
 over_both_transports!(
@@ -245,8 +275,10 @@ fn sends_after_the_half_close_are_refused(endpoint: &Endpoint) {
     );
     assert!(!serialised.get(), "a refused send serialised its payload");
 
-    let received = read_to_end_of_stream(&mut network, &mut client);
+    let mut events = Events::default();
+    let received = read_to_end_of_stream(&mut network, &mut client, &mut events);
     assert!(received.is_empty(), "{received:?}");
+    assert!(events.disconnected.is_empty(), "the refused send ended the connection");
 }
 
 over_both_transports!(
@@ -260,16 +292,16 @@ fn a_hard_close_after_the_half_close_ends_the_connection(endpoint: &Endpoint) {
     let token = wait_for_accept(&mut network, group);
 
     assert!(network.shutdown_write_when_drained(token));
-    assert!(read_to_end_of_stream(&mut network, &mut client).is_empty());
+    let mut events = Events::default();
+    assert!(read_to_end_of_stream(&mut network, &mut client, &mut events).is_empty());
 
     assert!(network.disconnect(token), "the half-closed connection was gone already");
-    let mut events = Events::default();
-    let deadline = Instant::now() + TIMEOUT;
-    while Instant::now() < deadline && events.disconnected == 0 {
-        events.pump(&mut network);
-        thread::sleep(Duration::from_millis(1));
-    }
-    assert_eq!(events.disconnected, 1);
+    events.wait_until(
+        &mut network,
+        |events| !events.disconnected.is_empty(),
+        "the hard close was not reported",
+    );
+    assert_eq!(events.disconnected, [token]);
 
     // The connection is gone: the token is unknown, and what the peer sends
     // reaches nobody.
@@ -280,7 +312,169 @@ fn a_hard_close_after_the_half_close_ends_the_connection(endpoint: &Endpoint) {
         events.pump(&mut network);
         thread::sleep(Duration::from_millis(1));
     }
-    assert_eq!(events.disconnected, 1);
+    assert_eq!(events.disconnected, [token]);
     assert!(events.messages.is_empty(), "{:?}", events.messages);
     assert!(read_available(&mut *client, &mut Vec::new()), "the peer read past the close");
+}
+
+/// Which of the two closes a test asks for first.
+#[derive(Clone, Copy)]
+enum Order {
+    /// The hard close, then the half-close.
+    HardCloseFirst,
+    /// The half-close, then the hard close.
+    HalfCloseFirst,
+}
+
+over_both_transports!(
+    a_hard_close_asked_for_first_wins,
+    a_hard_close_asked_for_first_wins_tcp,
+    a_hard_close_asked_for_first_wins_unix
+);
+fn a_hard_close_asked_for_first_wins(endpoint: &Endpoint) {
+    a_hard_close_wins(endpoint, Order::HardCloseFirst);
+}
+
+over_both_transports!(
+    a_hard_close_asked_for_second_wins,
+    a_hard_close_asked_for_second_wins_tcp,
+    a_hard_close_asked_for_second_wins_unix
+);
+fn a_hard_close_asked_for_second_wins(endpoint: &Endpoint) {
+    a_hard_close_wins(endpoint, Order::HalfCloseFirst);
+}
+
+/// A connection asked for both closes ends outright when its queue drains,
+/// whichever close was asked for first: the peer reads every queued byte and
+/// then the end of the stream, and the connection is gone.
+fn a_hard_close_wins(endpoint: &Endpoint, order: Order) {
+    let payload = vec![0xC3; 4 * 1024 * 1024];
+    let (mut network, group) = server(endpoint, ConnectionGroupConfig {
+        socket_buf_size: Some(4096),
+        max_frame_size: payload.len(),
+        backlog_warn_bytes: None,
+        ..raw_group("both-closes")
+    });
+    let mut client = connect_client(endpoint);
+    let token = wait_for_accept(&mut network, group);
+
+    // Both closes are asked for while the queue holds the bulk of the
+    // payload, so the drain is what decides between them.
+    assert!(network.send_with(token, |out| out.extend_from_slice(&payload)));
+    match order {
+        Order::HardCloseFirst => {
+            assert!(network.disconnect_when_drained(token));
+            assert!(network.shutdown_write_when_drained(token));
+        }
+        Order::HalfCloseFirst => {
+            assert!(network.shutdown_write_when_drained(token));
+            assert!(network.disconnect_when_drained(token));
+        }
+    }
+
+    let mut events = Events::default();
+    let received = read_to_end_of_stream(&mut network, &mut client, &mut events);
+    assert_eq!(received.len(), payload.len(), "the end of the stream arrived early");
+
+    events.wait_until(
+        &mut network,
+        |events| !events.disconnected.is_empty(),
+        "the connection was half-closed instead of closed",
+    );
+    assert_eq!(events.disconnected, [token]);
+    assert!(!network.disconnect(token), "the connection outlived its hard close");
+
+    // The peer holds its own end of the connection open, and nothing more
+    // reaches the network through it.
+    let _ = client.write_all(INBOUND);
+    for _ in 0..50 {
+        events.pump(&mut network);
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(events.disconnected, [token]);
+    assert!(events.messages.is_empty(), "{:?}", events.messages);
+}
+
+over_both_transports!(
+    a_broadcast_passes_over_a_half_closed_member,
+    a_broadcast_passes_over_a_half_closed_member_tcp,
+    a_broadcast_passes_over_a_half_closed_member_unix
+);
+fn a_broadcast_passes_over_a_half_closed_member(endpoint: &Endpoint) {
+    let (mut network, group) = server(endpoint, raw_group("broadcast"));
+    let mut open = connect_client(endpoint);
+    let open_token = wait_for_accept(&mut network, group);
+    let mut shut = connect_client(endpoint);
+    let shut_token = wait_for_accept(&mut network, group);
+    assert_ne!(open_token, shut_token);
+
+    assert!(network.shutdown_write_when_drained(shut_token));
+    let mut events = Events::default();
+    assert!(read_to_end_of_stream(&mut network, &mut shut, &mut events).is_empty());
+
+    // The half-closed member is not a recipient, and the group's other
+    // connection is untouched by its being there.
+    assert_eq!(network.broadcast_with(group, |out| out.extend_from_slice(BROADCAST)), 1);
+    let mut received = Vec::new();
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && received != BROADCAST {
+        events.pump(&mut network);
+        read_available(&mut open, &mut received);
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(received, BROADCAST);
+    assert!(events.disconnected.is_empty(), "the broadcast closed a connection");
+
+    // The half-closed member is still at the end of its stream: the
+    // broadcast queued nothing for it.
+    let mut late = Vec::new();
+    assert!(read_available(&mut shut, &mut late), "the half-closed member was written to");
+    assert!(late.is_empty(), "{late:?}");
+}
+
+over_both_transports!(
+    a_reconnect_opens_the_write_side_again,
+    a_reconnect_opens_the_write_side_again_tcp,
+    a_reconnect_opens_the_write_side_again_unix
+);
+fn a_reconnect_opens_the_write_side_again(endpoint: &Endpoint) {
+    let mut network = StreamNetwork::default();
+    let server_group = network.add_group(raw_group("server"));
+    let client_group = network.add_group(ConnectionGroupConfig {
+        reconnect_interval: flux_timing::Duration::from_millis(1),
+        ..raw_group("client")
+    });
+    network.listen(server_group, endpoint.clone()).unwrap();
+    let outbound = network.connect(client_group, endpoint.clone());
+
+    let mut events = Events::default();
+    events.wait_until(
+        &mut network,
+        |events| events.connected.contains(&outbound) && !events.accepted.is_empty(),
+        "the outbound endpoint did not connect",
+    );
+
+    // The half-close ends this connection: the accepting side reads the end
+    // of the stream and closes what is left of it, which the endpoint
+    // answers by reconnecting.
+    assert!(network.shutdown_write_when_drained(outbound));
+    events.wait_until(
+        &mut network,
+        |events| {
+            events.disconnected.len() == 2 &&
+                events.connected.iter().filter(|token| **token == outbound).count() == 2 &&
+                events.accepted.len() == 2
+        },
+        "the outbound endpoint did not reconnect",
+    );
+
+    // The half-close belonged to the socket that is gone, so the endpoint
+    // sends over its new one.
+    let accepted = events.accepted[1];
+    assert!(network.send_with(outbound, |out| out.extend_from_slice(RECONNECTED)));
+    events.wait_until(
+        &mut network,
+        |events| events.inbound_from(accepted) == RECONNECTED,
+        "the payload did not reach the reconnected peer",
+    );
 }

--- a/crates/flux-network/tests/half_close.rs
+++ b/crates/flux-network/tests/half_close.rs
@@ -1,0 +1,286 @@
+//! The write-side half-close: what the peer of a half-closed connection
+//! reads, and what still reaches the network afterwards.
+
+use std::{
+    cell::Cell,
+    io::{self, Read, Write},
+    net::{Ipv4Addr, SocketAddr},
+    thread,
+    time::{Duration, Instant},
+};
+
+use flux_network::stream::{
+    ConnectionGroup, ConnectionGroupConfig, Endpoint, Framing, StreamEvent, StreamNetwork,
+};
+use mio::Token;
+
+const TIMEOUT: Duration = Duration::from_secs(10);
+const INBOUND: &[u8] = b"sent after the end of the stream";
+
+fn unused_addr() -> SocketAddr {
+    let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+    addr
+}
+
+/// Runs one test body over both transports: a loopback TCP address on an
+/// ephemeral port, and a Unix-domain socket path under a temporary directory
+/// that lives for the duration of the run.
+macro_rules! over_both_transports {
+    ($body:ident, $tcp:ident, $unix:ident) => {
+        #[test]
+        fn $tcp() {
+            $body(&Endpoint::Tcp(unused_addr()));
+        }
+
+        #[test]
+        fn $unix() {
+            let dir = tempfile::tempdir().unwrap();
+            $body(&Endpoint::Unix(dir.path().join("s")));
+        }
+    };
+}
+
+/// A nonblocking client socket speaking raw bytes to the network under test.
+trait ClientStream: Read + Write {}
+impl<T: Read + Write> ClientStream for T {}
+
+fn connect_client(endpoint: &Endpoint) -> Box<dyn ClientStream> {
+    match endpoint {
+        Endpoint::Tcp(addr) => {
+            let stream = std::net::TcpStream::connect(addr).unwrap();
+            stream.set_nonblocking(true).unwrap();
+            Box::new(stream)
+        }
+        Endpoint::Unix(path) => {
+            let stream = std::os::unix::net::UnixStream::connect(path).unwrap();
+            stream.set_nonblocking(true).unwrap();
+            Box::new(stream)
+        }
+    }
+}
+
+fn raw_group(name: &'static str) -> ConnectionGroupConfig {
+    ConnectionGroupConfig { name, framing: Framing::Raw, ..ConnectionGroupConfig::default() }
+}
+
+/// A listening network, and the group its connections belong to.
+fn server(endpoint: &Endpoint, config: ConnectionGroupConfig) -> (StreamNetwork, ConnectionGroup) {
+    let mut network = StreamNetwork::default();
+    let group = network.add_group(config);
+    network.listen(group, endpoint.clone()).unwrap();
+    (network, group)
+}
+
+fn wait_for_accept(network: &mut StreamNetwork, group: ConnectionGroup) -> Token {
+    let mut accepted = None;
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && accepted.is_none() {
+        network.poll_with(|event| {
+            if let StreamEvent::Accepted { group: event_group, token, .. } = event {
+                assert_eq!(event_group, group);
+                accepted = Some(token);
+            }
+        });
+        thread::sleep(Duration::from_millis(1));
+    }
+    accepted.expect("connection was not accepted")
+}
+
+/// What the network delivered after the connection was accepted.
+#[derive(Default)]
+struct Events {
+    messages: Vec<Vec<u8>>,
+    disconnected: usize,
+}
+
+impl Events {
+    /// Runs one iteration of the network, recording what it delivers.
+    fn pump(&mut self, network: &mut StreamNetwork) {
+        network.poll_with(|event| match event {
+            StreamEvent::Message { payload, .. } => self.messages.push(payload.to_vec()),
+            StreamEvent::Disconnected { .. } => self.disconnected += 1,
+            StreamEvent::Accepted { .. } | StreamEvent::Connected { .. } => {
+                panic!("unexpected lifecycle event")
+            }
+        });
+    }
+
+    /// The inbound bytes as the peer wrote them: a raw-framed group delivers a
+    /// read chunk at a time, and chunks do not preserve message boundaries.
+    fn inbound(&self) -> Vec<u8> {
+        self.messages.concat()
+    }
+}
+
+/// Reads what the client can without blocking, reporting the end of the
+/// stream.
+///
+/// A hard close can reset bytes still in flight from the client; everything
+/// the network wrote before it has already arrived, so a reset is as much an
+/// end of stream as a clean one.
+fn read_available(client: &mut dyn Read, out: &mut Vec<u8>) -> bool {
+    let mut buffer = [0; 16 * 1024];
+    match client.read(&mut buffer) {
+        Ok(0) => true,
+        Ok(read) => {
+            out.extend_from_slice(&buffer[..read]);
+            false
+        }
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => false,
+        Err(err) if err.kind() == io::ErrorKind::ConnectionReset => true,
+        Err(err) => panic!("client read failed: {err}"),
+    }
+}
+
+/// Reads the client to the end of the stream, driving the network meanwhile.
+fn read_to_end_of_stream(network: &mut StreamNetwork, client: &mut dyn Read) -> Vec<u8> {
+    let mut received = Vec::new();
+    let deadline = Instant::now() + TIMEOUT;
+    loop {
+        if read_available(client, &mut received) {
+            return received;
+        }
+        assert!(Instant::now() < deadline, "the peer did not see the end of the stream");
+        network.poll_with(|_| {});
+    }
+}
+
+over_both_transports!(
+    half_close_ends_the_stream_and_keeps_reading,
+    half_close_ends_the_stream_and_keeps_reading_tcp,
+    half_close_ends_the_stream_and_keeps_reading_unix
+);
+fn half_close_ends_the_stream_and_keeps_reading(endpoint: &Endpoint) {
+    let (mut network, group) = server(endpoint, raw_group("half-close"));
+    let mut client = connect_client(endpoint);
+    let token = wait_for_accept(&mut network, group);
+
+    assert!(network.shutdown_write_when_drained(token));
+
+    // An empty queue shuts the write side there and then.
+    let received = read_to_end_of_stream(&mut network, &mut client);
+    assert!(received.is_empty(), "{received:?}");
+
+    // The connection is still registered and readable, so what the peer
+    // sends after the end of the stream still arrives.
+    client.write_all(INBOUND).unwrap();
+    let mut events = Events::default();
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && events.inbound() != INBOUND {
+        events.pump(&mut network);
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(events.inbound(), INBOUND);
+    assert_eq!(events.disconnected, 0, "the half-close ended the connection");
+
+    // And the peer's own close is still a disconnect.
+    drop(client);
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && events.disconnected == 0 {
+        events.pump(&mut network);
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(events.disconnected, 1);
+}
+
+over_both_transports!(
+    queued_bytes_reach_the_peer_before_the_end_of_the_stream,
+    queued_bytes_reach_the_peer_before_the_end_of_the_stream_tcp,
+    queued_bytes_reach_the_peer_before_the_end_of_the_stream_unix
+);
+fn queued_bytes_reach_the_peer_before_the_end_of_the_stream(endpoint: &Endpoint) {
+    let payload = vec![0xA5; 4 * 1024 * 1024];
+    let (mut network, group) = server(endpoint, ConnectionGroupConfig {
+        socket_buf_size: Some(4096),
+        max_frame_size: payload.len(),
+        backlog_warn_bytes: None,
+        ..raw_group("half-close-drain")
+    });
+    let mut client = connect_client(endpoint);
+    let token = wait_for_accept(&mut network, group);
+
+    assert!(network.send_with(token, |out| out.extend_from_slice(&payload)));
+    assert!(network.shutdown_write_when_drained(token));
+
+    // The peer starts reading late, so the write side is asked to shut while
+    // the bulk of the payload is still queued, and again while the queue
+    // drains.
+    let mut events = Events::default();
+    for _ in 0..10 {
+        events.pump(&mut network);
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    let received = read_to_end_of_stream(&mut network, &mut client);
+    assert_eq!(received.len(), payload.len(), "the end of the stream arrived early");
+    assert!(received == payload, "the peer received bytes the network never sent");
+    assert_eq!(events.disconnected, 0, "the drain ended the connection");
+}
+
+over_both_transports!(
+    sends_after_the_half_close_are_refused,
+    sends_after_the_half_close_are_refused_tcp,
+    sends_after_the_half_close_are_refused_unix
+);
+fn sends_after_the_half_close_are_refused(endpoint: &Endpoint) {
+    let (mut network, group) = server(endpoint, raw_group("half-close-send"));
+    let mut client = connect_client(endpoint);
+    let token = wait_for_accept(&mut network, group);
+
+    assert!(network.shutdown_write_when_drained(token));
+
+    let serialised = Cell::new(false);
+    assert!(!network.send_with(token, |out| {
+        serialised.set(true);
+        out.extend_from_slice(b"after the end of the stream");
+    }));
+    assert_eq!(
+        network.broadcast_with(group, |out| {
+            serialised.set(true);
+            out.extend_from_slice(b"after the end of the stream");
+        }),
+        0
+    );
+    assert!(!serialised.get(), "a refused send serialised its payload");
+
+    let received = read_to_end_of_stream(&mut network, &mut client);
+    assert!(received.is_empty(), "{received:?}");
+}
+
+over_both_transports!(
+    a_hard_close_after_the_half_close_ends_the_connection,
+    a_hard_close_after_the_half_close_ends_the_connection_tcp,
+    a_hard_close_after_the_half_close_ends_the_connection_unix
+);
+fn a_hard_close_after_the_half_close_ends_the_connection(endpoint: &Endpoint) {
+    let (mut network, group) = server(endpoint, raw_group("half-close-hard"));
+    let mut client = connect_client(endpoint);
+    let token = wait_for_accept(&mut network, group);
+
+    assert!(network.shutdown_write_when_drained(token));
+    assert!(read_to_end_of_stream(&mut network, &mut client).is_empty());
+
+    assert!(network.disconnect(token), "the half-closed connection was gone already");
+    let mut events = Events::default();
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && events.disconnected == 0 {
+        events.pump(&mut network);
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(events.disconnected, 1);
+
+    // The connection is gone: the token is unknown, and what the peer sends
+    // reaches nobody.
+    assert!(!network.disconnect(token));
+    assert!(!network.shutdown_write_when_drained(token));
+    let _ = client.write_all(INBOUND);
+    for _ in 0..50 {
+        events.pump(&mut network);
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(events.disconnected, 1);
+    assert!(events.messages.is_empty(), "{:?}", events.messages);
+    assert!(read_available(&mut *client, &mut Vec::new()), "the peer read past the close");
+}


### PR DESCRIPTION
This PR builds on #141. It adds two transport-level controls to `StreamNetwork`: write-side half-close and a per-group cap on accepted connections. Four commits.

## Write-side half-close

`shutdown_write_when_drained(token)` writes everything already queued, shuts the connection's write side, and keeps reading. The peer sees the end of the outbound stream, while later inbound bytes and the peer's eventual close still arrive as normal events. TCP and Unix sockets share this behavior.

Sends are rejected from the half-close request onward, before their payload is serialized, so the queue can only shrink. Broadcasts skip half-closing and half-closed connections. A hard close still wins in either call order, and an outbound endpoint starts a reconnect with its write side open again.

A TCP peer that never drains is bounded by `TCP_USER_TIMEOUT`; a Unix peer has no corresponding bound.

## Connection admission

`ConnectionGroupConfig::max_connections` limits the accepted connections a group holds. `None` leaves the group uncapped; `Some(0)` is rejected. A connection arriving at the cap is accepted and immediately closed without registration, bytes or an event, while the accept loop continues to drain the listener backlog.

Draining and half-closed accepted connections continue to hold their places. Listeners and outbound endpoints do not count, and every listener in one group shares the same allowance.

Each group maintains its accepted count, making admission and refusal O(1) regardless of the network's size. Peer close, local disconnect, removal and group close release the corresponding places.

`refused_connections(group)` reports the cumulative refusals. Warnings identify the group and are limited to one every ten seconds. Refusal remains entirely below the service layer, so an `HttpService` never receives an event for that connection.

## Verification

Half-close tests cover immediate and queued shutdown, continued reads, send and broadcast filtering, hard-close precedence, and reconnects over TCP and Unix sockets. Admission tests cover the cap boundary, draining and half-closed connections, backlog draining, every release path, shared caps across listeners, outbound endpoints, group isolation and HTTP behavior.

The loopback tests still guess unused TCP ports. That race is fixed later in the stack when `listen` reports the endpoint it bound; rerun the job if it appears in CI.

Workspace tests, Clippy with warnings denied, the nightly formatting check and `cargo doc` pass at this tip with no new warnings.

Base: #141. Next: B, HTTP lingering close, request deadlines and status framing.

Refer: #143

Assisted-by: Claude Code:claude-fable-5
Assisted-by: Codex:gpt-5
