### PR TITLE
test(network): reduce backpressure test timing sensitivity

### DIFF
--- a/crates/flux-network/src/tcp/connector.rs
+++ b/crates/flux-network/src/tcp/connector.rs
@@ -803,6 +803,11 @@ impl TcpConnector {
     /// 2) polls `mio` with a zero timeout
     /// 3) for each event calls `handler` with the appropriate [`PollEvent`]
     /// 4) returns whether any IO events were processed
+    ///
+    /// Writable events trigger retries of queued writes. Because this method
+    /// performs a single non-blocking poll, calling it infrequently can slow
+    /// backlog draining under backpressure, particularly when using small
+    /// socket buffers configured via [`Self::with_socket_buf_size`].
     #[inline]
     pub fn poll_with<F>(&mut self, mut handler: F) -> bool
     where

--- a/crates/flux-network/tests/tcp_multi_client_backpressure.rs
+++ b/crates/flux-network/tests/tcp_multi_client_backpressure.rs
@@ -48,8 +48,14 @@ fn spawn_frame_collector(read_delay: Duration) -> (SocketAddr, thread::JoinHandl
 fn pump(conn: &mut TcpConnector, for_how_long: Duration) {
     let deadline = std::time::Instant::now() + for_how_long;
     while std::time::Instant::now() < deadline {
-        while conn.poll_with(|_| {}) {}
-        thread::sleep(Duration::from_millis(1));
+        let mut worked = false;
+        while conn.poll_with(|_| {}) {
+            worked = true;
+        }
+        // Sleep only when idle so the delay does not slow backlog draining.
+        if !worked {
+            thread::sleep(Duration::from_millis(1));
+        }
     }
 }
 
@@ -69,9 +75,9 @@ fn queued_messages_flush_on_second_connection_after_backpressure() {
     let slow_token = conn.connect(slow_addr).expect("failed to connect to slow collector");
     assert_ne!(fast_token, slow_token);
 
-    // Fill the 2nd socket while the receiver is paused, forcing queue/backpressure
-    // path.
-    let big = vec![7_u8; 8 * 1024 * 1024];
+    // Send a large payload while the second receiver is paused to exercise the
+    // backpressure path. Keep it modest so the test has time to drain the backlog.
+    let big = vec![7_u8; 2 * 1024 * 1024];
     send_payload(&mut conn, slow_token, &big);
 
     let marker = b"marker-after-backpressure".to_vec();


### PR DESCRIPTION
## Fix flaky test.

The multi-client backpressure test queued an 8 MiB payload for a receiver that initially pauses, then allowed five seconds for the queued payload and marker to arrive. Observed runs came close to that deadline, making the test sensitive to timing variation.

Reduce the payload to 2 MiB to provide more headroom. It remains much larger than the requested 1 KiB socket buffer, while the receiver delay continues to create backpressure.

Avoid the unconditional sleep after poll activity, reducing unnecessary delay while the connection is making progress. Also document that infrequent calls to poll_with can slow queued-write progress under backpressure.
