### PR TITLE
flux-network: return bound endpoints and remove a port-selection race

### DIFF
--- a/crates/flux-network/src/http.rs
+++ b/crates/flux-network/src/http.rs
@@ -1892,7 +1892,7 @@ pub fn reason_phrase(status: u16) -> &'static str {
 mod tests {
     use std::{
         io::Write as _,
-        net::{Ipv4Addr, SocketAddr, TcpStream},
+        net::{Ipv4Addr, TcpStream},
     };
 
     use flux_timing::{Duration, Instant};
@@ -1938,13 +1938,6 @@ mod tests {
         assert_eq!(span(buffer, &buffer[4..9], 0), 4..9);
         assert_eq!(span(buffer, &buffer[4..9], 100), 104..109);
         assert_eq!(span(buffer, b"", 7), 7..7);
-    }
-
-    fn unused_addr() -> SocketAddr {
-        let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-        let addr = listener.local_addr().unwrap();
-        drop(listener);
-        addr
     }
 
     /// A service on a raw group of its own, with no listener and no
@@ -2080,8 +2073,11 @@ mod tests {
         fn with_two_requests() -> (Self, usize) {
             let mut net = StreamNetwork::default();
             let mut http = bare_service(&mut net);
-            let addr = unused_addr();
-            http.listen(&mut net, Endpoint::Tcp(addr)).unwrap();
+            // Port 0 leaves the port to the kernel, and the listener reports
+            // the address a client must dial.
+            let bound =
+                http.listen(&mut net, Endpoint::Tcp((Ipv4Addr::LOCALHOST, 0).into())).unwrap();
+            let Endpoint::Tcp(addr) = bound else { unreachable!("the harness listens on TCP") };
             let mut client = TcpStream::connect(addr).unwrap();
             let first = padded_request("/one", 64);
             client.write_all(&[first.clone(), padded_request("/two", 192)].concat()).unwrap();

--- a/crates/flux-network/src/http.rs
+++ b/crates/flux-network/src/http.rs
@@ -351,7 +351,8 @@ impl Responder<'_> {
     /// are reclaimed on the next pull or network tick, after the event's
     /// borrow ends. [`HttpService::respond`] reclaims before it returns.
     pub fn respond(self, status: u16, headers: &[(&str, &str)], body: &[u8]) -> bool {
-        self.respond_with(status, headers, |out| out.extend_from_slice(body))
+        let Self { net, state, token, linger, .. } = self;
+        write_framed(net, state, token, linger, status, headers, body)
     }
 
     /// Queues the response with its body written by `body`, and returns
@@ -360,8 +361,8 @@ impl Responder<'_> {
     /// The closure renders into a buffer the service keeps for the next
     /// response, so a body composed here costs no allocation. Every framing
     /// rule of [`Self::respond`] holds, and the closure runs whatever the
-    /// request was: a `HEAD` request is answered with the `Content-Length`
-    /// of the body it is not sent.
+    /// request was — but only once the answer is one the service will send: a
+    /// refused status or header composes nothing.
     pub fn respond_with(
         self,
         status: u16,
@@ -369,73 +370,95 @@ impl Responder<'_> {
         body: impl FnOnce(&mut Vec<u8>),
     ) -> bool {
         let Self { net, state, scratch, token, linger } = self;
-        if state.phase != Phase::Pending {
+        if !answerable(state, status, headers) {
             return false
         }
-        if !(100..=599).contains(&status) ||
-            headers.iter().any(|(name, value)| invalid_header(name, value))
-        {
-            return false
-        }
-        let caller_close = headers.iter().any(|(name, value)| {
-            name.eq_ignore_ascii_case("connection") && has_value_token(value.as_bytes(), b"close")
-        });
-        let close = state.close || caller_close;
-        let suppress_body = state.head_request || matches!(status, 100..=199 | 204 | 304);
-        let include_length = !matches!(status, 100..=199 | 204);
         scratch.clear();
         body(scratch);
-        let body: &[u8] = scratch;
-        let ok = net.send_with(token, |out| {
-            write!(out, "HTTP/1.1 {status} {}\r\n", reason_phrase(status)).unwrap();
-            // Caller Connection headers only feed the close decision; exactly
-            // one canonical Connection header is always written below.
-            for (name, value) in headers {
-                if name.eq_ignore_ascii_case("connection") {
-                    continue
-                }
-                out.extend_from_slice(name.as_bytes());
-                out.extend_from_slice(b": ");
-                out.extend_from_slice(value.as_bytes());
-                out.extend_from_slice(b"\r\n");
-            }
-            if include_length {
-                write!(out, "Content-Length: {}\r\n", body.len()).unwrap();
-            }
-            out.extend_from_slice(if close {
-                b"Connection: close\r\n"
-            } else {
-                b"Connection: keep-alive\r\n"
-            });
-            out.extend_from_slice(b"\r\n");
-            if !suppress_body {
-                out.extend_from_slice(body);
-            }
-        });
-        if ok {
-            if let Some(end) = state.req_end.take() {
-                state.consumed = end;
-            }
-            if !close {
-                state.phase = Phase::Idle;
-            } else if state.framing_lost && linger.is_some() {
-                // The peer is still sending a request stream this response ends.
-                // Shutting the write side alone puts the answer in front of it
-                // before the connection goes.
-                net.shutdown_write_when_drained(token);
-                // The caps time what follows the answer, so they start where the
-                // answer ends: here when nothing was queued behind it, and at the
-                // tick that sees the write side shut otherwise.
-                let clock =
-                    net.write_side_shut(token).then(|| LingerClock::started(Instant::now()));
-                state.phase = Phase::Lingering { clock };
-            } else {
-                state.phase = Phase::Draining;
-                net.disconnect_when_drained(token);
-            }
-        }
-        ok
+        write_framed(net, state, token, linger, status, headers, scratch)
     }
+}
+
+/// Whether this response can be written for the request `state` holds: one
+/// request is answered once, with a status HTTP frames and headers the
+/// service does not reserve for itself.
+fn answerable(state: &ConnState, status: u16, headers: &[(&str, &str)]) -> bool {
+    state.phase == Phase::Pending &&
+        (100..=599).contains(&status) &&
+        !headers.iter().any(|(name, value)| invalid_header(name, value))
+}
+
+/// Writes one response for a pending request and moves the connection on.
+///
+/// The body reaches the wire in a single copy, from wherever the caller
+/// holds it. A `HEAD` request is framed with its `Content-Length` and sent
+/// none of it.
+fn write_framed(
+    net: &mut StreamNetwork,
+    state: &mut ConnState,
+    token: Token,
+    linger: Option<Linger>,
+    status: u16,
+    headers: &[(&str, &str)],
+    body: &[u8],
+) -> bool {
+    if !answerable(state, status, headers) {
+        return false
+    }
+    let caller_close = headers.iter().any(|(name, value)| {
+        name.eq_ignore_ascii_case("connection") && has_value_token(value.as_bytes(), b"close")
+    });
+    let close = state.close || caller_close;
+    let suppress_body = state.head_request || matches!(status, 100..=199 | 204 | 304);
+    let include_length = !matches!(status, 100..=199 | 204);
+    let ok = net.send_with(token, |out| {
+        write!(out, "HTTP/1.1 {status} {}\r\n", reason_phrase(status)).unwrap();
+        // Caller Connection headers only feed the close decision; exactly
+        // one canonical Connection header is always written below.
+        for (name, value) in headers {
+            if name.eq_ignore_ascii_case("connection") {
+                continue
+            }
+            out.extend_from_slice(name.as_bytes());
+            out.extend_from_slice(b": ");
+            out.extend_from_slice(value.as_bytes());
+            out.extend_from_slice(b"\r\n");
+        }
+        if include_length {
+            write!(out, "Content-Length: {}\r\n", body.len()).unwrap();
+        }
+        out.extend_from_slice(if close {
+            b"Connection: close\r\n"
+        } else {
+            b"Connection: keep-alive\r\n"
+        });
+        out.extend_from_slice(b"\r\n");
+        if !suppress_body {
+            out.extend_from_slice(body);
+        }
+    });
+    if ok {
+        if let Some(end) = state.req_end.take() {
+            state.consumed = end;
+        }
+        if !close {
+            state.phase = Phase::Idle;
+        } else if state.framing_lost && linger.is_some() {
+            // The peer is still sending a request stream this response ends.
+            // Shutting the write side alone puts the answer in front of it
+            // before the connection goes.
+            net.shutdown_write_when_drained(token);
+            // The caps time what follows the answer, so they start where the
+            // answer ends: here when nothing was queued behind it, and at the
+            // tick that sees the write side shut otherwise.
+            let clock = net.write_side_shut(token).then(|| LingerClock::started(Instant::now()));
+            state.phase = Phase::Lingering { clock };
+        } else {
+            state.phase = Phase::Draining;
+            net.disconnect_when_drained(token);
+        }
+    }
+    ok
 }
 
 /// What answering one request touches, and all a [`Responder`] may reach.
@@ -819,7 +842,7 @@ impl HttpService {
         headers: &[(&str, &str)],
         body: &[u8],
     ) -> bool {
-        self.respond_with(net, token, status, headers, |out| out.extend_from_slice(body))
+        self.answer(net, token, |responder| responder.respond(status, headers, body))
     }
 
     /// Answers a request whose [`Responder`] was dropped with a body `body`
@@ -839,6 +862,17 @@ impl HttpService {
         headers: &[(&str, &str)],
         body: impl FnOnce(&mut Vec<u8>),
     ) -> bool {
+        self.answer(net, token, |responder| responder.respond_with(status, headers, body))
+    }
+
+    /// Hands `answer` the responder for the request pending on an accepted
+    /// `token`, and reclaims what its response consumed.
+    fn answer(
+        &mut self,
+        net: &mut StreamNetwork,
+        token: Token,
+        answer: impl FnOnce(Responder<'_>) -> bool,
+    ) -> bool {
         let Some(index) = self.index_of(token) else { return false };
         if !matches!(self.conns[index].role, Role::Accepted) {
             return false
@@ -846,7 +880,7 @@ impl HttpService {
         let linger = self.config.linger;
         let Self { conns, scratch, .. } = self;
         let responder = Responder { net, state: &mut conns[index].state, scratch, token, linger };
-        if !responder.respond_with(status, headers, body) {
+        if !answer(responder) {
             return false
         }
         self.reclaim(index);
@@ -1294,7 +1328,7 @@ impl HttpService {
         // The request this answers was never read to its end, whether it was
         // unparseable, too large, or framed in a way the service refuses.
         state.framing_lost = true;
-        Responder { net, state, scratch, token, linger }.respond_with(status, &[], |_| {});
+        Responder { net, state, scratch, token, linger }.respond(status, &[], &[]);
     }
 
     /// Drops an outbound connection whose peer broke the protocol.

--- a/crates/flux-network/src/http.rs
+++ b/crates/flux-network/src/http.rs
@@ -352,6 +352,9 @@ impl Responder<'_> {
     /// borrow ends. [`HttpService::respond`] reclaims before it returns.
     pub fn respond(self, status: u16, headers: &[(&str, &str)], body: &[u8]) -> bool {
         let Self { net, state, token, linger, .. } = self;
+        if !answerable(state, status, headers) {
+            return false
+        }
         write_framed(net, state, token, linger, status, headers, body)
     }
 
@@ -390,6 +393,8 @@ fn answerable(state: &ConnState, status: u16, headers: &[(&str, &str)]) -> bool 
 
 /// Writes one response for a pending request and moves the connection on.
 ///
+/// The caller has asked [`answerable`] already — each public path asks it
+/// once, before anything is composed — so the answer is framed as admitted.
 /// The body reaches the wire in a single copy, from wherever the caller
 /// holds it. A `HEAD` request is framed with its `Content-Length` and sent
 /// none of it.
@@ -402,9 +407,7 @@ fn write_framed(
     headers: &[(&str, &str)],
     body: &[u8],
 ) -> bool {
-    if !answerable(state, status, headers) {
-        return false
-    }
+    debug_assert!(answerable(state, status, headers), "an answer is admitted before it is framed");
     let caller_close = headers.iter().any(|(name, value)| {
         name.eq_ignore_ascii_case("connection") && has_value_token(value.as_bytes(), b"close")
     });

--- a/crates/flux-network/src/http.rs
+++ b/crates/flux-network/src/http.rs
@@ -719,12 +719,16 @@ impl HttpService {
         ServiceRef::new(self)
     }
 
-    /// Adds a listener.
+    /// Adds a listener, and reports the endpoint it bound.
+    ///
+    /// That endpoint is the one asked for, except for a TCP address whose
+    /// port is `0`: the kernel picks the port, and what comes back is the
+    /// address a client must dial.
     ///
     /// An [`Endpoint::Unix`] socket file is created with mode `0777` less the
     /// umask bits and is unlinked when the service is closed; see
     /// [`StreamNetwork::listen`].
-    pub fn listen(&mut self, net: &mut StreamNetwork, endpoint: Endpoint) -> io::Result<()> {
+    pub fn listen(&mut self, net: &mut StreamNetwork, endpoint: Endpoint) -> io::Result<Endpoint> {
         net.listen(self.group, endpoint)
     }
 

--- a/crates/flux-network/src/stream/network.rs
+++ b/crates/flux-network/src/stream/network.rs
@@ -443,15 +443,16 @@ impl NetworkState {
         &self.groups[group.0].config
     }
 
-    fn listen(&mut self, group: ConnectionGroup, endpoint: Endpoint) -> io::Result<()> {
+    fn listen(&mut self, group: ConnectionGroup, endpoint: Endpoint) -> io::Result<Endpoint> {
         if group.0 >= self.groups.len() {
             return Err(io::Error::new(io::ErrorKind::InvalidInput, "unknown connection group"));
         }
         let mut socket = ListenSocket::bind(endpoint)?;
+        let bound = socket.endpoint()?;
         let token = self.next_token();
         self.registry.register(&mut socket, token, Interest::READABLE)?;
         self.listeners.push(Listener { token, group, socket });
-        Ok(())
+        Ok(bound)
     }
 
     fn connect(&mut self, group: ConnectionGroup, endpoint: Endpoint) -> Token {
@@ -1286,7 +1287,11 @@ impl StreamNetwork {
         self.release_group(group);
     }
 
-    /// Adds a listener to `group`.
+    /// Adds a listener to `group`, and reports the endpoint it bound.
+    ///
+    /// That endpoint is the one asked for, except for a TCP address whose
+    /// port is `0`: the kernel picks the port, and what comes back is the
+    /// address a peer must dial.
     ///
     /// An [`Endpoint::Unix`] listener creates its socket file with mode `0777`
     /// less the umask bits; flux sets no mode of its own. Connecting to a
@@ -1294,7 +1299,7 @@ impl StreamNetwork {
     /// usual `022` umask yields `0755` and admits the owner alone. An operator
     /// who wants group or world access sets the umask before the bind or
     /// changes the mode after it.
-    pub fn listen(&mut self, group: ConnectionGroup, endpoint: Endpoint) -> io::Result<()> {
+    pub fn listen(&mut self, group: ConnectionGroup, endpoint: Endpoint) -> io::Result<Endpoint> {
         self.state.listen(group, endpoint)
     }
 

--- a/crates/flux-network/src/stream/service.rs
+++ b/crates/flux-network/src/stream/service.rs
@@ -161,11 +161,18 @@ mod tests {
         }
     }
 
-    fn unused_addr() -> SocketAddr {
-        let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-        let addr = listener.local_addr().unwrap();
-        drop(listener);
-        addr
+    /// A loopback endpoint whose port the kernel picks when the listener binds,
+    /// so no address is handed out before something holds it.
+    fn ephemeral() -> Endpoint {
+        Endpoint::Tcp((Ipv4Addr::LOCALHOST, 0).into())
+    }
+
+    /// The TCP address a listener bound, port included.
+    fn bound_addr(bound: Endpoint) -> SocketAddr {
+        match bound {
+            Endpoint::Tcp(addr) => addr,
+            Endpoint::Unix(path) => panic!("a TCP listener bound {}", path.display()),
+        }
     }
 
     fn raw_group(network: &mut StreamNetwork, name: &'static str) -> ConnectionGroup {
@@ -267,10 +274,8 @@ mod tests {
         let mut network = StreamNetwork::default();
         let owned = raw_group(&mut network, "owned");
         let raw = raw_group(&mut network, "raw");
-        let owned_addr = unused_addr();
-        let raw_addr = unused_addr();
-        network.listen(owned, Endpoint::Tcp(owned_addr)).unwrap();
-        network.listen(raw, Endpoint::Tcp(raw_addr)).unwrap();
+        let owned_addr = bound_addr(network.listen(owned, ephemeral()).unwrap());
+        let raw_addr = bound_addr(network.listen(raw, ephemeral()).unwrap());
         network.claim_group(owned);
         let mut probe = Probe::new(owned);
 
@@ -304,8 +309,7 @@ mod tests {
     fn a_disconnect_from_maintenance_reaches_the_service_before_its_tick() {
         let mut network = StreamNetwork::default();
         let group = raw_group(&mut network, "kicked");
-        let addr = unused_addr();
-        network.listen(group, Endpoint::Tcp(addr)).unwrap();
+        let addr = bound_addr(network.listen(group, ephemeral()).unwrap());
         network.claim_group(group);
         let mut probe = Probe::new(group);
         let client = StdTcpStream::connect(addr).unwrap();
@@ -332,8 +336,7 @@ mod tests {
     fn an_external_tick_delivers_a_maintenance_disconnect_before_the_tick() {
         let (mut external, mut network) = External::build();
         let group = raw_group(&mut network, "kicked");
-        let addr = unused_addr();
-        network.listen(group, Endpoint::Tcp(addr)).unwrap();
+        let addr = bound_addr(network.listen(group, ephemeral()).unwrap());
         network.claim_group(group);
         let mut probe = Probe::new(group);
         let client = StdTcpStream::connect(addr).unwrap();
@@ -383,8 +386,7 @@ mod tests {
     fn work_is_reported_by_services_and_by_routed_events() {
         let mut network = StreamNetwork::default();
         let group = raw_group(&mut network, "work");
-        let addr = unused_addr();
-        network.listen(group, Endpoint::Tcp(addr)).unwrap();
+        let addr = bound_addr(network.listen(group, ephemeral()).unwrap());
         network.claim_group(group);
         let mut probe = Probe::new(group);
 
@@ -447,7 +449,7 @@ mod tests {
     fn poll_with_never_blocks() {
         let mut network = StreamNetwork::default();
         let group = raw_group(&mut network, "raw");
-        network.listen(group, Endpoint::Tcp(unused_addr())).unwrap();
+        network.listen(group, ephemeral()).unwrap();
 
         let started = std::time::Instant::now();
         network.poll_with(|_| {});
@@ -458,8 +460,7 @@ mod tests {
     fn a_service_answers_the_bytes_the_network_lends_it() {
         let mut network = StreamNetwork::default();
         let group = raw_group(&mut network, "echo");
-        let addr = unused_addr();
-        network.listen(group, Endpoint::Tcp(addr)).unwrap();
+        let addr = bound_addr(network.listen(group, ephemeral()).unwrap());
         network.claim_group(group);
         let mut probe = Probe::new(group);
         let mut client = StdTcpStream::connect(addr).unwrap();

--- a/crates/flux-network/src/stream/transport.rs
+++ b/crates/flux-network/src/stream/transport.rs
@@ -30,6 +30,15 @@ impl ListenSocket {
         }
     }
 
+    /// The endpoint the socket is listening on, which differs from the one
+    /// [`Self::bind`] was given only for a TCP port of `0`.
+    pub(crate) fn endpoint(&self) -> io::Result<Endpoint> {
+        match self {
+            Self::Tcp(listener) => listener.local_addr().map(Endpoint::Tcp),
+            Self::Unix(listener) => Ok(Endpoint::Unix(listener.path.clone())),
+        }
+    }
+
     /// Accepts one pending connection, with the identity of its remote end.
     pub(crate) fn accept(&self) -> io::Result<(TransportStream, Peer)> {
         match self {

--- a/crates/flux-network/tests/connection_cap.rs
+++ b/crates/flux-network/tests/connection_cap.rs
@@ -3,7 +3,7 @@
 
 use std::{
     io::{self, Read, Write},
-    net::{Ipv4Addr, SocketAddr},
+    net::Ipv4Addr,
     thread,
     time::{Duration, Instant},
 };
@@ -20,21 +20,20 @@ const TIMEOUT: Duration = Duration::from_secs(10);
 const REQUEST: &[u8] = b"GET /hello HTTP/1.1\r\nHost: x\r\n\r\n";
 const BODY: &[u8] = b"hello";
 
-fn unused_addr() -> SocketAddr {
-    let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-    let addr = listener.local_addr().unwrap();
-    drop(listener);
-    addr
+/// A loopback endpoint whose port the kernel picks when the listener binds,
+/// so no address is handed out before something holds it.
+fn ephemeral() -> Endpoint {
+    Endpoint::Tcp((Ipv4Addr::LOCALHOST, 0).into())
 }
 
-/// Runs one test body over both transports: a loopback TCP address on an
-/// ephemeral port, and a Unix-domain socket path under a temporary directory
-/// that lives for the duration of the run.
+/// Runs one test body over both transports: a loopback address whose port the
+/// listener's own bind decides, and a Unix-domain socket path under a
+/// temporary directory that lives for the duration of the run.
 macro_rules! over_both_transports {
     ($body:ident, $tcp:ident, $unix:ident) => {
         #[test]
         fn $tcp() {
-            $body(&Endpoint::Tcp(unused_addr()));
+            $body(&ephemeral());
         }
 
         #[test]
@@ -110,11 +109,16 @@ impl Server {
         }
     }
 
-    /// Adds a group and a listener for it.
-    fn listen(&mut self, config: ConnectionGroupConfig, endpoint: &Endpoint) -> ConnectionGroup {
+    /// Adds a group and a listener for it, reporting the group and the
+    /// endpoint the listener bound.
+    fn listen(
+        &mut self,
+        config: ConnectionGroupConfig,
+        endpoint: &Endpoint,
+    ) -> (ConnectionGroup, Endpoint) {
         let group = self.network.add_group(config);
-        self.network.listen(group, endpoint.clone()).unwrap();
-        group
+        let bound = self.network.listen(group, endpoint.clone()).unwrap();
+        (group, bound)
     }
 
     /// Runs one iteration of the network, recording what it delivers.
@@ -192,7 +196,8 @@ over_both_transports!(
 );
 fn a_client_arriving_at_the_cap_is_refused(endpoint: &Endpoint) {
     let mut server = Server::new();
-    let group = server.listen(capped_group("capped", 2), endpoint);
+    let (group, bound) = server.listen(capped_group("capped", 2), endpoint);
+    let endpoint = &bound;
 
     let mut first = connect_client(endpoint);
     let mut second = connect_client(endpoint);
@@ -216,7 +221,7 @@ over_both_transports!(
 fn a_draining_connection_holds_its_place(endpoint: &Endpoint) {
     let payload = vec![0x5A; 4 * 1024 * 1024];
     let mut server = Server::new();
-    let group = server.listen(
+    let (group, bound) = server.listen(
         ConnectionGroupConfig {
             socket_buf_size: Some(4096),
             max_frame_size: payload.len(),
@@ -225,6 +230,7 @@ fn a_draining_connection_holds_its_place(endpoint: &Endpoint) {
         },
         endpoint,
     );
+    let endpoint = &bound;
 
     let mut first = connect_client(endpoint);
     let token = server.wait_for_accepts(group, 1)[0];
@@ -254,7 +260,8 @@ over_both_transports!(
 );
 fn a_half_closed_connection_holds_its_place(endpoint: &Endpoint) {
     let mut server = Server::new();
-    let group = server.listen(capped_group("half-closed", 1), endpoint);
+    let (group, bound) = server.listen(capped_group("half-closed", 1), endpoint);
+    let endpoint = &bound;
 
     let mut first = connect_client(endpoint);
     let token = server.wait_for_accepts(group, 1)[0];
@@ -278,9 +285,8 @@ fn a_half_closed_connection_holds_its_place(endpoint: &Endpoint) {
 /// an edge-triggered listener is told about a pending connection once.
 #[test]
 fn a_refusal_leaves_none_of_the_backlog_unaccepted() {
-    let endpoint = Endpoint::Tcp(unused_addr());
     let mut server = Server::new();
-    let group = server.listen(capped_group("backlog", 1), &endpoint);
+    let (group, endpoint) = server.listen(capped_group("backlog", 1), &ephemeral());
 
     let _first = connect_client(&endpoint);
     server.wait_for_accepts(group, 1);
@@ -296,9 +302,8 @@ fn a_refusal_leaves_none_of_the_backlog_unaccepted() {
 
 #[test]
 fn a_closed_connection_frees_its_place() {
-    let endpoint = Endpoint::Tcp(unused_addr());
     let mut server = Server::new();
-    let group = server.listen(capped_group("freed", 1), &endpoint);
+    let (group, endpoint) = server.listen(capped_group("freed", 1), &ephemeral());
 
     let first = connect_client(&endpoint);
     server.wait_for_accepts(group, 1);
@@ -314,9 +319,8 @@ fn a_closed_connection_frees_its_place() {
 /// let the connection go rather than because the peer went.
 #[test]
 fn a_disconnected_connection_frees_its_place() {
-    let endpoint = Endpoint::Tcp(unused_addr());
     let mut server = Server::new();
-    let group = server.listen(capped_group("disconnected", 1), &endpoint);
+    let (group, endpoint) = server.listen(capped_group("disconnected", 1), &ephemeral());
 
     let _first = connect_client(&endpoint);
     let token = server.wait_for_accepts(group, 1)[0];
@@ -332,9 +336,8 @@ fn a_disconnected_connection_frees_its_place() {
 /// place it held is freed by the removal itself.
 #[test]
 fn a_removed_connection_frees_its_place() {
-    let endpoint = Endpoint::Tcp(unused_addr());
     let mut server = Server::new();
-    let group = server.listen(capped_group("removed", 1), &endpoint);
+    let (group, endpoint) = server.listen(capped_group("removed", 1), &ephemeral());
 
     let _first = connect_client(&endpoint);
     let token = server.wait_for_accepts(group, 1)[0];
@@ -348,11 +351,9 @@ fn a_removed_connection_frees_its_place() {
 
 #[test]
 fn the_cap_belongs_to_one_group() {
-    let capped_endpoint = Endpoint::Tcp(unused_addr());
-    let open_endpoint = Endpoint::Tcp(unused_addr());
     let mut server = Server::new();
-    let capped = server.listen(capped_group("capped", 1), &capped_endpoint);
-    let open = server.listen(raw_group("open"), &open_endpoint);
+    let (capped, capped_endpoint) = server.listen(capped_group("capped", 1), &ephemeral());
+    let (open, open_endpoint) = server.listen(raw_group("open"), &ephemeral());
 
     let _first = connect_client(&capped_endpoint);
     server.wait_for_accepts(capped, 1);
@@ -370,11 +371,9 @@ fn the_cap_belongs_to_one_group() {
 #[test]
 fn two_listeners_of_one_group_share_its_cap() {
     let dir = tempfile::tempdir().unwrap();
-    let tcp = Endpoint::Tcp(unused_addr());
-    let unix = Endpoint::Unix(dir.path().join("s"));
     let mut server = Server::new();
-    let group = server.listen(capped_group("shared", 1), &tcp);
-    server.network.listen(group, unix.clone()).unwrap();
+    let (group, tcp) = server.listen(capped_group("shared", 1), &ephemeral());
+    let unix = server.network.listen(group, Endpoint::Unix(dir.path().join("s"))).unwrap();
 
     let first = connect_client(&tcp);
     server.wait_for_accepts(group, 1);
@@ -393,21 +392,19 @@ fn two_listeners_of_one_group_share_its_cap() {
 
 #[test]
 fn an_outbound_endpoint_holds_no_place() {
-    let capped_endpoint = Endpoint::Tcp(unused_addr());
-    let remote_endpoint = Endpoint::Tcp(unused_addr());
     let mut server = Server::new();
-    let remote = server.listen(raw_group("remote"), &remote_endpoint);
-    let capped = server.listen(
+    let (remote, remote_endpoint) = server.listen(raw_group("remote"), &ephemeral());
+    let (capped, capped_endpoint) = server.listen(
         ConnectionGroupConfig {
             reconnect_interval: flux_timing::Duration::from_millis(1),
             ..capped_group("capped", 1)
         },
-        &capped_endpoint,
+        &ephemeral(),
     );
 
     // The capped group holds an outbound endpoint of its own: a connection
     // it made rather than accepted, which the cap counts for nothing.
-    let outbound = server.network.connect(capped, remote_endpoint.clone());
+    let outbound = server.network.connect(capped, remote_endpoint);
     server.wait_for_accepts(remote, 1);
     let deadline = Instant::now() + TIMEOUT;
     while Instant::now() < deadline && !server.connected.contains(&outbound) {
@@ -446,7 +443,6 @@ fn serve(network: &mut StreamNetwork, service: &mut HttpService) {
 /// an `HttpService` never hears of the connection its group refused.
 #[test]
 fn an_http_service_serves_its_clients_while_the_cap_refuses_another() {
-    let endpoint = Endpoint::Tcp(unused_addr());
     let mut network = StreamNetwork::default();
     let group = network.add_group(ConnectionGroupConfig {
         name: "http",
@@ -456,7 +452,7 @@ fn an_http_service_serves_its_clients_while_the_cap_refuses_another() {
         ..ConnectionGroupConfig::default()
     });
     let mut service = HttpService::new(&mut network, group, HttpConfig::default());
-    service.listen(&mut network, endpoint.clone()).unwrap();
+    let endpoint = service.listen(&mut network, ephemeral()).unwrap();
 
     let mut served = [connect_client(&endpoint), connect_client(&endpoint)];
     let mut answers = [Vec::new(), Vec::new()];
@@ -520,11 +516,10 @@ fn drive_service(network: &mut StreamNetwork, service: &mut HttpService) -> bool
 /// `HttpService::close` is the public way to close a group.
 #[test]
 fn a_closed_group_frees_the_places_it_held() {
-    let endpoint = Endpoint::Tcp(unused_addr());
     let mut server = Server::new();
     let group = server.network.add_group(capped_group("closed", 1));
     let mut service = HttpService::new(&mut server.network, group, HttpConfig::default());
-    service.listen(&mut server.network, endpoint.clone()).unwrap();
+    let endpoint = service.listen(&mut server.network, ephemeral()).unwrap();
 
     let _first = connect_client(&endpoint);
     let deadline = Instant::now() + TIMEOUT;
@@ -548,8 +543,7 @@ fn a_closed_group_frees_the_places_it_held() {
 
     service.close(&mut server.network);
 
-    let reopened_endpoint = Endpoint::Tcp(unused_addr());
-    server.network.listen(group, reopened_endpoint.clone()).unwrap();
+    let reopened_endpoint = server.network.listen(group, ephemeral()).unwrap();
     let _client = connect_client(&reopened_endpoint);
     server.wait_for_accepts(group, 1);
     assert_eq!(server.refused(group), 1, "the group refused a client it had room for");

--- a/crates/flux-network/tests/external_mode.rs
+++ b/crates/flux-network/tests/external_mode.rs
@@ -3,10 +3,9 @@
 //! refuses.
 
 use std::{
-    collections::BTreeSet,
     io::{self, Read, Write},
     net::{Ipv4Addr, SocketAddr, TcpStream},
-    sync::{Arc, Mutex},
+    sync::Arc,
     thread,
     time::{Duration, Instant},
 };
@@ -26,20 +25,17 @@ const TOKEN_BASE: Token = Token(1000);
 /// A token of the caller's own, for a source the network never sees.
 const FOREIGN: Token = Token(7);
 
-/// A loopback address no listener holds. The probe binding is released before
-/// the address is handed out, and a port this run has already given away is
-/// never given away again.
-fn unused_addr() -> SocketAddr {
-    static TAKEN: Mutex<BTreeSet<u16>> = Mutex::new(BTreeSet::new());
-    let mut probes = Vec::new();
-    loop {
-        let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-        let addr = listener.local_addr().unwrap();
-        if TAKEN.lock().unwrap().insert(addr.port()) {
-            return addr;
-        }
-        probes.push(listener);
-        assert!(probes.len() < 64, "no free loopback port");
+/// A loopback endpoint whose port the kernel picks when the listener binds,
+/// so no address is handed out before something holds it.
+fn ephemeral() -> Endpoint {
+    Endpoint::Tcp((Ipv4Addr::LOCALHOST, 0).into())
+}
+
+/// The TCP address a listener bound, port included.
+fn bound_addr(bound: Endpoint) -> SocketAddr {
+    match bound {
+        Endpoint::Tcp(addr) => addr,
+        Endpoint::Unix(path) => panic!("a TCP listener bound {}", path.display()),
     }
 }
 
@@ -120,12 +116,12 @@ fn response_len(bytes: &[u8]) -> Option<usize> {
     (bytes.len() >= head + length).then_some(head + length)
 }
 
-/// An HTTP service listening on `addr`, inside a network on the test's poll.
-fn served(ext: &mut External, addr: SocketAddr, config: HttpConfig) -> HttpService {
+/// A service serving on a port the kernel picked, and the address to dial it.
+fn served(ext: &mut External, config: HttpConfig) -> (HttpService, SocketAddr) {
     let group = ext.net.add_group(raw_group("http"));
     let mut http = HttpService::new(&mut ext.net, group, config);
-    http.listen(&mut ext.net, Endpoint::Tcp(addr)).unwrap();
-    http
+    let addr = bound_addr(http.listen(&mut ext.net, ephemeral()).unwrap());
+    (http, addr)
 }
 
 // ---------------------------------------------------------------------------
@@ -134,8 +130,7 @@ fn served(ext: &mut External, addr: SocketAddr, config: HttpConfig) -> HttpServi
 #[test]
 fn an_external_network_serves_over_the_three_calls() {
     let mut ext = External::new();
-    let addr = unused_addr();
-    let mut http = served(&mut ext, addr, HttpConfig::default());
+    let (mut http, addr) = served(&mut ext, HttpConfig::default());
     let mut client = client_at(addr);
     client.write_all(b"GET /over-there HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
 
@@ -161,12 +156,11 @@ fn an_external_network_serves_over_the_three_calls() {
 #[test]
 fn a_foreign_source_keeps_its_events_and_its_connections() {
     let mut ext = External::new();
-    let addr = unused_addr();
-    let mut http = served(&mut ext, addr, HttpConfig::default());
+    let (mut http, addr) = served(&mut ext, HttpConfig::default());
 
     // A listener of the caller's own, on a token below the network's base.
-    let foreign_addr = unused_addr();
-    let mut foreign = mio::net::TcpListener::bind(foreign_addr).unwrap();
+    let mut foreign = mio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0).into()).unwrap();
+    let foreign_addr = foreign.local_addr().unwrap();
     ext.poll.registry().register(&mut foreign, FOREIGN, Interest::READABLE).unwrap();
 
     let _to_foreign = client_at(foreign_addr);
@@ -220,8 +214,7 @@ fn a_foreign_event_is_handed_back_before_the_services_are_checked() {
 #[should_panic(expected = "service-owned group 0 has no service")]
 fn an_own_event_is_checked_against_the_services_before_it_is_routed() {
     let mut ext = External::new();
-    let addr = unused_addr();
-    let _http = served(&mut ext, addr, HttpConfig::default());
+    let (_http, addr) = served(&mut ext, HttpConfig::default());
     let _client = client_at(addr);
 
     // The listener becomes readable on a token of the network's own, and the
@@ -239,8 +232,7 @@ fn an_own_event_is_checked_against_the_services_before_it_is_routed() {
 #[test]
 fn a_tick_reports_a_request_no_one_pulled() {
     let mut ext = External::new();
-    let addr = unused_addr();
-    let mut http = served(&mut ext, addr, HttpConfig::default());
+    let (mut http, addr) = served(&mut ext, HttpConfig::default());
     let mut client = client_at(addr);
 
     let deadline = Instant::now() + TIMEOUT;
@@ -313,8 +305,7 @@ fn a_tick_attempts_the_reconnect_that_is_due() {
 fn a_late_event_for_a_gone_connection_is_still_ours() {
     let mut ext = External::new();
     let group = ext.net.add_group(raw_group("stale"));
-    let addr = unused_addr();
-    ext.net.listen(group, Endpoint::Tcp(addr)).unwrap();
+    let addr = bound_addr(ext.net.listen(group, ephemeral()).unwrap());
     let mut client = client_at(addr);
 
     let deadline = Instant::now() + TIMEOUT;
@@ -357,9 +348,8 @@ fn a_late_event_for_a_gone_connection_is_still_ours() {
 #[test]
 fn next_deadline_folds_the_services_idle_sweep() {
     let mut ext = External::new();
-    let addr = unused_addr();
     let idle = flux_timing::Duration::from_millis(500);
-    let mut http = served(&mut ext, addr, HttpConfig::default().with_idle_timeout(idle));
+    let (mut http, addr) = served(&mut ext, HttpConfig::default().with_idle_timeout(idle));
     assert!(
         ext.net.next_deadline(&[http.as_service()]).is_none(),
         "nothing is due before a connection exists"
@@ -402,8 +392,7 @@ fn next_deadline_validates_before_it_folds() {
 fn a_wake_returns_from_a_blocking_drive_without_work() {
     let mut net = StreamNetwork::default();
     let group = net.add_group(raw_group("raw"));
-    let addr = unused_addr();
-    net.listen(group, Endpoint::Tcp(addr)).unwrap();
+    let addr = bound_addr(net.listen(group, ephemeral()).unwrap());
     // A waker delivers only while it is alive, so the test holds one end of
     // it for as long as the drive it wakes.
     let waker = Arc::new(net.waker().unwrap());
@@ -556,9 +545,9 @@ fn allocation_stops_below_the_reserved_waker_token() {
     let mut net =
         StreamNetwork::with_registry(poll.registry().try_clone().unwrap(), Token(usize::MAX - 1));
     let group = net.add_group(raw_group("edge"));
-    net.listen(group, Endpoint::Tcp(unused_addr())).unwrap();
+    net.listen(group, ephemeral()).unwrap();
     // The next token would be the one the waker reserves.
-    net.listen(group, Endpoint::Tcp(unused_addr())).unwrap();
+    net.listen(group, ephemeral()).unwrap();
 }
 
 #[test]
@@ -567,8 +556,7 @@ fn handle_event_delivers_the_disconnect_it_produced() {
     let group = ext
         .net
         .add_group(ConnectionGroupConfig { socket_buf_size: Some(1024), ..raw_group("drained") });
-    let addr = unused_addr();
-    ext.net.listen(group, Endpoint::Tcp(addr)).unwrap();
+    let addr = bound_addr(ext.net.listen(group, ephemeral()).unwrap());
     let mut client = client_at(addr);
 
     // No tick runs anywhere in this test: everything the network reports has

--- a/crates/flux-network/tests/half_close.rs
+++ b/crates/flux-network/tests/half_close.rs
@@ -4,7 +4,7 @@
 use std::{
     cell::Cell,
     io::{self, Read, Write},
-    net::{Ipv4Addr, SocketAddr},
+    net::Ipv4Addr,
     thread,
     time::{Duration, Instant},
 };
@@ -19,21 +19,20 @@ const INBOUND: &[u8] = b"sent after the end of the stream";
 const BROADCAST: &[u8] = b"broadcast to the group";
 const RECONNECTED: &[u8] = b"sent after the reconnect";
 
-fn unused_addr() -> SocketAddr {
-    let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-    let addr = listener.local_addr().unwrap();
-    drop(listener);
-    addr
+/// A loopback endpoint whose port the kernel picks when the listener binds,
+/// so no address is handed out before something holds it.
+fn ephemeral() -> Endpoint {
+    Endpoint::Tcp((Ipv4Addr::LOCALHOST, 0).into())
 }
 
-/// Runs one test body over both transports: a loopback TCP address on an
-/// ephemeral port, and a Unix-domain socket path under a temporary directory
-/// that lives for the duration of the run.
+/// Runs one test body over both transports: a loopback address whose port the
+/// listener's own bind decides, and a Unix-domain socket path under a
+/// temporary directory that lives for the duration of the run.
 macro_rules! over_both_transports {
     ($body:ident, $tcp:ident, $unix:ident) => {
         #[test]
         fn $tcp() {
-            $body(&Endpoint::Tcp(unused_addr()));
+            $body(&ephemeral());
         }
 
         #[test]
@@ -67,12 +66,16 @@ fn raw_group(name: &'static str) -> ConnectionGroupConfig {
     ConnectionGroupConfig { name, framing: Framing::Raw, ..ConnectionGroupConfig::default() }
 }
 
-/// A listening network, and the group its connections belong to.
-fn server(endpoint: &Endpoint, config: ConnectionGroupConfig) -> (StreamNetwork, ConnectionGroup) {
+/// A listening network, the group its connections belong to, and the endpoint
+/// it bound: for a TCP request on port `0` that is where a client must dial.
+fn server(
+    endpoint: &Endpoint,
+    config: ConnectionGroupConfig,
+) -> (StreamNetwork, ConnectionGroup, Endpoint) {
     let mut network = StreamNetwork::default();
     let group = network.add_group(config);
-    network.listen(group, endpoint.clone()).unwrap();
-    (network, group)
+    let bound = network.listen(group, endpoint.clone()).unwrap();
+    (network, group, bound)
 }
 
 fn wait_for_accept(network: &mut StreamNetwork, group: ConnectionGroup) -> Token {
@@ -184,7 +187,8 @@ over_both_transports!(
     half_close_ends_the_stream_and_keeps_reading_unix
 );
 fn half_close_ends_the_stream_and_keeps_reading(endpoint: &Endpoint) {
-    let (mut network, group) = server(endpoint, raw_group("half-close"));
+    let (mut network, group, bound) = server(endpoint, raw_group("half-close"));
+    let endpoint = &bound;
     let mut client = connect_client(endpoint);
     let token = wait_for_accept(&mut network, group);
 
@@ -222,12 +226,13 @@ over_both_transports!(
 );
 fn queued_bytes_reach_the_peer_before_the_end_of_the_stream(endpoint: &Endpoint) {
     let payload = vec![0xA5; 4 * 1024 * 1024];
-    let (mut network, group) = server(endpoint, ConnectionGroupConfig {
+    let (mut network, group, bound) = server(endpoint, ConnectionGroupConfig {
         socket_buf_size: Some(4096),
         max_frame_size: payload.len(),
         backlog_warn_bytes: None,
         ..raw_group("half-close-drain")
     });
+    let endpoint = &bound;
     let mut client = connect_client(endpoint);
     let token = wait_for_accept(&mut network, group);
 
@@ -255,7 +260,8 @@ over_both_transports!(
     sends_after_the_half_close_are_refused_unix
 );
 fn sends_after_the_half_close_are_refused(endpoint: &Endpoint) {
-    let (mut network, group) = server(endpoint, raw_group("half-close-send"));
+    let (mut network, group, bound) = server(endpoint, raw_group("half-close-send"));
+    let endpoint = &bound;
     let mut client = connect_client(endpoint);
     let token = wait_for_accept(&mut network, group);
 
@@ -287,7 +293,8 @@ over_both_transports!(
     a_hard_close_after_the_half_close_ends_the_connection_unix
 );
 fn a_hard_close_after_the_half_close_ends_the_connection(endpoint: &Endpoint) {
-    let (mut network, group) = server(endpoint, raw_group("half-close-hard"));
+    let (mut network, group, bound) = server(endpoint, raw_group("half-close-hard"));
+    let endpoint = &bound;
     let mut client = connect_client(endpoint);
     let token = wait_for_accept(&mut network, group);
 
@@ -349,12 +356,13 @@ fn a_hard_close_asked_for_second_wins(endpoint: &Endpoint) {
 /// then the end of the stream, and the connection is gone.
 fn a_hard_close_wins(endpoint: &Endpoint, order: Order) {
     let payload = vec![0xC3; 4 * 1024 * 1024];
-    let (mut network, group) = server(endpoint, ConnectionGroupConfig {
+    let (mut network, group, bound) = server(endpoint, ConnectionGroupConfig {
         socket_buf_size: Some(4096),
         max_frame_size: payload.len(),
         backlog_warn_bytes: None,
         ..raw_group("both-closes")
     });
+    let endpoint = &bound;
     let mut client = connect_client(endpoint);
     let token = wait_for_accept(&mut network, group);
 
@@ -401,7 +409,8 @@ over_both_transports!(
     a_broadcast_passes_over_a_half_closed_member_unix
 );
 fn a_broadcast_passes_over_a_half_closed_member(endpoint: &Endpoint) {
-    let (mut network, group) = server(endpoint, raw_group("broadcast"));
+    let (mut network, group, bound) = server(endpoint, raw_group("broadcast"));
+    let endpoint = &bound;
     let mut open = connect_client(endpoint);
     let open_token = wait_for_accept(&mut network, group);
     let mut shut = connect_client(endpoint);
@@ -444,8 +453,8 @@ fn a_reconnect_opens_the_write_side_again(endpoint: &Endpoint) {
         reconnect_interval: flux_timing::Duration::from_millis(1),
         ..raw_group("client")
     });
-    network.listen(server_group, endpoint.clone()).unwrap();
-    let outbound = network.connect(client_group, endpoint.clone());
+    let bound = network.listen(server_group, endpoint.clone()).unwrap();
+    let outbound = network.connect(client_group, bound);
 
     let mut events = Events::default();
     events.wait_until(

--- a/crates/flux-network/tests/http.rs
+++ b/crates/flux-network/tests/http.rs
@@ -571,6 +571,53 @@ fn respond_with_frames_the_body_the_closure_writes() {
 }
 
 #[test]
+fn a_slice_answer_after_a_composed_one_carries_only_its_own_body() {
+    let dir = tempfile::tempdir().unwrap();
+    let endpoint = Endpoint::Unix(dir.path().join("s"));
+    let mut server = server_at(&endpoint);
+    let mut client = connect_client(&endpoint);
+    client
+        .write_all(b"GET /one HTTP/1.1\r\nHost: x\r\n\r\nGET /two HTTP/1.1\r\nHost: x\r\n\r\n")
+        .unwrap();
+
+    let composed = b"a composed body, and a long one".as_slice();
+    let slice = b"short".as_slice();
+    let mut expected = Vec::new();
+    for body in [composed, slice] {
+        expected.extend_from_slice(b"HTTP/1.1 200 OK\r\n");
+        expected.extend_from_slice(format!("Content-Length: {}\r\n", body.len()).as_bytes());
+        expected.extend_from_slice(b"Connection: keep-alive\r\n\r\n");
+        expected.extend_from_slice(body);
+    }
+
+    // The first answer is rendered into the buffer the service keeps; the
+    // second is a slice the caller holds. Nothing of the first may reach it.
+    let mut answered = 0;
+    let mut received = Vec::new();
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && received.len() < expected.len() {
+        let mut tokens = Vec::new();
+        server.pump(|event| {
+            if let HttpEvent::Request { token, .. } = event {
+                tokens.push(token);
+            }
+        });
+        for token in tokens {
+            assert!(if answered == 0 {
+                server.respond_with(token, 200, &[], |out| out.extend_from_slice(composed))
+            } else {
+                server.respond(token, 200, &[], slice)
+            });
+            answered += 1;
+        }
+        read_available(&mut client, &mut received);
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(answered, 2, "both pipelined requests were answered");
+    assert_eq!(received, expected, "{}", String::from_utf8_lossy(&received));
+}
+
+#[test]
 fn a_head_request_carries_the_length_of_the_body_it_is_not_sent() {
     let (mut server, addr) = server();
     let mut client = std::net::TcpStream::connect(addr).unwrap();

--- a/crates/flux-network/tests/http.rs
+++ b/crates/flux-network/tests/http.rs
@@ -1,8 +1,6 @@
 use std::{
-    collections::BTreeSet,
     io::{self, Read, Write},
     net::{Ipv4Addr, SocketAddr},
-    sync::Mutex,
     thread,
     time::{Duration, Instant},
 };
@@ -17,25 +15,17 @@ use flux_network::{
 
 const TIMEOUT: Duration = Duration::from_secs(10);
 
-/// A loopback address no listener holds.
-///
-/// The probe binding is released before the address is handed out, so a port
-/// this run has already given away must never be given away again: the kernel
-/// reuses a released ephemeral port readily, and two tests binding one port is
-/// a failure that has nothing to do with what they test. Ports that collide
-/// stay bound until a fresh one is found, which is what makes the kernel offer
-/// another.
-fn unused_addr() -> SocketAddr {
-    static TAKEN: Mutex<BTreeSet<u16>> = Mutex::new(BTreeSet::new());
-    let mut probes = Vec::new();
-    loop {
-        let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-        let addr = listener.local_addr().unwrap();
-        if TAKEN.lock().unwrap().insert(addr.port()) {
-            return addr;
-        }
-        probes.push(listener);
-        assert!(probes.len() < 64, "no free loopback port");
+/// A loopback endpoint whose port the kernel picks when the listener binds,
+/// so no address is handed out before something holds it.
+fn ephemeral() -> Endpoint {
+    Endpoint::Tcp((Ipv4Addr::LOCALHOST, 0).into())
+}
+
+/// The TCP address a listener bound, port included.
+fn bound_addr(bound: Endpoint) -> SocketAddr {
+    match bound {
+        Endpoint::Tcp(addr) => addr,
+        Endpoint::Unix(path) => panic!("a TCP listener bound {}", path.display()),
     }
 }
 
@@ -149,8 +139,10 @@ impl Http {
         driver.iterate(net, &mut [service.as_service()], |_| {})
     }
 
-    fn listen(&mut self, endpoint: &Endpoint) {
-        self.service.listen(&mut self.net, endpoint.clone()).unwrap();
+    /// Listens, and reports the endpoint bound: for a TCP request on port
+    /// `0` that is the address a client must dial.
+    fn listen(&mut self, endpoint: &Endpoint) -> Endpoint {
+        self.service.listen(&mut self.net, endpoint.clone()).unwrap()
     }
 
     fn connect(&mut self, endpoint: Endpoint) -> Token {
@@ -197,14 +189,14 @@ impl Http {
     }
 }
 
-/// Runs one test body over both transports: a loopback TCP address on an
-/// ephemeral port, and a Unix-domain socket path under a temporary directory
-/// that lives for the duration of the run.
+/// Runs one test body over both transports: a loopback address whose port the
+/// listener's own bind decides, and a Unix-domain socket path under a
+/// temporary directory that lives for the duration of the run.
 macro_rules! over_both_transports {
     ($body:ident, $tcp:ident, $unix:ident) => {
         #[test]
         fn $tcp() {
-            $body(&Endpoint::Tcp(unused_addr()));
+            $body(&ephemeral());
         }
 
         #[test]
@@ -221,12 +213,12 @@ macro_rules! over_transports_and_modes {
     ($body:ident, $tcp:ident, $tcp_external:ident, $unix:ident, $unix_external:ident) => {
         #[test]
         fn $tcp() {
-            $body(Mode::Owned, &Endpoint::Tcp(unused_addr()));
+            $body(Mode::Owned, &ephemeral());
         }
 
         #[test]
         fn $tcp_external() {
-            $body(Mode::External, &Endpoint::Tcp(unused_addr()));
+            $body(Mode::External, &ephemeral());
         }
 
         #[test]
@@ -306,19 +298,20 @@ fn response_len(bytes: &[u8]) -> Option<usize> {
     (bytes.len() >= head + length).then_some(head + length)
 }
 
-fn server_at(endpoint: &Endpoint) -> Http {
+fn server_at(endpoint: &Endpoint) -> (Http, Endpoint) {
     server_at_in(Mode::Owned, endpoint)
 }
 
-fn server_at_in(mode: Mode, endpoint: &Endpoint) -> Http {
+fn server_at_in(mode: Mode, endpoint: &Endpoint) -> (Http, Endpoint) {
     let mut server = Http::new_in(mode);
-    server.listen(endpoint);
-    server
+    let bound = server.listen(endpoint);
+    (server, bound)
 }
 
 fn server() -> (Http, SocketAddr) {
-    let addr = unused_addr();
-    (server_at(&Endpoint::Tcp(addr)), addr)
+    let mut server = Http::new();
+    let addr = bound_addr(server.listen(&ephemeral()));
+    (server, addr)
 }
 
 over_transports_and_modes!(
@@ -329,7 +322,8 @@ over_transports_and_modes!(
     get_keepalive_two_requests_unix_external
 );
 fn get_keepalive_two_requests(mode: Mode, endpoint: &Endpoint) {
-    let mut server = server_at_in(mode, endpoint);
+    let (mut server, bound) = server_at_in(mode, endpoint);
+    let endpoint = &bound;
     let mut client = connect_client(endpoint);
     let deadline = Instant::now() + TIMEOUT;
     let mut first = Vec::new();
@@ -381,7 +375,8 @@ over_transports_and_modes!(
     post_echo_body_unix_external
 );
 fn post_echo_body(mode: Mode, endpoint: &Endpoint) {
-    let mut server = server_at_in(mode, endpoint);
+    let (mut server, bound) = server_at_in(mode, endpoint);
+    let endpoint = &bound;
     let body = vec![42; 4096];
     let mut client = connect_client(endpoint);
     client
@@ -462,13 +457,12 @@ fn post_binary_body_lone_lf() {
 
 #[test]
 fn connection_close_large_body() {
-    let addr = unused_addr();
     let mut server = Http::build(
         Mode::Owned,
         ConnectionGroupConfig { socket_buf_size: Some(1024), ..http_group() },
         HttpConfig::default(),
     );
-    server.listen(&Endpoint::Tcp(addr));
+    let addr = bound_addr(server.listen(&ephemeral()));
     let body = vec![7; 256 * 1024];
     let mut client = std::net::TcpStream::connect(addr).unwrap();
     client.set_nonblocking(true).unwrap();
@@ -498,11 +492,10 @@ fn limits_and_errors() {
         (b"nope\r\n\r\n".as_slice(), 400),
         (b"POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n".as_slice(), 501),
     ] {
-        let addr = unused_addr();
         let mut server = Http::with_config(
             HttpConfig::default().with_max_head_bytes(64).with_max_body_bytes(8),
         );
-        server.listen(&Endpoint::Tcp(addr));
+        let addr = bound_addr(server.listen(&ephemeral()));
         let mut client = std::net::TcpStream::connect(addr).unwrap();
         client.set_nonblocking(true).unwrap();
         client.write_all(request).unwrap();
@@ -574,7 +567,7 @@ fn respond_with_frames_the_body_the_closure_writes() {
 fn a_slice_answer_after_a_composed_one_carries_only_its_own_body() {
     let dir = tempfile::tempdir().unwrap();
     let endpoint = Endpoint::Unix(dir.path().join("s"));
-    let mut server = server_at(&endpoint);
+    let (mut server, endpoint) = server_at(&endpoint);
     let mut client = connect_client(&endpoint);
     client
         .write_all(b"GET /one HTTP/1.1\r\nHost: x\r\n\r\nGET /two HTTP/1.1\r\nHost: x\r\n\r\n")
@@ -742,7 +735,8 @@ over_transports_and_modes!(
     pipelined_requests_unix_external
 );
 fn pipelined_requests(mode: Mode, endpoint: &Endpoint) {
-    let mut server = server_at_in(mode, endpoint);
+    let (mut server, bound) = server_at_in(mode, endpoint);
+    let endpoint = &bound;
     let mut client = connect_client(endpoint);
     client
         .write_all(b"GET /one HTTP/1.1\r\nHost: x\r\n\r\nGET /two HTTP/1.1\r\nHost: x\r\n\r\n")
@@ -776,7 +770,8 @@ over_transports_and_modes!(
     client_server_roundtrip_unix_external
 );
 fn client_server_roundtrip(mode: Mode, endpoint: &Endpoint) {
-    let mut server = server_at_in(mode, endpoint);
+    let (mut server, bound) = server_at_in(mode, endpoint);
+    let endpoint = &bound;
     let mut client = Http::new_in(mode);
     let token = client.connect(endpoint.clone());
     let mut sent = false;
@@ -1128,11 +1123,10 @@ fn client_chunked_overflow() {
 
 #[test]
 fn idle_timeout_disconnects() {
-    let addr = unused_addr();
     let mut server = Http::with_config(
         HttpConfig::default().with_idle_timeout(Duration::from_millis(200).into()),
     );
-    server.listen(&Endpoint::Tcp(addr));
+    let addr = bound_addr(server.listen(&ephemeral()));
     let mut client = std::net::TcpStream::connect(addr).unwrap();
     client.set_nonblocking(true).unwrap();
     let deadline = Instant::now() + Duration::from_secs(2);
@@ -1176,14 +1170,13 @@ fn idle_timeout_disconnects() {
 
 #[test]
 fn pending_buffer_cap_waits_for_the_answer() {
-    let addr = unused_addr();
     let mut server = Http::with_config(
         HttpConfig::default()
             .with_max_head_bytes(64)
             .with_max_body_bytes(64)
             .with_idle_timeout(Duration::from_millis(200).into()),
     );
-    server.listen(&Endpoint::Tcp(addr));
+    let addr = bound_addr(server.listen(&ephemeral()));
     let mut client = std::net::TcpStream::connect(addr).unwrap();
     client.set_nonblocking(true).unwrap();
     client.write_all(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
@@ -1324,9 +1317,8 @@ fn server_disconnect_kicks() {
 
 #[test]
 fn wrong_role_calls_return_false() {
-    let addr = unused_addr();
     let mut http = Http::new();
-    http.listen(&Endpoint::Tcp(addr));
+    let addr = bound_addr(http.listen(&ephemeral()));
     let outbound = http.connect(Endpoint::Tcp(addr));
     let stream = std::net::TcpStream::connect(addr).unwrap();
     stream.set_nonblocking(true).unwrap();
@@ -1346,9 +1338,8 @@ fn wrong_role_calls_return_false() {
 
 #[test]
 fn single_instance_serves_itself() {
-    let addr = unused_addr();
     let mut http = Http::new();
-    http.listen(&Endpoint::Tcp(addr));
+    let addr = bound_addr(http.listen(&ephemeral()));
     let outbound = http.connect(Endpoint::Tcp(addr));
     let deadline = Instant::now() + TIMEOUT;
     let mut sent = false;
@@ -1382,7 +1373,8 @@ over_both_transports!(
     outbound_host_header_names_the_endpoint_unix
 );
 fn outbound_host_header_names_the_endpoint(endpoint: &Endpoint) {
-    let mut server = server_at(endpoint);
+    let (mut server, bound) = server_at(endpoint);
+    let endpoint = &bound;
     let mut client = Http::new();
     let token = client.connect(endpoint.clone());
     let mut sent = false;
@@ -1418,7 +1410,8 @@ fn outbound_host_header_names_the_endpoint(endpoint: &Endpoint) {
 
 over_both_transports!(accepted_reports_peer, accepted_reports_peer_tcp, accepted_reports_peer_unix);
 fn accepted_reports_peer(endpoint: &Endpoint) {
-    let mut server = server_at(endpoint);
+    let (mut server, bound) = server_at(endpoint);
+    let endpoint = &bound;
     let _client = connect_client(endpoint);
     let mut accepted = None;
     let deadline = Instant::now() + TIMEOUT;
@@ -1487,7 +1480,7 @@ fn a_dropped_responder_answers_later_by_token() {
 fn a_refused_answer_composes_no_body() {
     let dir = tempfile::tempdir().unwrap();
     let endpoint = Endpoint::Unix(dir.path().join("s"));
-    let mut server = server_at(&endpoint);
+    let (mut server, endpoint) = server_at(&endpoint);
     let mut client = connect_client(&endpoint);
     client.write_all(b"GET /defer HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
     let (token, _) = pull_deferred_request(&mut server);
@@ -1707,12 +1700,11 @@ fn a_second_response_to_one_request_is_refused() {
 
 #[test]
 fn answered_bytes_cost_the_connection_nothing() {
-    let addr = unused_addr();
     // Two of these requests together outgrow the limit; one at a time does
     // not, and an answered one costs nothing even before it is reclaimed.
     let mut server =
         Http::with_config(HttpConfig::default().with_max_head_bytes(64).with_max_body_bytes(0));
-    server.listen(&Endpoint::Tcp(addr));
+    let addr = bound_addr(server.listen(&ephemeral()));
     let mut client = std::net::TcpStream::connect(addr).unwrap();
     client.set_nonblocking(true).unwrap();
     let request = padded_request("/first", 60);
@@ -1771,10 +1763,9 @@ fn padded_request(path: &str, size: usize) -> Vec<u8> {
 
 #[test]
 fn a_pending_request_survives_a_compaction() {
-    let addr = unused_addr();
     let mut server =
         Http::with_config(HttpConfig::default().with_max_head_bytes(256).with_max_body_bytes(0));
-    server.listen(&Endpoint::Tcp(addr));
+    let addr = bound_addr(server.listen(&ephemeral()));
     let mut client = std::net::TcpStream::connect(addr).unwrap();
     client.set_nonblocking(true).unwrap();
     let mut pipelined = Vec::new();
@@ -1966,11 +1957,10 @@ fn a_request_split_across_reads_is_delivered_once_complete() {
 
 #[test]
 fn a_pending_request_reports_work_and_holds_off_the_sweep() {
-    let addr = unused_addr();
     let mut server = Http::with_config(
         HttpConfig::default().with_idle_timeout(Duration::from_millis(200).into()),
     );
-    server.listen(&Endpoint::Tcp(addr));
+    let addr = bound_addr(server.listen(&ephemeral()));
     let mut client = std::net::TcpStream::connect(addr).unwrap();
     client.set_nonblocking(true).unwrap();
     client.write_all(b"GET /slow HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
@@ -2049,11 +2039,10 @@ fn work_is_reported_after_an_inline_answer_stops_the_pull() {
 
 #[test]
 fn a_blocking_drive_wakes_for_the_idle_sweep() {
-    let addr = unused_addr();
     let mut server = Http::with_config(
         HttpConfig::default().with_idle_timeout(Duration::from_millis(500).into()),
     );
-    server.listen(&Endpoint::Tcp(addr));
+    let addr = bound_addr(server.listen(&ephemeral()));
     let _client = std::net::TcpStream::connect(addr).unwrap();
     let deadline = Instant::now() + TIMEOUT;
     let mut accepted = false;
@@ -2080,9 +2069,8 @@ fn a_blocking_drive_wakes_for_the_idle_sweep() {
 
 #[test]
 fn a_blocking_drive_wakes_for_a_connection() {
-    let addr = unused_addr();
     let mut server = Http::with_config(HttpConfig::default().without_idle_timeout());
-    server.listen(&Endpoint::Tcp(addr));
+    let addr = bound_addr(server.listen(&ephemeral()));
 
     // Nothing is due, so an uncapped drive blocks until a client arrives. The
     // second connection is the test's own deadline: it wakes the poll even if
@@ -2182,10 +2170,8 @@ fn two_services_on_one_network_keep_their_own_events(mode: Mode) {
     let second_group = net.add_group(ConnectionGroupConfig { name: "second", ..http_group() });
     let mut first = HttpService::new(&mut net, first_group, HttpConfig::default());
     let mut second = HttpService::new(&mut net, second_group, HttpConfig::default());
-    let first_addr = unused_addr();
-    let second_addr = unused_addr();
-    first.listen(&mut net, Endpoint::Tcp(first_addr)).unwrap();
-    second.listen(&mut net, Endpoint::Tcp(second_addr)).unwrap();
+    let first_addr = bound_addr(first.listen(&mut net, ephemeral()).unwrap());
+    let second_addr = bound_addr(second.listen(&mut net, ephemeral()).unwrap());
 
     let mut to_first = std::net::TcpStream::connect(first_addr).unwrap();
     let mut to_second = std::net::TcpStream::connect(second_addr).unwrap();
@@ -2239,14 +2225,13 @@ fn close_returns_the_group_to_raw_use() {
     let other_group = net.add_group(http_group());
     let mut http = HttpService::new(&mut net, group, HttpConfig::default());
     let mut other = HttpService::new(&mut net, other_group, HttpConfig::default());
-    http.listen(&mut net, Endpoint::Tcp(unused_addr())).unwrap();
+    http.listen(&mut net, ephemeral()).unwrap();
     http.close(&mut net);
 
     // The remaining service alone passes validation.
     net.drive(Some(Duration::ZERO.into()), &mut [other.as_service()], |_| {});
 
-    let addr = unused_addr();
-    net.listen(group, Endpoint::Tcp(addr)).unwrap();
+    let addr = bound_addr(net.listen(group, ephemeral()).unwrap());
     let mut client = std::net::TcpStream::connect(addr).unwrap();
     client.write_all(b"raw bytes").unwrap();
     let mut raw = Vec::new();
@@ -2316,7 +2301,7 @@ fn dropping_a_service_and_its_network_together_is_harmless() {
     let mut net = StreamNetwork::default();
     let group = net.add_group(http_group());
     let mut http = HttpService::new(&mut net, group, HttpConfig::default());
-    http.listen(&mut net, Endpoint::Tcp(unused_addr())).unwrap();
+    http.listen(&mut net, ephemeral()).unwrap();
     net.drive(Some(Duration::ZERO.into()), &mut [http.as_service()], |_| {});
     drop(http);
     drop(net);

--- a/crates/flux-network/tests/linger.rs
+++ b/crates/flux-network/tests/linger.rs
@@ -28,12 +28,18 @@ const REJECTED: [(&[u8], u16); 4] = [
     (b"POST / HTTP/1.1\r\nContent-Length: 9\r\n\r\n", 413),
 ];
 
-/// A loopback address no listener holds.
-fn unused_addr() -> SocketAddr {
-    let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-    let addr = listener.local_addr().unwrap();
-    drop(listener);
-    addr
+/// A loopback endpoint whose port the kernel picks when the listener binds,
+/// so no address is handed out before something holds it.
+fn ephemeral() -> Endpoint {
+    Endpoint::Tcp((Ipv4Addr::LOCALHOST, 0).into())
+}
+
+/// The TCP address a listener bound, port included.
+fn bound_addr(bound: Endpoint) -> SocketAddr {
+    match bound {
+        Endpoint::Tcp(addr) => addr,
+        Endpoint::Unix(path) => panic!("a TCP listener bound {}", path.display()),
+    }
 }
 
 /// Runs one test body over both transports.
@@ -41,7 +47,7 @@ macro_rules! over_both_transports {
     ($body:ident, $tcp:ident, $unix:ident) => {
         #[test]
         fn $tcp() {
-            $body(&Endpoint::Tcp(unused_addr()));
+            $body(&ephemeral());
         }
 
         #[test]
@@ -109,6 +115,8 @@ struct Server {
     /// The body every request is answered with where it is delivered,
     /// leaving nothing for the test to answer by token.
     inline_answer: Option<Vec<u8>>,
+    /// The endpoint the listener bound, which is where a client dials.
+    endpoint: Endpoint,
 }
 
 impl Server {
@@ -116,7 +124,7 @@ impl Server {
         let mut net = StreamNetwork::default();
         let group = net.add_group(group);
         let mut service = HttpService::new(&mut net, group, config);
-        service.listen(&mut net, endpoint.clone()).unwrap();
+        let endpoint = service.listen(&mut net, endpoint.clone()).unwrap();
         Self {
             net,
             service,
@@ -125,6 +133,7 @@ impl Server {
             disconnected: Vec::new(),
             requests: Vec::new(),
             inline_answer: None,
+            endpoint,
         }
     }
 
@@ -248,6 +257,8 @@ over_both_transports!(
 fn an_error_response_reaches_a_peer_that_is_still_sending(endpoint: &Endpoint) {
     for (request, status) in REJECTED {
         let mut server = Server::new(endpoint, small_heads());
+        let bound = server.endpoint.clone();
+        let endpoint = &bound;
         let mut client = connect_client(endpoint);
         server.accepted_token();
         client.write_all(request).unwrap();
@@ -278,6 +289,8 @@ fn a_lingering_connection_ends_at_the_peers_close(endpoint: &Endpoint) {
     // Caps far longer than the test: only the peer's close can end this.
     let config = small_heads().with_linger(linger(TIMEOUT * 3, TIMEOUT * 6));
     let mut server = Server::new(endpoint, config);
+    let bound = server.endpoint.clone();
+    let endpoint = &bound;
     let mut client = connect_client(endpoint);
     let token = server.accepted_token();
     client.write_all(b"nope\r\n\r\n").unwrap();
@@ -299,8 +312,8 @@ fn a_lingering_connection_ends_at_the_peers_close(endpoint: &Endpoint) {
 fn a_lingering_connection_ends_at_the_idle_cap() {
     let idle = Duration::from_millis(150);
     let config = small_heads().with_linger(linger(idle, TIMEOUT * 3));
-    let endpoint = Endpoint::Tcp(unused_addr());
-    let mut server = Server::new(&endpoint, config);
+    let mut server = Server::new(&ephemeral(), config);
+    let endpoint = server.endpoint.clone();
     let mut client = connect_client(&endpoint);
     server.accepted_token();
 
@@ -319,8 +332,8 @@ fn a_lingering_connection_ends_at_the_total_cap() {
     let idle = Duration::from_millis(150);
     let total = Duration::from_millis(600);
     let config = small_heads().with_linger(linger(idle, total));
-    let endpoint = Endpoint::Tcp(unused_addr());
-    let mut server = Server::new(&endpoint, config);
+    let mut server = Server::new(&ephemeral(), config);
+    let endpoint = server.endpoint.clone();
     let mut client = connect_client(&endpoint);
     server.accepted_token();
 
@@ -347,8 +360,8 @@ fn a_lingering_connection_outlives_a_shorter_idle_timeout() {
     let config = small_heads()
         .with_idle_timeout(Duration::from_millis(50).into())
         .with_linger(linger(TIMEOUT * 3, total));
-    let endpoint = Endpoint::Tcp(unused_addr());
-    let mut server = Server::new(&endpoint, config);
+    let mut server = Server::new(&ephemeral(), config);
+    let endpoint = server.endpoint.clone();
     let mut client = connect_client(&endpoint);
     server.accepted_token();
 
@@ -374,6 +387,8 @@ fn a_lingering_connection_holds_its_place(endpoint: &Endpoint) {
     let config = small_heads().with_linger(linger(TIMEOUT * 3, TIMEOUT * 6));
     let group = ConnectionGroupConfig { max_connections: Some(1), ..raw_group() };
     let mut server = Server::build(endpoint, group, config);
+    let bound = server.endpoint.clone();
+    let endpoint = &bound;
     let mut client = connect_client(endpoint);
     let token = server.accepted_token();
     client.write_all(b"nope\r\n\r\n").unwrap();
@@ -405,6 +420,8 @@ fn an_over_limit_pending_request_is_answered_before_the_linger(endpoint: &Endpoi
         .with_max_body_bytes(64)
         .with_linger(linger(TIMEOUT * 3, TIMEOUT * 6));
     let mut server = Server::new(endpoint, config);
+    let bound = server.endpoint.clone();
+    let endpoint = &bound;
     let mut client = connect_client(endpoint);
     let token = server.accepted_token();
     client.write_all(b"GET /slow HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
@@ -440,6 +457,8 @@ fn a_completed_request_answered_with_close_drains(endpoint: &Endpoint) {
     // still be open when the assertion runs.
     let config = HttpConfig::default().with_linger(linger(TIMEOUT * 3, TIMEOUT * 6));
     let mut server = Server::new(endpoint, config);
+    let bound = server.endpoint.clone();
+    let endpoint = &bound;
     let mut client = connect_client(endpoint);
     let token = server.accepted_token();
     client.write_all(b"GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n").unwrap();
@@ -460,6 +479,8 @@ over_both_transports!(
 fn an_http_1_0_request_is_answered_and_closed(endpoint: &Endpoint) {
     let config = HttpConfig::default().with_linger(linger(TIMEOUT * 3, TIMEOUT * 6));
     let mut server = Server::new(endpoint, config);
+    let bound = server.endpoint.clone();
+    let endpoint = &bound;
     let mut client = connect_client(endpoint);
     let token = server.accepted_token();
     client.write_all(b"GET / HTTP/1.0\r\nHost: x\r\n\r\n").unwrap();
@@ -479,6 +500,8 @@ over_both_transports!(
 );
 fn without_linger_an_error_response_closes(endpoint: &Endpoint) {
     let mut server = Server::new(endpoint, small_heads().without_linger());
+    let bound = server.endpoint.clone();
+    let endpoint = &bound;
     let mut client = connect_client(endpoint);
     let token = server.accepted_token();
     client.write_all(b"nope\r\n\r\n").unwrap();
@@ -496,8 +519,8 @@ fn the_caps_wait_for_the_answer_to_reach_the_peer() {
         .with_max_head_bytes(64)
         .with_max_body_bytes(64)
         .with_linger(linger(idle, TIMEOUT * 3));
-    let endpoint = Endpoint::Tcp(unused_addr());
-    let mut server = Server::build(&endpoint, group, config);
+    let mut server = Server::build(&ephemeral(), group, config);
+    let endpoint = server.endpoint.clone();
     let mut client = connect_client(&endpoint);
     let token = server.accepted_token();
     client.write_all(b"GET /slow HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
@@ -558,8 +581,8 @@ fn over_the_limit_at_a_request_boundary(inline: bool, after_a_tick: bool) -> Str
         .with_max_head_bytes(64)
         .with_max_body_bytes(64)
         .with_linger(linger(TIMEOUT * 3, TIMEOUT * 6));
-    let endpoint = Endpoint::Tcp(unused_addr());
-    let mut server = Server::new(&endpoint, config);
+    let mut server = Server::new(&ephemeral(), config);
+    let endpoint = server.endpoint.clone();
     if inline {
         server.inline_answer = Some(b"ok".to_vec());
     }
@@ -600,9 +623,9 @@ fn an_over_limit_request_boundary_is_answered() {
 fn a_blocking_drive_wakes_for_the_idle_cap() {
     let idle = Duration::from_millis(500);
     let config = small_heads().without_idle_timeout().with_linger(linger(idle, TIMEOUT * 3));
-    let addr = unused_addr();
-    let endpoint = Endpoint::Tcp(addr);
-    let mut server = Server::new(&endpoint, config);
+    let mut server = Server::new(&ephemeral(), config);
+    let endpoint = server.endpoint.clone();
+    let addr = bound_addr(endpoint.clone());
     let mut client = connect_client(&endpoint);
     server.accepted_token();
     client.write_all(b"nope\r\n\r\n").unwrap();
@@ -639,6 +662,8 @@ fn an_undelivered_answer_is_swept(endpoint: &Endpoint) {
         .with_idle_timeout(timeout.into())
         .with_linger(linger(Duration::from_secs(5), Duration::from_secs(30)));
     let mut server = Server::build(endpoint, group, config);
+    let bound = server.endpoint.clone();
+    let endpoint = &bound;
     let mut client = connect_client(endpoint);
     let token = server.accepted_token();
     client.write_all(b"GET /slow HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
@@ -669,14 +694,13 @@ fn an_undelivered_answer_is_swept(endpoint: &Endpoint) {
 fn the_caps_start_when_the_answer_has_left() {
     let idle = Duration::from_millis(200);
     let answer = vec![7; 256 * 1024];
-    let addr = unused_addr();
-    let endpoint = Endpoint::Tcp(addr);
     let group = ConnectionGroupConfig { socket_buf_size: Some(16 * 1024), ..raw_group() };
     let config = HttpConfig::default()
         .with_max_head_bytes(64)
         .with_max_body_bytes(64)
         .with_linger(linger(idle, TIMEOUT * 3));
-    let mut server = Server::build(&endpoint, group, config);
+    let mut server = Server::build(&ephemeral(), group, config);
+    let addr = bound_addr(server.endpoint.clone());
 
     // The peer sends more than the connection may hold and then reads nothing
     // for half a second. The answer is larger than the sockets between them

--- a/crates/flux-network/tests/request_failure.rs
+++ b/crates/flux-network/tests/request_failure.rs
@@ -3,7 +3,7 @@
 
 use std::{
     io::{self, Read, Write},
-    net::{Ipv4Addr, SocketAddr},
+    net::Ipv4Addr,
     os::unix::net::UnixListener,
     thread,
     time::{Duration, Instant},
@@ -17,12 +17,10 @@ use flux_network::{
 
 const TIMEOUT: Duration = Duration::from_secs(10);
 
-/// A loopback address no listener holds.
-fn unused_addr() -> SocketAddr {
-    let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-    let addr = listener.local_addr().unwrap();
-    drop(listener);
-    addr
+/// A loopback endpoint whose port the kernel picks when the listener binds,
+/// so no address is handed out before something holds it.
+fn ephemeral() -> Endpoint {
+    Endpoint::Tcp((Ipv4Addr::LOCALHOST, 0).into())
 }
 
 /// Runs one test body over both transports.
@@ -30,7 +28,7 @@ macro_rules! over_both_transports {
     ($body:ident, $tcp:ident, $unix:ident) => {
         #[test]
         fn $tcp() {
-            $body(&Endpoint::Tcp(unused_addr()));
+            $body(&ephemeral());
         }
 
         #[test]
@@ -58,6 +56,8 @@ impl<T: Read + Write> PeerStream for T {}
 struct Peer {
     listener: Listener,
     stream: Option<Box<dyn PeerStream>>,
+    /// The endpoint the listener bound, which is where the service dials.
+    endpoint: Endpoint,
 }
 
 enum Listener {
@@ -67,19 +67,20 @@ enum Listener {
 
 impl Peer {
     fn bind(endpoint: &Endpoint) -> Self {
-        let listener = match endpoint {
+        let (listener, endpoint) = match endpoint {
             Endpoint::Tcp(addr) => {
                 let listener = std::net::TcpListener::bind(addr).unwrap();
                 listener.set_nonblocking(true).unwrap();
-                Listener::Tcp(listener)
+                let bound = Endpoint::Tcp(listener.local_addr().unwrap());
+                (Listener::Tcp(listener), bound)
             }
             Endpoint::Unix(path) => {
                 let listener = UnixListener::bind(path).unwrap();
                 listener.set_nonblocking(true).unwrap();
-                Listener::Unix(listener)
+                (Listener::Unix(listener), Endpoint::Unix(path.clone()))
             }
         };
-        Self { listener, stream: None }
+        Self { listener, stream: None, endpoint }
     }
 
     /// Takes the connection waiting to be accepted, if there is one.
@@ -226,7 +227,7 @@ fn an_unanswered_request_times_out(endpoint: &Endpoint) {
     };
     let config = HttpConfig::default().with_request_timeout(Duration::from_millis(100).into());
     let mut peer = Peer::bind(endpoint);
-    let mut client = Client::build(endpoint, group, config);
+    let mut client = Client::build(&peer.endpoint, group, config);
     connect_and_request(&mut client, &mut peer);
 
     // The failure comes first, the close it causes second, and the endpoint
@@ -254,7 +255,7 @@ fn an_answer_within_the_deadline_clears_it(endpoint: &Endpoint) {
     let timeout = Duration::from_millis(100);
     let config = HttpConfig::default().with_request_timeout(timeout.into());
     let mut peer = Peer::bind(endpoint);
-    let mut client = Client::new(endpoint, config);
+    let mut client = Client::new(&peer.endpoint, config);
     connect_and_request(&mut client, &mut peer);
     peer.answer(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok");
 
@@ -274,12 +275,11 @@ fn an_answer_within_the_deadline_clears_it(endpoint: &Endpoint) {
 fn the_deadline_runs_from_the_queued_request() {
     // A peer that never reads leaves the request queued behind a full socket,
     // so a clock started when the last byte left would never run at all.
-    let endpoint = Endpoint::Tcp(unused_addr());
     let group = ConnectionGroupConfig { socket_buf_size: Some(4096), ..raw_group() };
     let timeout = Duration::from_millis(150);
     let config = HttpConfig::default().with_request_timeout(timeout.into());
-    let mut peer = Peer::bind(&endpoint);
-    let mut client = Client::build(&endpoint, group, config);
+    let mut peer = Peer::bind(&ephemeral());
+    let mut client = Client::build(&peer.endpoint, group, config);
     run_until(
         &mut client,
         &mut peer,
@@ -308,7 +308,7 @@ fn assert_failure(
     reason: RequestFailure,
 ) {
     let mut peer = Peer::bind(endpoint);
-    let mut client = Client::new(endpoint, config);
+    let mut client = Client::new(&peer.endpoint, config);
     connect_and_request(&mut client, &mut peer);
     peer.answer(answer);
     if close {
@@ -379,7 +379,7 @@ over_both_transports!(
 fn an_endpoint_that_drops_with_nothing_in_flight_fails_nothing(endpoint: &Endpoint) {
     let config = HttpConfig::default().with_request_timeout(Duration::from_millis(100).into());
     let mut peer = Peer::bind(endpoint);
-    let mut client = Client::new(endpoint, config);
+    let mut client = Client::new(&peer.endpoint, config);
     run_until(
         &mut client,
         &mut peer,
@@ -409,7 +409,7 @@ fn an_answer_whose_head_is_over_the_cap_is_too_large() {
     answer.extend_from_slice(&[b'v'; 100]);
     answer.extend_from_slice(b"\r\nContent-Length: 0\r\n\r\n");
     assert_failure(
-        &Endpoint::Tcp(unused_addr()),
+        &ephemeral(),
         HttpConfig::default().with_max_head_bytes(64),
         &answer,
         false,
@@ -420,7 +420,7 @@ fn an_answer_whose_head_is_over_the_cap_is_too_large() {
 #[test]
 fn a_chunked_answer_over_the_cap_is_too_large() {
     assert_failure(
-        &Endpoint::Tcp(unused_addr()),
+        &ephemeral(),
         HttpConfig::default().with_max_body_bytes(8),
         b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n20\r\n\
           xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\r\n0\r\n\r\n",
@@ -434,7 +434,7 @@ fn an_answer_the_close_delimits_over_the_cap_is_too_large() {
     let mut answer = b"HTTP/1.1 200 OK\r\n\r\n".to_vec();
     answer.extend_from_slice(&[b'x'; 64]);
     assert_failure(
-        &Endpoint::Tcp(unused_addr()),
+        &ephemeral(),
         HttpConfig::default().with_max_body_bytes(8),
         &answer,
         true,
@@ -445,7 +445,7 @@ fn an_answer_the_close_delimits_over_the_cap_is_too_large() {
 #[test]
 fn a_chunk_the_service_cannot_size_is_malformed() {
     assert_failure(
-        &Endpoint::Tcp(unused_addr()),
+        &ephemeral(),
         HttpConfig::default(),
         b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\nzz\r\nxx\r\n0\r\n\r\n",
         false,
@@ -461,7 +461,7 @@ fn an_answer_with_more_headers_than_the_parse_holds_is_malformed() {
     }
     answer.extend_from_slice(b"Content-Length: 0\r\n\r\n");
     assert_failure(
-        &Endpoint::Tcp(unused_addr()),
+        &ephemeral(),
         HttpConfig::default().with_max_headers(8),
         &answer,
         false,
@@ -472,7 +472,7 @@ fn an_answer_with_more_headers_than_the_parse_holds_is_malformed() {
 #[test]
 fn an_answer_framed_twice_over_is_malformed() {
     assert_failure(
-        &Endpoint::Tcp(unused_addr()),
+        &ephemeral(),
         HttpConfig::default(),
         b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n",
         false,
@@ -482,8 +482,8 @@ fn an_answer_framed_twice_over_is_malformed() {
 
 #[test]
 fn a_blocking_drive_wakes_for_a_request_deadline() {
-    let addr = unused_addr();
-    let listener = std::net::TcpListener::bind(addr).unwrap();
+    let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let addr = listener.local_addr().unwrap();
     // The peer accepts, answers nothing, and sends one byte three seconds
     // later. That byte is the test's own deadline: a drive that ignored the
     // request deadline wakes on it, well past the bound below, rather than
@@ -526,7 +526,7 @@ fn an_answer_whose_open_head_is_over_the_cap_is_too_large() {
     answer.extend_from_slice(&[b'v'; 100]);
     answer.extend_from_slice(b"\r\n");
     assert_failure(
-        &Endpoint::Tcp(unused_addr()),
+        &ephemeral(),
         HttpConfig::default().with_max_head_bytes(64),
         &answer,
         false,

--- a/crates/flux-network/tests/status_line.rs
+++ b/crates/flux-network/tests/status_line.rs
@@ -16,12 +16,18 @@ use flux_network::{
 
 const TIMEOUT: Duration = Duration::from_secs(10);
 
-/// A loopback address no listener holds.
-fn unused_addr() -> SocketAddr {
-    let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-    let addr = listener.local_addr().unwrap();
-    drop(listener);
-    addr
+/// A loopback endpoint whose port the kernel picks when the listener binds,
+/// so no address is handed out before something holds it.
+fn ephemeral() -> Endpoint {
+    Endpoint::Tcp((Ipv4Addr::LOCALHOST, 0).into())
+}
+
+/// The TCP address a listener bound, port included.
+fn bound_addr(bound: Endpoint) -> SocketAddr {
+    match bound {
+        Endpoint::Tcp(addr) => addr,
+        Endpoint::Unix(path) => panic!("a TCP listener bound {}", path.display()),
+    }
 }
 
 /// A listening HTTP service, and the requests it has yet to answer.
@@ -34,7 +40,6 @@ struct Server {
 impl Server {
     /// A server on a fresh address, and a client connected to it.
     fn start() -> (Self, TcpStream) {
-        let addr = unused_addr();
         let mut net = StreamNetwork::default();
         let group = net.add_group(ConnectionGroupConfig {
             name: "status",
@@ -42,7 +47,7 @@ impl Server {
             ..ConnectionGroupConfig::default()
         });
         let mut service = HttpService::new(&mut net, group, HttpConfig::default());
-        service.listen(&mut net, Endpoint::Tcp(addr)).unwrap();
+        let addr = bound_addr(service.listen(&mut net, ephemeral()).unwrap());
         let client = TcpStream::connect(addr).unwrap();
         client.set_nonblocking(true).unwrap();
         (Self { net, service, requests: Vec::new() }, client)

--- a/crates/flux-network/tests/stream_network.rs
+++ b/crates/flux-network/tests/stream_network.rs
@@ -17,21 +17,28 @@ const REQUEST: &[u8] = b"request-payload";
 const RESPONSE: &[u8] = b"response-payload";
 const BATCH_MESSAGES: [&[u8]; 3] = [b"batch-one", b"batch-two", b"batch-three"];
 
-fn unused_addr() -> SocketAddr {
-    let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-    let addr = listener.local_addr().unwrap();
-    drop(listener);
-    addr
+/// A loopback endpoint whose port the kernel picks when the listener binds,
+/// so no address is handed out before something holds it.
+fn ephemeral() -> Endpoint {
+    Endpoint::Tcp((Ipv4Addr::LOCALHOST, 0).into())
 }
 
-/// Runs one test body over both transports: a loopback TCP address on an
-/// ephemeral port, and a Unix-domain socket path under a temporary directory
-/// that lives for the duration of the run.
+/// The TCP address a listener bound, port included.
+fn bound_addr(bound: Endpoint) -> SocketAddr {
+    match bound {
+        Endpoint::Tcp(addr) => addr,
+        Endpoint::Unix(path) => panic!("a TCP listener bound {}", path.display()),
+    }
+}
+
+/// Runs one test body over both transports: a loopback address whose port the
+/// listener's own bind decides, and a Unix-domain socket path under a
+/// temporary directory that lives for the duration of the run.
 macro_rules! over_both_transports {
     ($body:ident, $tcp:ident, $unix:ident) => {
         #[test]
         fn $tcp() {
-            $body(&Endpoint::Tcp(unused_addr()));
+            $body(&ephemeral());
         }
 
         #[test]
@@ -99,7 +106,9 @@ fn groups_route_events_and_messages(endpoint: &Endpoint) {
         reconnect_interval: flux_timing::Duration::from_millis(1),
         ..ConnectionGroupConfig::default()
     });
-    network.listen(server_group, endpoint.clone()).unwrap();
+    let bound = network.listen(server_group, endpoint.clone()).unwrap();
+    // A TCP listener on port 0 binds a port of the kernel's choosing.
+    let endpoint = &bound;
     let client_token = network.connect(client_group, endpoint.clone());
 
     let mut server_token = None;
@@ -386,7 +395,9 @@ over_both_transports!(
 fn partial_header_and_payload_are_not_delivered_early(endpoint: &Endpoint) {
     let mut network = StreamNetwork::default();
     let group = network.add_group(ConnectionGroupConfig { name: "server", ..Default::default() });
-    network.listen(group, endpoint.clone()).unwrap();
+    let bound = network.listen(group, endpoint.clone()).unwrap();
+    // A TCP listener on port 0 binds a port of the kernel's choosing.
+    let endpoint = &bound;
 
     let mut peer = raw_peer(endpoint);
     let token = wait_for_accept(&mut network, group);
@@ -432,7 +443,9 @@ fn oversized_frame_disconnects_the_peer(endpoint: &Endpoint) {
         max_frame_size: 32,
         ..Default::default()
     });
-    network.listen(group, endpoint.clone()).unwrap();
+    let bound = network.listen(group, endpoint.clone()).unwrap();
+    // A TCP listener on port 0 binds a port of the kernel's choosing.
+    let endpoint = &bound;
 
     let mut peer = raw_peer(endpoint);
     let token = wait_for_accept(&mut network, group);
@@ -461,7 +474,6 @@ fn oversized_frame_disconnects_the_peer(endpoint: &Endpoint) {
 /// arranges through `SO_SNDBUF` on a TCP socket.
 #[test]
 fn hard_backlog_limit_disconnects_the_peer() {
-    let addr = unused_addr();
     let mut network = StreamNetwork::default();
     let server_group =
         network.add_group(ConnectionGroupConfig { name: "server", ..Default::default() });
@@ -473,7 +485,7 @@ fn hard_backlog_limit_disconnects_the_peer() {
         max_frame_size: 2 * 1024 * 1024,
         ..Default::default()
     });
-    network.listen(server_group, Endpoint::Tcp(addr)).unwrap();
+    let addr = bound_addr(network.listen(server_group, ephemeral()).unwrap());
     let client_token = network.connect(client_group, Endpoint::Tcp(addr));
 
     let mut connected = false;
@@ -518,7 +530,9 @@ fn broadcast_serializes_once_for_multiple_connections(endpoint: &Endpoint) {
         reconnect_interval: flux_timing::Duration::from_millis(1),
         ..Default::default()
     });
-    network.listen(server_group, endpoint.clone()).unwrap();
+    let bound = network.listen(server_group, endpoint.clone()).unwrap();
+    // A TCP listener on port 0 binds a port of the kernel's choosing.
+    let endpoint = &bound;
     let _first_client = network.connect(client_group, endpoint.clone());
     let _second_client = network.connect(client_group, endpoint.clone());
 
@@ -580,7 +594,9 @@ fn disconnected_messages_are_dropped_and_token_survives_reconnect(endpoint: &End
         reconnect_interval: flux_timing::Duration::from_millis(1),
         ..Default::default()
     });
-    network.listen(server_group, endpoint.clone()).unwrap();
+    let bound = network.listen(server_group, endpoint.clone()).unwrap();
+    // A TCP listener on port 0 binds a port of the kernel's choosing.
+    let endpoint = &bound;
     let client_token = network.connect(client_group, endpoint.clone());
 
     let mut server_token = None;
@@ -662,14 +678,13 @@ fn disconnected_messages_are_dropped_and_token_survives_reconnect(endpoint: &End
 /// TCP only: `TcpConnector` speaks TCP alone.
 #[test]
 fn stream_network_is_wire_compatible_with_tcp_connector() {
-    let addr = unused_addr();
     let mut network = StreamNetwork::default();
     let server_group = network.add_group(ConnectionGroupConfig {
         name: "network-server",
         on_connect_msg: Some(SERVER_HELLO.to_vec()),
         ..Default::default()
     });
-    network.listen(server_group, Endpoint::Tcp(addr)).unwrap();
+    let addr = bound_addr(network.listen(server_group, ephemeral()).unwrap());
 
     let mut connector = TcpConnector::default();
     let connector_token = connector.connect(addr).expect("connector failed to connect");
@@ -714,10 +729,20 @@ fn stream_network_is_wire_compatible_with_tcp_connector() {
     assert!(contains(&connector_messages, RESPONSE));
 }
 
+/// A loopback address for the one listener this file cannot bind through the
+/// network: `TcpConnector::listen_at` takes an address and reports none back,
+/// so the port is chosen here and bound a moment later.
+fn probed_addr() -> SocketAddr {
+    let probe = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let addr = probe.local_addr().unwrap();
+    drop(probe);
+    addr
+}
+
 /// TCP only: `TcpConnector` speaks TCP alone.
 #[test]
 fn stream_network_client_is_wire_compatible_with_tcp_connector_server() {
-    let addr = unused_addr();
+    let addr = probed_addr();
     let mut connector = TcpConnector::default().with_on_connect_msg(SERVER_HELLO.to_vec());
     connector.listen_at(addr).expect("connector failed to listen");
 
@@ -804,7 +829,9 @@ fn accepted_peer_identifies_the_transport(endpoint: &Endpoint) {
         reconnect_interval: flux_timing::Duration::from_millis(1),
         ..Default::default()
     });
-    network.listen(server_group, endpoint.clone()).unwrap();
+    let bound = network.listen(server_group, endpoint.clone()).unwrap();
+    // A TCP listener on port 0 binds a port of the kernel's choosing.
+    let endpoint = &bound;
     let client_token = network.connect(client_group, endpoint.clone());
 
     let mut accepted = None;

--- a/crates/flux-network/tests/stream_network_raw.rs
+++ b/crates/flux-network/tests/stream_network_raw.rs
@@ -9,11 +9,18 @@ use flux_network::stream::{ConnectionGroupConfig, Endpoint, Framing, StreamEvent
 
 const TIMEOUT: Duration = Duration::from_secs(5);
 
-fn unused_addr() -> SocketAddr {
-    let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-    let addr = listener.local_addr().unwrap();
-    drop(listener);
-    addr
+/// A loopback endpoint whose port the kernel picks when the listener binds,
+/// so no address is handed out before something holds it.
+fn ephemeral() -> Endpoint {
+    Endpoint::Tcp((Ipv4Addr::LOCALHOST, 0).into())
+}
+
+/// The TCP address a listener bound, port included.
+fn bound_addr(bound: Endpoint) -> SocketAddr {
+    match bound {
+        Endpoint::Tcp(addr) => addr,
+        Endpoint::Unix(path) => panic!("a TCP listener bound {}", path.display()),
+    }
 }
 
 fn raw_group(name: &'static str) -> ConnectionGroupConfig {
@@ -23,10 +30,9 @@ fn raw_group(name: &'static str) -> ConnectionGroupConfig {
 #[test]
 fn raw_roundtrip() {
     let request = b"raw request bytes";
-    let addr = unused_addr();
     let mut network = StreamNetwork::default();
     let group = network.add_group(raw_group("raw-server"));
-    network.listen(group, Endpoint::Tcp(addr)).unwrap();
+    let addr = bound_addr(network.listen(group, ephemeral()).unwrap());
 
     let mut client = std::net::TcpStream::connect(addr).unwrap();
     client.set_nonblocking(true).unwrap();
@@ -107,10 +113,9 @@ fn raw_batch_concatenates_payloads() {
 fn http_get_smoke() {
     let request = b"GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
     let response = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok";
-    let addr = unused_addr();
     let mut network = StreamNetwork::default();
     let group = network.add_group(raw_group("http"));
-    network.listen(group, Endpoint::Tcp(addr)).unwrap();
+    let addr = bound_addr(network.listen(group, ephemeral()).unwrap());
 
     let mut client = std::net::TcpStream::connect(addr).unwrap();
     client.set_nonblocking(true).unwrap();
@@ -222,14 +227,12 @@ fn raw_outbound_connect() {
 
 #[test]
 fn framed_and_raw_coexist() {
-    let framed_addr = unused_addr();
-    let raw_addr = unused_addr();
     let mut server = StreamNetwork::default();
     let framed_server =
         server.add_group(ConnectionGroupConfig { name: "framed-server", ..Default::default() });
     let raw_server = server.add_group(raw_group("raw-server"));
-    server.listen(framed_server, Endpoint::Tcp(framed_addr)).unwrap();
-    server.listen(raw_server, Endpoint::Tcp(raw_addr)).unwrap();
+    let framed_addr = bound_addr(server.listen(framed_server, ephemeral()).unwrap());
+    let raw_addr = bound_addr(server.listen(raw_server, ephemeral()).unwrap());
 
     let mut framed_client = StreamNetwork::default();
     let framed_client_group = framed_client.add_group(ConnectionGroupConfig {
@@ -300,7 +303,6 @@ fn framed_and_raw_coexist() {
 
 #[test]
 fn raw_disconnect_when_drained_flushes_queue() {
-    let addr = unused_addr();
     let payload = vec![0xA5; 8 * 1024 * 1024];
     let mut network = StreamNetwork::default();
     let group = network.add_group(ConnectionGroupConfig {
@@ -310,7 +312,7 @@ fn raw_disconnect_when_drained_flushes_queue() {
         max_frame_size: payload.len(),
         ..ConnectionGroupConfig::default()
     });
-    network.listen(group, Endpoint::Tcp(addr)).unwrap();
+    let addr = bound_addr(network.listen(group, ephemeral()).unwrap());
 
     let mut client = std::net::TcpStream::connect(addr).unwrap();
     client.set_nonblocking(true).unwrap();

--- a/crates/flux-network/tests/stream_network_telemetry.rs
+++ b/crates/flux-network/tests/stream_network_telemetry.rs
@@ -13,11 +13,18 @@ use mio::Token;
 
 const APP_NAME: &str = "tcp-network-telemetry-reconnect-test";
 
-fn unused_addr() -> SocketAddr {
-    let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-    let addr = listener.local_addr().unwrap();
-    drop(listener);
-    addr
+/// A loopback endpoint whose port the kernel picks when the listener binds,
+/// so no address is handed out before something holds it.
+fn ephemeral() -> Endpoint {
+    Endpoint::Tcp((Ipv4Addr::LOCALHOST, 0).into())
+}
+
+/// The TCP address a listener bound, port included.
+fn bound_addr(bound: Endpoint) -> SocketAddr {
+    match bound {
+        Endpoint::Tcp(addr) => addr,
+        Endpoint::Unix(path) => panic!("a TCP listener bound {}", path.display()),
+    }
 }
 
 fn process_mapping_count() -> usize {
@@ -55,7 +62,6 @@ fn outbound_endpoint_reuses_telemetry_mappings_across_reconnects() {
     let shmem = shmem_dir(APP_NAME);
     cleanup_shmem(&shmem);
 
-    let addr = unused_addr();
     let mut network = StreamNetwork::default();
     let server_group =
         network.add_group(ConnectionGroupConfig { name: "server", ..Default::default() });
@@ -65,7 +71,7 @@ fn outbound_endpoint_reuses_telemetry_mappings_across_reconnects() {
         telemetry: TcpTelemetry::Enabled { app_name: APP_NAME },
         ..Default::default()
     });
-    network.listen(server_group, Endpoint::Tcp(addr)).unwrap();
+    let addr = bound_addr(network.listen(server_group, ephemeral()).unwrap());
     let client_token = network.connect(client_group, Endpoint::Tcp(addr));
 
     let mut server_token =

--- a/crates/flux-network/tests/zero_alloc.rs
+++ b/crates/flux-network/tests/zero_alloc.rs
@@ -112,9 +112,6 @@ impl Harness {
     /// A service listening for `client` and connected to `upstream`, with both
     /// connections established.
     fn build(deadline: Instant) -> Self {
-        let probe = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-        let serve_addr = probe.local_addr().unwrap();
-        drop(probe);
         let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
         let upstream_addr = listener.local_addr().unwrap();
         listener.set_nonblocking(true).unwrap();
@@ -128,7 +125,8 @@ impl Harness {
             ..ConnectionGroupConfig::default()
         });
         let mut service = HttpService::new(&mut net, group, HttpConfig::default());
-        service.listen(&mut net, Endpoint::Tcp(serve_addr)).unwrap();
+        let serving = service.listen(&mut net, Endpoint::Tcp((Ipv4Addr::LOCALHOST, 0).into()));
+        let Endpoint::Tcp(serve_addr) = serving.unwrap() else { unreachable!("a TCP listener") };
         let upstream_token = service.connect(&mut net, Endpoint::Tcp(upstream_addr));
 
         let client = TcpStream::connect(serve_addr).unwrap();


### PR DESCRIPTION
This PR builds on #144. `listen` now reports the endpoint it bound, tests bind ephemeral ports without a probe-then-bind race, and slice response bodies go directly to the framing path without first passing through the service's composition scratch.

## Bound endpoints

`StreamNetwork::listen(group, endpoint)` and `HttpService::listen(&mut net, endpoint)` return `io::Result<Endpoint>` instead of `io::Result<()>`. The result matches the requested endpoint except when TCP port 0 is used, in which case it contains the port selected by the kernel; a Unix listener returns its path. A caller binding a fixed endpoint may ignore the value, while one requesting port 0 can publish an address that the listener already holds.

## Response framing

`respond(status, headers, body)` passes the caller's slice directly to the framing path, while `respond_with` renders into the reusable service-owned buffer. Both use one framing implementation and copy the body into the send queue once. Admission requires a pending request, a status in `100..=599`, and headers the service does not reserve; it is checked before composition, so a refused answer does not run the body closure. A `HEAD` request still uses the composed body length for `Content-Length` while sending none of the body.

## Tests bind ephemeral ports

The integration suites and in-module harness now bind TCP port 0 and dial the endpoint returned by `listen`, so an address is not published until its listener holds it. The old helper released a probe before the real bind and, while avoiding reuse, could temporarily occupy a port already handed to another test thread; the victim then failed with `AddrInUse`.

## Verification

Tests cover a composed response followed by a slice response, preventing stale scratch contents from leaking, and pin refusal before body composition on both response paths. Workspace tests, Clippy with warnings denied, the nightly formatting check, and `cargo doc` pass without new warnings.

## Scope

The only API change is the return type of the two `listen` methods. The version bump that lists this and the stack's other breaking changes follows as the last PR.

Base: #144. Next: the 0.2.0 bump.

Refer: #143

Assisted-by: Claude Code:claude-fable-5
Assisted-by: Codex:gpt-5
