### PR TITLE
feat(network): add batched TCP sends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,7 +585,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flux"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "bitcode",
  "core_affinity",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "flux-communication"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "directories",
  "flux-timing",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "flux-ctl"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "clap",
  "crossterm",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "flux-disk"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "flux-timing",
  "flux-utils",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "flux-network"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "flux",
  "flux-communication",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "flux-profiler"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "bytesize",
  "clap",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "flux-profiler-macros"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "flux-timekeeper"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "auto_impl",
  "bitflags 2.10.0",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "flux-timing"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "bitcode",
  "chrono",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "flux-utils"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "core_affinity",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "flux-versioned-types"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "flux",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "flux-versioned-types-macros"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1791,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "spine-derive"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2034,11 +2034,11 @@ dependencies = [
 
 [[package]]
 name = "type-hash"
-version = "0.1.3"
+version = "0.2.0"
 
 [[package]]
 name = "type-hash-derive"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ license = "Apache-2.0 AND MIT"
 publish = false
 repository = "https://github.com/gattaca-com/flux"
 rust-version = "1.91.0"
-version = "0.1.3"
+version = "0.2.0"
 
 
 [workspace.dependencies]

--- a/crates/flux-network/src/tcp/mod.rs
+++ b/crates/flux-network/src/tcp/mod.rs
@@ -3,6 +3,6 @@ mod network;
 mod stream;
 
 pub use connector::{PollEvent, SendBehavior, TcpConnector};
-pub use network::{Framing, TcpEvent, TcpGroup, TcpGroupConfig, TcpNetwork};
+pub use network::{Framing, PayloadBuf, TcpEvent, TcpGroup, TcpGroupConfig, TcpNetwork};
 pub(crate) use stream::set_socket_buf_size;
 pub use stream::{ConnState, TcpStream, TcpTelemetry};

--- a/crates/flux-network/src/tcp/network.rs
+++ b/crates/flux-network/src/tcp/network.rs
@@ -1,6 +1,7 @@
 use std::{
     io::{self, IoSlice, Read, Write},
     net::{Shutdown, SocketAddr},
+    ops::{Deref, DerefMut},
 };
 
 use flux_communication::Timer;
@@ -11,8 +12,8 @@ use tracing::{debug, error, info, warn};
 use super::{
     TcpTelemetry, set_socket_buf_size,
     stream::{
-        DEFAULT_TCP_USER_TIMEOUT_MS, FRAME_HEADER_SIZE, set_keepalive, set_user_timeout,
-        write_frame_header,
+        DEFAULT_TCP_USER_TIMEOUT_MS, FRAME_HEADER_SIZE, frame_payload_len, set_keepalive,
+        set_user_timeout, write_frame_header, write_frame_len, write_frame_ts,
     },
 };
 
@@ -40,6 +41,155 @@ pub enum Framing {
     /// Bytes pass through untouched. Received chunks do not preserve message
     /// boundaries, and their event timestamp is the local receive time.
     Raw,
+}
+
+/// The payload of one outgoing frame while a serialiser fills it.
+///
+/// Frames are staged back to back in one send buffer, so a serialiser must
+/// not be able to reach the bytes of frames staged before its own. This
+/// wrapper exposes only the payload region: every length, index, and
+/// truncation is relative to the start of the payload, and the frame header
+/// and earlier frames stay out of reach.
+pub struct PayloadBuf<'a> {
+    bytes: &'a mut Vec<u8>,
+    start: usize,
+}
+
+impl<'a> PayloadBuf<'a> {
+    fn new(bytes: &'a mut Vec<u8>) -> Self {
+        let start = bytes.len();
+        Self { bytes, start }
+    }
+
+    /// Bytes serialised into this payload so far.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.bytes.len() - self.start
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Reserves room for at least `additional` more payload bytes.
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.bytes.reserve(additional);
+    }
+
+    #[inline]
+    pub fn push(&mut self, byte: u8) {
+        self.bytes.push(byte);
+    }
+
+    #[inline]
+    pub fn extend_from_slice(&mut self, other: &[u8]) {
+        self.bytes.extend_from_slice(other);
+    }
+
+    /// Resizes the payload to `len` bytes, filling new bytes with `value`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the payload cannot fit in memory, as `Vec::resize` does.
+    #[inline]
+    pub fn resize(&mut self, len: usize, value: u8) {
+        let end = self.start.checked_add(len).expect("payload length overflows usize");
+        self.bytes.resize(end, value);
+    }
+
+    /// Shortens the payload to `len` bytes; no-op if already shorter.
+    #[inline]
+    pub fn truncate(&mut self, len: usize) {
+        // Clamping keeps `start + len` from wrapping into earlier frames.
+        let len = len.min(self.len());
+        self.bytes.truncate(self.start + len);
+    }
+
+    /// Removes every payload byte serialised so far.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.bytes.truncate(self.start);
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &[u8] {
+        &self.bytes[self.start..]
+    }
+
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        &mut self.bytes[self.start..]
+    }
+}
+
+impl Deref for PayloadBuf<'_> {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
+impl DerefMut for PayloadBuf<'_> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut [u8] {
+        self.as_mut_slice()
+    }
+}
+
+impl Extend<u8> for PayloadBuf<'_> {
+    #[inline]
+    fn extend<I: IntoIterator<Item = u8>>(&mut self, iter: I) {
+        self.bytes.extend(iter);
+    }
+}
+
+impl<'b> Extend<&'b u8> for PayloadBuf<'_> {
+    #[inline]
+    fn extend<I: IntoIterator<Item = &'b u8>>(&mut self, iter: I) {
+        self.bytes.extend(iter);
+    }
+}
+
+#[cfg(feature = "wincode")]
+impl wincode::io::Writer for PayloadBuf<'_> {
+    #[inline]
+    fn write(&mut self, src: &[u8]) -> Result<(), wincode::io::WriteError> {
+        self.bytes.extend_from_slice(src);
+        Ok(())
+    }
+
+    #[inline]
+    unsafe fn as_trusted_for(
+        &mut self,
+        n_bytes: usize,
+    ) -> Result<impl wincode::io::Writer, wincode::io::WriteError> {
+        // SAFETY: the caller upholds the `as_trusted_for` contract, and the
+        // `Vec<u8>` writer only ever appends, so the payload start stays valid.
+        unsafe { wincode::io::Writer::as_trusted_for(&mut *self.bytes, n_bytes) }
+    }
+}
+
+impl Write for PayloadBuf<'_> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.bytes.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.bytes.extend_from_slice(buf);
+        Ok(())
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
 }
 
 /// Configuration shared by every listener and connection in a [`TcpGroup`].
@@ -188,8 +338,10 @@ struct NetworkState {
     connections: Vec<Connection>,
     pending_disconnects: Vec<PendingDisconnect>,
     next_token: usize,
-    send_header: [u8; FRAME_HEADER_SIZE],
-    send_payload: Vec<u8>,
+    /// Frames staged for the next socket write, each as a contiguous
+    /// `[header][payload]` for length-prefixed groups or bare bytes for raw
+    /// groups.
+    send_buffer: Vec<u8>,
 }
 
 impl Default for NetworkState {
@@ -201,8 +353,7 @@ impl Default for NetworkState {
             connections: Vec::with_capacity(INITIAL_CONNECTION_CAPACITY),
             pending_disconnects: Vec::with_capacity(INITIAL_CONNECTION_CAPACITY),
             next_token: 0,
-            send_header: [0; FRAME_HEADER_SIZE],
-            send_payload: Vec::with_capacity(INITIAL_SEND_BUFFER_SIZE),
+            send_buffer: Vec::with_capacity(INITIAL_SEND_BUFFER_SIZE),
         }
     }
 }
@@ -577,58 +728,80 @@ impl NetworkState {
         }
     }
 
-    fn prepare_frame<F>(&mut self, group: TcpGroup, serialise: F) -> bool
+    /// Finds the connection `token` can currently send on.
+    fn sendable_index(&self, token: Token) -> Option<usize> {
+        self.connections.iter().position(|connection| {
+            connection.token == token &&
+                !connection.close_when_drained &&
+                matches!(connection.state, ConnectionState::Connected(_))
+        })
+    }
+
+    /// Serialises one payload as a frame at the end of `send_buffer`.
+    /// Length-prefixed groups reserve a header ahead of the payload and fill
+    /// in its length here; `stamp_frames` writes the timestamp just before the
+    /// socket write. Empty or oversized payloads are removed again. Returns
+    /// whether the frame was kept.
+    fn append_frame<F>(&mut self, group: TcpGroup, serialise: F) -> bool
     where
-        F: FnOnce(&mut Vec<u8>),
+        F: FnOnce(&mut PayloadBuf<'_>),
     {
-        self.send_payload.clear();
-        serialise(&mut self.send_payload);
-        let config = self.config(group);
-        if self.send_payload.is_empty() {
+        let config = &self.groups[group.0].config;
+        let framed = config.framing == Framing::LengthPrefixed;
+        let start = self.send_buffer.len();
+        if framed {
+            self.send_buffer.resize(start + FRAME_HEADER_SIZE, 0);
+        }
+        let payload_start = self.send_buffer.len();
+        let mut payload = PayloadBuf::new(&mut self.send_buffer);
+        serialise(&mut payload);
+        let payload_len = payload.len();
+        if payload_len == 0 {
+            self.send_buffer.truncate(start);
             return false;
         }
-        if self.send_payload.len() > config.max_frame_size ||
-            (config.framing == Framing::LengthPrefixed &&
-                u32::try_from(self.send_payload.len()).is_err())
-        {
+        if payload_len > config.max_frame_size || (framed && u32::try_from(payload_len).is_err()) {
             error!(
                 group = config.name,
-                payload_len = self.send_payload.len(),
+                payload_len,
                 max_frame_size = config.max_frame_size,
                 "tcp payload exceeds maximum frame size"
             );
-            self.send_payload.clear();
+            self.send_buffer.truncate(start);
             return false;
         }
-        if config.framing == Framing::LengthPrefixed {
-            write_frame_header(&mut self.send_header, self.send_payload.len(), Nanos::now());
+        if framed {
+            write_frame_len(&mut self.send_buffer[start..payload_start], payload_len);
         }
         true
     }
 
-    fn send_with<F>(&mut self, token: Token, serialise: F) -> bool
-    where
-        F: FnOnce(&mut Vec<u8>),
-    {
-        let Some(index) = self.connections.iter().position(|connection| {
-            connection.token == token &&
-                !connection.close_when_drained &&
-                matches!(connection.state, ConnectionState::Connected(_))
-        }) else {
-            return false;
-        };
-        let group = self.connections[index].group;
-        if !self.prepare_frame(group, serialise) {
-            return false;
+    /// Writes `ts` into the header of every frame staged in `send_buffer`.
+    /// Raw groups carry no headers and are left untouched.
+    fn stamp_frames(&mut self, group: TcpGroup, ts: Nanos) {
+        if self.groups[group.0].config.framing != Framing::LengthPrefixed {
+            return;
         }
+        let mut offset = 0;
+        while offset < self.send_buffer.len() {
+            let header = &mut self.send_buffer[offset..offset + FRAME_HEADER_SIZE];
+            write_frame_ts(header, ts);
+            offset += FRAME_HEADER_SIZE + frame_payload_len(header);
+        }
+    }
+
+    /// Writes the staged frames to the connection at `index` in one socket
+    /// write, disconnecting it on failure. Returns whether the write was
+    /// accepted or queued.
+    fn write_staged(&mut self, index: usize) -> bool {
+        let group = self.connections[index].group;
         let config = &self.groups[group.0].config;
         let connection = &mut self.connections[index];
         let ConnectionState::Connected(stream) = &mut connection.state else { unreachable!() };
-        let header = (config.framing == Framing::LengthPrefixed).then_some(&self.send_header);
         let state = stream.write_frame(
             self.poll.registry(),
-            header,
-            &self.send_payload,
+            None,
+            &self.send_buffer,
             config,
             &mut connection.timers,
         );
@@ -639,24 +812,57 @@ impl NetworkState {
         true
     }
 
-    fn broadcast_with<F>(&mut self, group: TcpGroup, serialise: F) -> usize
+    fn send_with<F>(&mut self, token: Token, serialise: F) -> bool
     where
-        F: FnOnce(&mut Vec<u8>),
+        F: FnOnce(&mut PayloadBuf<'_>),
     {
-        if group.0 >= self.groups.len() {
-            return 0;
+        let Some(index) = self.sendable_index(token) else {
+            return false;
+        };
+        let group = self.connections[index].group;
+        self.send_buffer.clear();
+        if !self.append_frame(group, serialise) {
+            return false;
         }
-        if !self.connections.iter().any(|connection| {
-            connection.group == group &&
-                !connection.close_when_drained &&
-                matches!(connection.state, ConnectionState::Connected(_))
-        }) {
-            return 0;
-        }
-        if !self.prepare_frame(group, serialise) {
-            return 0;
-        }
+        self.stamp_frames(group, Nanos::now());
+        self.write_staged(index)
+    }
 
+    fn send_many_with<I, F>(&mut self, token: Token, items: I, mut serialise: F) -> bool
+    where
+        I: IntoIterator,
+        F: FnMut(&mut PayloadBuf<'_>, I::Item),
+    {
+        let Some(index) = self.sendable_index(token) else {
+            return false;
+        };
+        let group = self.connections[index].group;
+        self.send_buffer.clear();
+        for item in items {
+            self.append_frame(group, |buf| serialise(buf, item));
+        }
+        if self.send_buffer.is_empty() {
+            return false;
+        }
+        self.stamp_frames(group, Nanos::now());
+        self.write_staged(index)
+    }
+
+    /// Whether `group` exists and has at least one member that can receive a
+    /// broadcast right now.
+    fn has_broadcast_recipient(&self, group: TcpGroup) -> bool {
+        group.0 < self.groups.len() &&
+            self.connections.iter().any(|connection| {
+                connection.group == group &&
+                    !connection.close_when_drained &&
+                    matches!(connection.state, ConnectionState::Connected(_))
+            })
+    }
+
+    /// Writes the staged frames to every connected member of `group`,
+    /// disconnecting members whose write fails. Returns the number of
+    /// recipients attempted.
+    fn broadcast_staged(&mut self, group: TcpGroup) -> usize {
         let mut attempted = 0;
         let mut index = self.connections.len();
         while index != 0 {
@@ -668,27 +874,43 @@ impl NetworkState {
                 continue;
             }
             attempted += 1;
-            let state = {
-                let config = &self.groups[group.0].config;
-                let connection = &mut self.connections[index];
-                let ConnectionState::Connected(stream) = &mut connection.state else {
-                    unreachable!()
-                };
-                let header =
-                    (config.framing == Framing::LengthPrefixed).then_some(&self.send_header);
-                stream.write_frame(
-                    self.poll.registry(),
-                    header,
-                    &self.send_payload,
-                    config,
-                    &mut connection.timers,
-                )
-            };
-            if state == StreamState::Disconnected {
-                self.disconnect_index(index, true);
-            }
+            self.write_staged(index);
         }
         attempted
+    }
+
+    fn broadcast_with<F>(&mut self, group: TcpGroup, serialise: F) -> usize
+    where
+        F: FnOnce(&mut PayloadBuf<'_>),
+    {
+        if !self.has_broadcast_recipient(group) {
+            return 0;
+        }
+        self.send_buffer.clear();
+        if !self.append_frame(group, serialise) {
+            return 0;
+        }
+        self.stamp_frames(group, Nanos::now());
+        self.broadcast_staged(group)
+    }
+
+    fn broadcast_many_with<I, F>(&mut self, group: TcpGroup, items: I, mut serialise: F) -> usize
+    where
+        I: IntoIterator,
+        F: FnMut(&mut PayloadBuf<'_>, I::Item),
+    {
+        if !self.has_broadcast_recipient(group) {
+            return 0;
+        }
+        self.send_buffer.clear();
+        for item in items {
+            self.append_frame(group, |buf| serialise(buf, item));
+        }
+        if self.send_buffer.is_empty() {
+            return 0;
+        }
+        self.stamp_frames(group, Nanos::now());
+        self.broadcast_staged(group)
     }
 
     fn disconnect(&mut self, token: Token) -> bool {
@@ -813,9 +1035,25 @@ impl TcpNetwork {
     /// disconnected.
     pub fn send_with<F>(&mut self, token: Token, serialise: F) -> bool
     where
-        F: FnOnce(&mut Vec<u8>),
+        F: FnOnce(&mut PayloadBuf<'_>),
     {
         self.state.send_with(token, serialise)
+    }
+
+    /// Serializes and sends multiple payloads to a connected token.
+    /// Length-prefixed groups preserve each payload as a separate frame and
+    /// share one send timestamp. Raw groups concatenate the payloads. The
+    /// batch uses one socket write when no backlog exists. Each payload is
+    /// checked against `max_frame_size`. The caller must bound the item count
+    /// or total batch size. `max_backlog_bytes` only limits bytes queued after
+    /// a partial write. Invalid payloads are skipped. The closure is not called
+    /// when the token is unknown or disconnected.
+    pub fn send_many_with<I, F>(&mut self, token: Token, items: I, serialise: F) -> bool
+    where
+        I: IntoIterator,
+        F: FnMut(&mut PayloadBuf<'_>, I::Item),
+    {
+        self.state.send_many_with(token, items, serialise)
     }
 
     /// Serializes one payload and sends it to every connected member of
@@ -823,9 +1061,23 @@ impl TcpNetwork {
     /// the payload unchanged. Returns the number of recipients attempted.
     pub fn broadcast_with<F>(&mut self, group: TcpGroup, serialise: F) -> usize
     where
-        F: FnOnce(&mut Vec<u8>),
+        F: FnOnce(&mut PayloadBuf<'_>),
     {
         self.state.broadcast_with(group, serialise)
+    }
+
+    /// Serializes multiple payloads once and sends the batch to every
+    /// connected member of `group`. Framing, size limits, and skipping of
+    /// invalid payloads follow [`TcpNetwork::send_many_with`]; each member
+    /// receives the batch in one socket write when it has no backlog. The
+    /// closure is not called when the group has no connected member. Returns
+    /// the number of recipients attempted.
+    pub fn broadcast_many_with<I, F>(&mut self, group: TcpGroup, items: I, serialise: F) -> usize
+    where
+        I: IntoIterator,
+        F: FnMut(&mut PayloadBuf<'_>, I::Item),
+    {
+        self.state.broadcast_many_with(group, items, serialise)
     }
 
     /// Closes a connection. Persistent outbound endpoints remain registered
@@ -1269,7 +1521,7 @@ mod tests {
     use mio::{Poll, Token};
 
     use super::{
-        ByteQueue, FRAME_HEADER_SIZE, FramedStream, StreamState, TcpGroupConfig,
+        ByteQueue, FRAME_HEADER_SIZE, FramedStream, PayloadBuf, StreamState, TcpGroupConfig,
         set_socket_buf_size, write_frame_header,
     };
 
@@ -1371,5 +1623,41 @@ mod tests {
             StreamState::Disconnected
         );
         assert_eq!(stream.send_queue.len(), 8);
+    }
+
+    #[test]
+    fn payload_buf_truncate_clamps_to_its_own_frame() {
+        let mut bytes = b"earlier".to_vec();
+        let mut payload = PayloadBuf::new(&mut bytes);
+        payload.extend_from_slice(b"payload");
+
+        payload.truncate(usize::MAX);
+        assert_eq!(payload.as_slice(), b"payload");
+        payload.truncate(3);
+        assert_eq!(payload.as_slice(), b"pay");
+        payload.truncate(0);
+        assert!(payload.is_empty());
+        assert_eq!(bytes, b"earlier");
+    }
+
+    #[test]
+    fn payload_buf_resize_and_clear_stay_relative() {
+        let mut bytes = b"earlier".to_vec();
+        let mut payload = PayloadBuf::new(&mut bytes);
+        payload.resize(3, 7);
+        assert_eq!(payload.as_slice(), &[7, 7, 7]);
+        payload.resize(1, 0);
+        assert_eq!(payload.as_slice(), &[7]);
+        payload.clear();
+        assert!(payload.is_empty());
+        assert_eq!(bytes, b"earlier");
+    }
+
+    #[test]
+    #[should_panic(expected = "payload length overflows usize")]
+    fn payload_buf_resize_rejects_overflow() {
+        let mut bytes = b"earlier".to_vec();
+        let mut payload = PayloadBuf::new(&mut bytes);
+        payload.resize(usize::MAX, 0);
     }
 }

--- a/crates/flux-network/src/tcp/stream.rs
+++ b/crates/flux-network/src/tcp/stream.rs
@@ -70,8 +70,27 @@ pub(crate) fn write_frame_header(
     payload_len: usize,
     ts: Nanos,
 ) {
+    write_frame_len(header, payload_len);
+    write_frame_ts(header, ts);
+}
+
+/// Write only the `[len]` half of a frame header. Used when frames are staged
+/// ahead of the write and stamped with `write_frame_ts` once they go out.
+#[inline]
+pub(crate) fn write_frame_len(header: &mut [u8], payload_len: usize) {
     header[..LEN_HEADER_SIZE].copy_from_slice(&(payload_len as u32).to_le_bytes());
+}
+
+/// Write only the `[ts]` half of a frame header.
+#[inline]
+pub(crate) fn write_frame_ts(header: &mut [u8], ts: Nanos) {
     header[LEN_HEADER_SIZE..FRAME_HEADER_SIZE].copy_from_slice(&ts.0.to_le_bytes());
+}
+
+/// Read the payload length from a frame header.
+#[inline]
+pub(crate) fn frame_payload_len(header: &[u8]) -> usize {
+    u32::from_le_bytes(header[..LEN_HEADER_SIZE].try_into().unwrap()) as usize
 }
 
 /// Allocate a contiguous `header + payload` frame for the send backlog.

--- a/crates/flux-network/tests/tcp_network.rs
+++ b/crates/flux-network/tests/tcp_network.rs
@@ -14,6 +14,7 @@ const CLIENT_HELLO: &[u8] = b"client-hello";
 const SERVER_HELLO: &[u8] = b"server-hello";
 const REQUEST: &[u8] = b"request-payload";
 const RESPONSE: &[u8] = b"response-payload";
+const BATCH_MESSAGES: [&[u8]; 3] = [b"batch-one", b"batch-two", b"batch-three"];
 
 fn unused_addr() -> SocketAddr {
     let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
@@ -131,6 +132,208 @@ fn groups_route_events_and_messages() {
         thread::sleep(Duration::from_millis(1));
     }
     assert!(contains(&client_messages, RESPONSE));
+}
+
+#[test]
+fn batch_send_preserves_framed_messages() {
+    let addr = unused_addr();
+    let mut network = TcpNetwork::default();
+    let server_group = network.add_group(TcpGroupConfig { name: "server", ..Default::default() });
+    let client_group = network.add_group(TcpGroupConfig { name: "client", ..Default::default() });
+    network.listen(server_group, addr).unwrap();
+    let _ = network.connect(client_group, addr);
+    let server_token = wait_for_accept(&mut network, server_group);
+
+    assert!(network.send_many_with(server_token, BATCH_MESSAGES, |buf, message| {
+        buf.extend_from_slice(message);
+    }));
+    assert!(network.send_many_with(server_token, [RESPONSE], |buf, message| {
+        buf.extend_from_slice(message);
+    }));
+
+    let mut messages = Vec::new();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline && messages.len() < BATCH_MESSAGES.len() + 1 {
+        network.poll_with(|event| {
+            if let TcpEvent::Message { group, payload, .. } = event &&
+                group == client_group
+            {
+                messages.push(payload.to_vec());
+            }
+        });
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    let expected = BATCH_MESSAGES.into_iter().chain([RESPONSE]);
+    assert!(messages.iter().map(Vec::as_slice).eq(expected));
+}
+
+#[test]
+fn payload_buffer_is_relative_to_its_own_frame() {
+    let addr = unused_addr();
+    let mut network = TcpNetwork::default();
+    let server_group = network.add_group(TcpGroupConfig { name: "server", ..Default::default() });
+    let client_group = network.add_group(TcpGroupConfig { name: "client", ..Default::default() });
+    network.listen(server_group, addr).unwrap();
+    let _ = network.connect(client_group, addr);
+    let server_token = wait_for_accept(&mut network, server_group);
+
+    // The middle serialiser rewrites its payload from scratch. Every
+    // operation must stay inside its own frame and leave the first intact.
+    assert!(network.send_many_with(server_token, BATCH_MESSAGES, |buf, message| {
+        buf.extend_from_slice(b"scratch");
+        assert_eq!(buf.len(), b"scratch".len());
+        buf.clear();
+        assert!(buf.is_empty());
+        buf.resize(message.len(), 0);
+        buf.copy_from_slice(message);
+    }));
+
+    let mut messages = Vec::new();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline && messages.len() < BATCH_MESSAGES.len() {
+        network.poll_with(|event| {
+            if let TcpEvent::Message { group, payload, .. } = event &&
+                group == client_group
+            {
+                messages.push(payload.to_vec());
+            }
+        });
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    assert!(messages.iter().map(Vec::as_slice).eq(BATCH_MESSAGES));
+}
+
+#[cfg(feature = "wincode")]
+#[test]
+fn payload_buffer_is_a_wincode_writer() {
+    let addr = unused_addr();
+    let mut network = TcpNetwork::default();
+    let server_group = network.add_group(TcpGroupConfig { name: "server", ..Default::default() });
+    let client_group = network.add_group(TcpGroupConfig { name: "client", ..Default::default() });
+    network.listen(server_group, addr).unwrap();
+    let _ = network.connect(client_group, addr);
+    let server_token = wait_for_accept(&mut network, server_group);
+
+    let values = [7u64, 11, 13];
+    assert!(network.send_many_with(server_token, values, |buf, value| {
+        wincode::serialize_into(buf, &value).unwrap();
+    }));
+
+    let mut decoded = Vec::new();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline && decoded.len() < values.len() {
+        network.poll_with(|event| {
+            if let TcpEvent::Message { group, payload, .. } = event &&
+                group == client_group
+            {
+                decoded.push(wincode::deserialize::<u64>(payload).unwrap());
+            }
+        });
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    assert_eq!(decoded, values);
+}
+
+#[test]
+fn batch_skips_oversized_payloads_and_keeps_the_rest() {
+    let addr = unused_addr();
+    let mut network = TcpNetwork::default();
+    let server_group = network.add_group(TcpGroupConfig {
+        name: "server",
+        max_frame_size: 32,
+        ..Default::default()
+    });
+    let client_group = network.add_group(TcpGroupConfig { name: "client", ..Default::default() });
+    network.listen(server_group, addr).unwrap();
+    let _ = network.connect(client_group, addr);
+    let server_token = wait_for_accept(&mut network, server_group);
+
+    let oversized = [7u8; 64];
+    let items: [&[u8]; 3] = [b"fits-one", &oversized, b"fits-two"];
+    assert!(network.send_many_with(server_token, items, |buf, item| buf.extend_from_slice(item)));
+
+    let mut messages = Vec::new();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline && messages.len() < 2 {
+        network.poll_with(|event| match event {
+            TcpEvent::Message { group, payload, .. } if group == client_group => {
+                messages.push(payload.to_vec());
+            }
+            TcpEvent::Disconnected { .. } => panic!("oversized payload disconnected the peer"),
+            _ => {}
+        });
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    let expected: [&[u8]; 2] = [b"fits-one", b"fits-two"];
+    assert!(messages.iter().map(Vec::as_slice).eq(expected));
+}
+
+#[test]
+fn broadcast_many_serializes_each_payload_once() {
+    let addr = unused_addr();
+    let mut network = TcpNetwork::default();
+    let server_group = network.add_group(TcpGroupConfig { name: "server", ..Default::default() });
+    let client_group = network.add_group(TcpGroupConfig {
+        name: "clients",
+        reconnect_interval: flux_timing::Duration::from_millis(1),
+        ..Default::default()
+    });
+    network.listen(server_group, addr).unwrap();
+    let _first_client = network.connect(client_group, addr);
+    let _second_client = network.connect(client_group, addr);
+
+    let mut accepted = 0;
+    let mut connected = 0;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline && (accepted != 2 || connected != 2) {
+        network.poll_with(|event| match event {
+            TcpEvent::Accepted { group, .. } => {
+                assert_eq!(group, server_group);
+                accepted += 1;
+            }
+            TcpEvent::Connected { group, .. } => {
+                assert_eq!(group, client_group);
+                connected += 1;
+            }
+            TcpEvent::Disconnected { .. } => panic!("unexpected disconnect"),
+            TcpEvent::Message { .. } => {}
+        });
+        thread::sleep(Duration::from_millis(1));
+    }
+    assert_eq!(accepted, 2);
+    assert_eq!(connected, 2);
+
+    let serializations = Cell::new(0);
+    let recipients = network.broadcast_many_with(server_group, BATCH_MESSAGES, |buf, message| {
+        serializations.set(serializations.get() + 1);
+        buf.extend_from_slice(message);
+    });
+    assert_eq!(recipients, 2);
+    assert_eq!(serializations.get(), BATCH_MESSAGES.len());
+
+    let mut per_client = std::collections::HashMap::<mio::Token, Vec<Vec<u8>>>::new();
+    let mut received = 0;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline && received != 2 * BATCH_MESSAGES.len() {
+        network.poll_with(|event| {
+            if let TcpEvent::Message { group, token, payload, .. } = event &&
+                group == client_group
+            {
+                per_client.entry(token).or_default().push(payload.to_vec());
+                received += 1;
+            }
+        });
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    assert_eq!(per_client.len(), 2);
+    for messages in per_client.values() {
+        assert!(messages.iter().map(Vec::as_slice).eq(BATCH_MESSAGES));
+    }
 }
 
 #[test]

--- a/crates/flux-network/tests/tcp_network_raw.rs
+++ b/crates/flux-network/tests/tcp_network_raw.rs
@@ -61,6 +61,49 @@ fn raw_roundtrip() {
 }
 
 #[test]
+fn raw_batch_concatenates_payloads() {
+    let addr = unused_addr();
+    let mut network = TcpNetwork::default();
+    let group = network.add_group(raw_group("raw-server"));
+    network.listen(group, addr).unwrap();
+
+    let mut client = std::net::TcpStream::connect(addr).unwrap();
+    client.set_nonblocking(true).unwrap();
+
+    let mut accepted = None;
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && accepted.is_none() {
+        network.poll_with(|event| {
+            if let TcpEvent::Accepted { group: event_group, token, .. } = event {
+                assert_eq!(event_group, group);
+                accepted = Some(token);
+            }
+        });
+        thread::sleep(Duration::from_millis(1));
+    }
+    let token = accepted.expect("connection was not accepted");
+
+    let parts: [&[u8]; 3] = [b"raw-", b"batch-", b"bytes"];
+    assert!(network.send_many_with(token, parts, |buf, part| buf.extend_from_slice(part)));
+
+    let expected = b"raw-batch-bytes";
+    let mut received = Vec::new();
+    let deadline = Instant::now() + TIMEOUT;
+    while Instant::now() < deadline && received.len() < expected.len() {
+        network.poll_with(|_| {});
+        let mut buffer = [0; 128];
+        match client.read(&mut buffer) {
+            Ok(read) => received.extend_from_slice(&buffer[..read]),
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+            Err(err) => panic!("client read failed: {err}"),
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    assert_eq!(received, expected);
+}
+
+#[test]
 fn http_get_smoke() {
     let request = b"GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
     let response = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok";


### PR DESCRIPTION
## Summary

- add `send_many_with` and `broadcast_many_with` for batched TCP writes
- isolate each serialized frame with `PayloadBuf`
- preserve length-prefixed frame boundaries and concatenate raw payload batches
- support standard writers and Wincode serialization
- bump the workspace version to `0.2.0` for the public API change

## Load test

Both processes used spare CPU 4. The public-network RTT was approximately 0.8 ms.

Each message was 1,280 bytes. Each case ran three times for five seconds.
The table contains median sender CPU time.

| Batch | Rate | Flux 0.1.3 single | Flux 0.2.0 single | Flux 0.2.0 batch | Batch vs 0.1.3 |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 4k msg/s | 575 ms | 572 ms | 572 ms | -0.6% |
| 4 | 16k msg/s | 762 ms | 636 ms | 583 ms | -23.5% |
| 8 | 32k msg/s | 980 ms | 939 ms | 582 ms | -40.6% |

All runs delivered every message in order. No send was rejected. No payload was corrupted.

## Validation

- `just fmt-check`
- `cargo check --workspace --all-features`
- `just clippy`
- `cargo test --workspace --all-features --locked`
- `python3 .github/scripts/test_release.py`
- `python3 .github/scripts/release.py`
