### PR TITLE
dcache consume api rework

### DIFF
--- a/crates/flux-communication/src/queue/mod.rs
+++ b/crates/flux-communication/src/queue/mod.rs
@@ -1101,6 +1101,12 @@ impl<T: 'static + Copy> Consumer<T> {
         self.should_log = arg;
     }
 
+    /// Returns whether queue overrun logging is enabled for this consumer.
+    #[inline]
+    pub fn logging_enabled(&self) -> bool {
+        self.should_log
+    }
+
     pub fn set_collaborative_group(&mut self, group_label: &'static str) {
         self.bare.set_collaborative_group(group_label);
     }

--- a/crates/flux-network/tests/tcp_dcache.rs
+++ b/crates/flux-network/tests/tcp_dcache.rs
@@ -10,7 +10,7 @@ use std::{
 
 use flux::{
     communication::{ShmemData, cleanup_shmem},
-    spine::{DCacheRead, ScopedSpine, SpineAdapter, SpineProducerWithDCache},
+    spine::{ScopedSpine, SpineAdapter, SpineProducerWithDCache},
     tile::{Tile, TileConfig, TileInfo, attach_tile},
 };
 use flux_network::tcp::{PollEvent, SendBehavior, TcpConnector};
@@ -74,11 +74,10 @@ impl Tile<TcpDcacheSpine> for ReaderTile {
         let count = &mut self.count;
         adapter.consume_with_dcache::<Payload, (), _, _>(
             |msg, bytes| assert_eq!(&msg.0[..], bytes),
-            |result, _| {
-                if let DCacheRead::Ok((msg, ())) = result {
-                    received.lock().unwrap().push(msg);
-                    *count += 1;
-                }
+            |msg, payload, _| {
+                assert_eq!(payload, Some(()));
+                received.lock().unwrap().push(msg);
+                *count += 1;
             },
         );
         if self.count >= self.expected || Instant::now() >= self.deadline {

--- a/crates/flux/src/spine/adapter.rs
+++ b/crates/flux/src/spine/adapter.rs
@@ -9,8 +9,8 @@ use signal_hook::consts::SIGINT;
 
 use crate::{
     spine::{
-        DCacheRead, FluxSpine, SpineConsumer, SpineDCacheConsumer, SpineProducer,
-        SpineProducerWithDCache, SpineProducers,
+        FluxSpine, SpineConsumer, SpineDCacheConsumer, SpineProducer, SpineProducerWithDCache,
+        SpineProducers,
     },
     tile::Tile,
 };
@@ -242,6 +242,14 @@ impl<S: FluxSpine> SpineAdapter<S> {
         consumed
     }
 
+    /// Drains intact messages from a dcache-backed queue.
+    ///
+    /// `read` is called only for messages with a payload. After the payload's
+    /// epoch is validated, `handle` receives the message and `Some` of the
+    /// value returned by `read`. A message produced without a payload is
+    /// passed directly to `handle` with `None`. Overrun and lost payload
+    /// outcomes are never passed to `handle`; `read` may already have
+    /// run when an epoch check detects a lost payload.
     #[inline]
     pub fn consume_with_dcache<T, R, F, G>(&mut self, mut read: F, mut handle: G)
     where
@@ -249,20 +257,16 @@ impl<S: FluxSpine> SpineAdapter<S> {
         S::Consumers: AsMut<SpineDCacheConsumer<T>>,
         S::Producers: SpineProducers,
         F: FnMut(T, &[u8]) -> R,
-        G: FnMut(DCacheRead<T, R>, &mut S::Producers),
+        G: FnMut(T, Option<R>, &mut S::Producers),
     {
         let c: &mut SpineDCacheConsumer<T> = self.consumers.as_mut();
-        loop {
-            let result = c.consume(&mut self.producers, &mut read);
-            let is_empty = matches!(result, DCacheRead::Empty);
-            self.did_work |= !(is_empty || matches!(result, DCacheRead::SpedPast));
-            handle(result, &mut self.producers);
-            if is_empty {
-                break;
-            }
+        while c.consume(&mut self.producers, &mut read, &mut handle) {
+            self.did_work = true;
         }
     }
 
+    /// Consumes at most one intact message from the shared collaborative
+    /// cursor. Callback behavior matches [`Self::consume_with_dcache`].
     #[inline]
     pub fn consume_with_dcache_collaborative<T, R, F, G>(&mut self, mut read: F, mut handle: G)
     where
@@ -270,14 +274,15 @@ impl<S: FluxSpine> SpineAdapter<S> {
         S::Consumers: AsMut<SpineDCacheConsumer<T>>,
         S::Producers: SpineProducers,
         F: FnMut(T, &[u8]) -> R,
-        G: FnMut(DCacheRead<T, R>, &mut S::Producers),
+        G: FnMut(T, Option<R>, &mut S::Producers),
     {
         let c: &mut SpineDCacheConsumer<T> = self.consumers.as_mut();
-        let result = c.consume_collaborative(&mut self.producers, &mut read);
-        self.did_work |= !matches!(result, DCacheRead::Empty | DCacheRead::SpedPast);
-        handle(result, &mut self.producers);
+        if c.consume_collaborative(&mut self.producers, &mut read, &mut handle) {
+            self.did_work = true;
+        }
     }
 
+    /// Internal-message variant of [`Self::consume_with_dcache`].
     #[inline]
     pub fn consume_with_dcache_internal_message<T, R, F, G>(&mut self, mut read: F, mut handle: G)
     where
@@ -285,20 +290,16 @@ impl<S: FluxSpine> SpineAdapter<S> {
         S::Consumers: AsMut<SpineDCacheConsumer<T>>,
         S::Producers: SpineProducers,
         F: FnMut(&InternalMessage<T>, &[u8]) -> R,
-        G: FnMut(DCacheRead<InternalMessage<T>, R>, &mut S::Producers),
+        G: FnMut(InternalMessage<T>, Option<R>, &mut S::Producers),
     {
         let c: &mut SpineDCacheConsumer<T> = self.consumers.as_mut();
-        loop {
-            let result = c.consume_internal_message(&mut self.producers, &mut read);
-            let is_empty = matches!(result, DCacheRead::Empty);
-            self.did_work |= !(is_empty || matches!(result, DCacheRead::SpedPast));
-            handle(result, &mut self.producers);
-            if is_empty {
-                break;
-            }
+        while c.consume_internal_message(&mut self.producers, &mut read, &mut handle) {
+            self.did_work = true;
         }
     }
 
+    /// Internal-message variant of
+    /// [`Self::consume_with_dcache_collaborative`].
     #[inline]
     pub fn consume_with_dcache_collaborative_internal_message<T, R, F, G>(
         &mut self,
@@ -309,12 +310,12 @@ impl<S: FluxSpine> SpineAdapter<S> {
         S::Consumers: AsMut<SpineDCacheConsumer<T>>,
         S::Producers: SpineProducers,
         F: FnMut(&InternalMessage<T>, &[u8]) -> R,
-        G: FnMut(DCacheRead<InternalMessage<T>, R>, &mut S::Producers),
+        G: FnMut(InternalMessage<T>, Option<R>, &mut S::Producers),
     {
         let c: &mut SpineDCacheConsumer<T> = self.consumers.as_mut();
-        let result = c.consume_collaborative_internal_message(&mut self.producers, &mut read);
-        self.did_work |= !matches!(result, DCacheRead::Empty | DCacheRead::SpedPast);
-        handle(result, &mut self.producers);
+        if c.consume_collaborative_internal_message(&mut self.producers, &mut read, &mut handle) {
+            self.did_work = true;
+        }
     }
 
     /// Override the collaborative group label for queue `T`. By default each

--- a/crates/flux/src/spine/consumer.rs
+++ b/crates/flux/src/spine/consumer.rs
@@ -216,18 +216,12 @@ impl<T: 'static + Copy> SpineConsumer<T> {
     }
 }
 
-#[derive(Debug)]
-pub enum DCacheRead<T, R> {
+enum DCacheRead<T, R> {
     Ok((T, R)),
-    /// Message consumed but no dcache ref present; payload not read.
     NoRef(T),
-    /// Queue was empty.
     Empty,
-    /// Consumer got sped past.
     SpedPast,
-    /// A message was dequeued but the payload could not be safely read
-    /// (producer lapped the consumer in either the queue seqlock or dcache).
-    Lost(T),
+    Lost,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -267,44 +261,80 @@ impl<T: 'static + Copy> SpineDCacheConsumer<T> {
         Self { timer, inner: queue::Consumer::new(queue, label), dcache }
     }
 
+    /// Consumes at most one message.
+    ///
+    /// `read` is called only when the producer supplied a payload. `handle` is
+    /// called for every intact message and receives `None` when the producer
+    /// supplied no payload. Queue overruns and lost payloads are logged when
+    /// logging is enabled and are not passed to `handle`.
+    ///
+    /// Returns whether an intact message was passed to `handle`.
     #[inline]
-    pub fn consume<P, R, F>(&mut self, producers: &mut P, mut read: F) -> DCacheRead<T, R>
+    pub fn consume<P, R, F, G>(&mut self, producers: &mut P, mut read: F, mut handle: G) -> bool
     where
         P: SpineProducers,
         F: FnMut(T, &[u8]) -> R,
+        G: FnMut(T, Option<R>, &mut P),
     {
-        match self.consume_internal_message(producers, |msg, payload| read(**msg, payload)) {
-            DCacheRead::Ok((msg, r)) => DCacheRead::Ok((msg.into_data(), r)),
-            DCacheRead::Lost(msg) => DCacheRead::Lost(msg.into_data()),
-            DCacheRead::NoRef(msg) => DCacheRead::NoRef(msg.into_data()),
-            DCacheRead::Empty => DCacheRead::Empty,
-            DCacheRead::SpedPast => DCacheRead::SpedPast,
-        }
+        self.consume_internal_message(
+            producers,
+            |msg, payload| read(**msg, payload),
+            |msg, payload, producers| handle(msg.into_data(), payload, producers),
+        )
     }
 
+    /// Collaborative variant of [`Self::consume`].
     #[inline]
-    pub fn consume_collaborative<P, R, F>(
+    pub fn consume_collaborative<P, R, F, G>(
         &mut self,
         producers: &mut P,
         mut read: F,
-    ) -> DCacheRead<T, R>
+        mut handle: G,
+    ) -> bool
     where
         P: SpineProducers,
         F: FnMut(T, &[u8]) -> R,
+        G: FnMut(T, Option<R>, &mut P),
     {
-        match self
-            .consume_collaborative_internal_message(producers, |msg, payload| read(**msg, payload))
-        {
-            DCacheRead::Ok((msg, r)) => DCacheRead::Ok((msg.into_data(), r)),
-            DCacheRead::Lost(msg) => DCacheRead::Lost(msg.into_data()),
-            DCacheRead::NoRef(msg) => DCacheRead::NoRef(msg.into_data()),
-            DCacheRead::Empty => DCacheRead::Empty,
-            DCacheRead::SpedPast => DCacheRead::SpedPast,
+        self.consume_collaborative_internal_message(
+            producers,
+            |msg, payload| read(**msg, payload),
+            |msg, payload, producers| handle(msg.into_data(), payload, producers),
+        )
+    }
+
+    /// Collaborative variant of [`Self::consume_internal_message`].
+    #[inline]
+    pub fn consume_collaborative_internal_message<P, R, F, G>(
+        &mut self,
+        producers: &mut P,
+        mut read: F,
+        mut handle: G,
+    ) -> bool
+    where
+        P: SpineProducers,
+        F: FnMut(&InternalMessage<T>, &[u8]) -> R,
+        G: FnMut(InternalMessage<T>, Option<R>, &mut P),
+    {
+        match self.try_consume_collaborative_internal_message(producers, &mut read) {
+            DCacheRead::Ok((msg, payload)) => {
+                handle(msg, Some(payload), producers);
+                true
+            }
+            DCacheRead::NoRef(msg) => {
+                handle(msg, None, producers);
+                true
+            }
+            DCacheRead::Empty | DCacheRead::SpedPast => false,
+            DCacheRead::Lost => {
+                self.log_payload_lost();
+                false
+            }
         }
     }
 
     #[inline]
-    pub fn consume_collaborative_internal_message<P, R, F>(
+    fn try_consume_collaborative_internal_message<P, R, F>(
         &mut self,
         producers: &mut P,
         mut read: F,
@@ -325,15 +355,16 @@ impl<T: 'static + Copy> SpineDCacheConsumer<T> {
                 self.timer.start();
                 let Ok(extracted) = self.dcache.map(dref, |payload| read(&user_msg, payload))
                 else {
-                    return DCacheRead::Lost(user_msg);
+                    return DCacheRead::Lost;
                 };
                 if self.inner.slot_version(slot_pos) != slot_ver {
-                    return DCacheRead::Lost(user_msg);
+                    return DCacheRead::Lost;
                 }
                 self.timer.record_processing_and_latency_from(ingestion_t.into());
                 DCacheRead::Ok((user_msg, extracted))
             }
             Err(ReadError::SpedPast) => {
+                self.log_sped_past(true);
                 self.inner.recover_collaborative_after_error();
                 DCacheRead::SpedPast
             }
@@ -341,8 +372,41 @@ impl<T: 'static + Copy> SpineDCacheConsumer<T> {
         }
     }
 
+    /// Like [`Self::consume`], but passes the complete internal message to
+    /// both callbacks.
     #[inline]
-    pub fn consume_internal_message<P, R, F>(
+    pub fn consume_internal_message<P, R, F, G>(
+        &mut self,
+        producers: &mut P,
+        mut read: F,
+        mut handle: G,
+    ) -> bool
+    where
+        P: SpineProducers,
+        F: FnMut(&InternalMessage<T>, &[u8]) -> R,
+        G: FnMut(InternalMessage<T>, Option<R>, &mut P),
+    {
+        loop {
+            match self.try_consume_internal_message(producers, &mut read) {
+                DCacheRead::Ok((msg, payload)) => {
+                    handle(msg, Some(payload), producers);
+                    return true;
+                }
+                DCacheRead::NoRef(msg) => {
+                    handle(msg, None, producers);
+                    return true;
+                }
+                DCacheRead::Empty => return false,
+                DCacheRead::SpedPast => {}
+                DCacheRead::Lost => {
+                    self.log_payload_lost();
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn try_consume_internal_message<P, R, F>(
         &mut self,
         producers: &mut P,
         mut read: F,
@@ -351,32 +415,53 @@ impl<T: 'static + Copy> SpineDCacheConsumer<T> {
         P: SpineProducers,
         F: FnMut(&InternalMessage<T>, &[u8]) -> R,
     {
-        loop {
-            match self.inner.try_consume_with_epoch() {
-                Ok((&msg, slot_pos, slot_ver)) => {
-                    let ingestion_t = msg.ingestion_time();
-                    *producers.timestamp_mut().ingestion_t_mut() = ingestion_t;
-                    let dref = msg.data().dref;
-                    if dref.is_none() {
-                        return DCacheRead::NoRef(msg.with_data(msg.data().data));
-                    }
-                    let user_msg = msg.with_data(msg.data().data);
-                    self.timer.start();
-                    let Ok(extracted) = self.dcache.map(dref, |payload| read(&user_msg, payload))
-                    else {
-                        return DCacheRead::Lost(user_msg);
-                    };
-                    if self.inner.slot_version(slot_pos) != slot_ver {
-                        return DCacheRead::Lost(user_msg);
-                    }
-                    self.timer.record_processing_and_latency_from(ingestion_t.into());
-                    return DCacheRead::Ok((user_msg, extracted));
+        match self.inner.try_consume_with_epoch() {
+            Ok((&msg, slot_pos, slot_ver)) => {
+                let ingestion_t = msg.ingestion_time();
+                *producers.timestamp_mut().ingestion_t_mut() = ingestion_t;
+                let dref = msg.data().dref;
+                if dref.is_none() {
+                    return DCacheRead::NoRef(msg.with_data(msg.data().data));
                 }
-                Err(ReadError::SpedPast) => {
-                    self.inner.recover_after_error();
+                let user_msg = msg.with_data(msg.data().data);
+                self.timer.start();
+                let Ok(extracted) = self.dcache.map(dref, |payload| read(&user_msg, payload))
+                else {
+                    return DCacheRead::Lost;
+                };
+                if self.inner.slot_version(slot_pos) != slot_ver {
+                    return DCacheRead::Lost;
                 }
-                Err(ReadError::Empty) => return DCacheRead::Empty,
+                self.timer.record_processing_and_latency_from(ingestion_t.into());
+                DCacheRead::Ok((user_msg, extracted))
             }
+            Err(ReadError::SpedPast) => {
+                self.log_sped_past(false);
+                self.inner.recover_after_error();
+                DCacheRead::SpedPast
+            }
+            Err(ReadError::Empty) => DCacheRead::Empty,
+        }
+    }
+
+    #[inline(never)]
+    fn log_sped_past(&self, collaborative: bool) {
+        if self.inner.logging_enabled() {
+            let mode = if collaborative { " collaborative" } else { "" };
+            flux_utils::safe_panic!(
+                "SpineDCacheConsumer<{}>{mode} got sped past",
+                std::any::type_name::<T>()
+            );
+        }
+    }
+
+    #[inline(never)]
+    fn log_payload_lost(&self) {
+        if self.inner.logging_enabled() {
+            flux_utils::safe_panic!(
+                "SpineDCacheConsumer<{}> lost a dequeued message because its payload could not be safely read",
+                std::any::type_name::<T>()
+            );
         }
     }
 }

--- a/crates/flux/src/spine/mod.rs
+++ b/crates/flux/src/spine/mod.rs
@@ -6,7 +6,7 @@ mod standalone_producer;
 use std::path::Path;
 
 pub use adapter::SpineAdapter;
-pub use consumer::{DCacheRead, SpineConsumer, SpineDCacheConsumer};
+pub use consumer::{SpineConsumer, SpineDCacheConsumer};
 use flux_timing::{IngestionTime, InternalMessage, Nanos, TrackingTimestamp};
 use flux_utils::{DCacheError, DCachePtr, DCacheRef, directories::shmem_dir};
 pub use scoped::ScopedSpine;

--- a/crates/flux/tests/spine.rs
+++ b/crates/flux/tests/spine.rs
@@ -40,6 +40,25 @@ struct TestSpine {
     pub qb: SpineQueue<MsgB>,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(C)]
+struct DCacheMsg(u8);
+
+#[from_spine("dcache-consume-api-test")]
+#[derive(Debug)]
+struct DCacheTestSpine {
+    pub tile_info: ShmemData<TileInfo>,
+    #[queue(size(16), mtu(64))]
+    pub messages: SpineQueue<DCacheMsg>,
+}
+
+#[derive(Clone, Copy)]
+struct DCacheTestTile;
+
+impl Tile<DCacheTestSpine> for DCacheTestTile {
+    fn loop_body(&mut self, _adapter: &mut SpineAdapter<DCacheTestSpine>) {}
+}
+
 #[derive(Clone, Copy, Default)]
 struct Writer;
 
@@ -166,6 +185,55 @@ fn all_shmem_files_reside_in_base_dir() {
             base.display()
         );
     }
+
+    cleanup_shmem(base);
+}
+
+#[test]
+fn dcache_consume_handles_optional_payload_and_ignores_empty() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let base = tmp.path();
+    let mut spine = DCacheTestSpine::new_with_base_dir(base, None);
+    let mut adapter = SpineAdapter::connect_tile(&DCacheTestTile, &mut spine);
+
+    let mut empty_reads = 0;
+    let mut empty_handles = 0;
+    adapter.consume_with_dcache::<DCacheMsg, Vec<u8>, _, _>(
+        |_, _| {
+            empty_reads += 1;
+            Vec::new()
+        },
+        |_, _, _| empty_handles += 1,
+    );
+    assert_eq!(empty_reads, 0);
+    assert_eq!(empty_handles, 0);
+
+    adapter
+        .produce_with_dcache(
+            DCacheMsg(1),
+            Some((3, |payload: &mut [u8]| payload.copy_from_slice(b"one"))),
+        )
+        .unwrap();
+    adapter.produce_with_dcache(DCacheMsg(2), None::<(usize, fn(&mut [u8]))>).unwrap();
+
+    let mut read_calls = 0;
+    let mut handled = Vec::new();
+    adapter.consume_with_dcache(
+        |_, payload| {
+            read_calls += 1;
+            payload.to_vec()
+        },
+        |msg, payload, _| handled.push((msg, payload)),
+    );
+
+    assert_eq!(read_calls, 1);
+    assert_eq!(handled, vec![(DCacheMsg(1), Some(b"one".to_vec())), (DCacheMsg(2), None)]);
+
+    adapter.consume_with_dcache(
+        |_, payload| payload.to_vec(),
+        |msg, payload, _| handled.push((msg, payload)),
+    );
+    assert_eq!(handled.len(), 2, "empty queue must not call either closure");
 
     cleanup_shmem(base);
 }


### PR DESCRIPTION
### Before
```
adapter.consume_with_dcache(
    |msg, bytes| parse_payload(msg, bytes),
    |result, producers| match result {
        DCacheRead::Ok((msg, payload)) => {
            handle_message(msg, Some(payload), producers);
        }
        DCacheRead::NoRef(msg) | DCacheRead::Lost(msg) => {
            handle_message(msg, None, producers);
        }
        DCacheRead::SpedPast => {
            // What should I do with that?
        }
        DCacheRead::Empty => {}
    },
);
```
  ### After
```
adapter.consume_with_dcache(
    |msg, bytes| parse_payload(msg, bytes),
    |msg, payload, producers| {
        handle_message(msg, payload, producers);
    },
);
 ```
 
tldr
DCacheRead::Empty => closure not called
DCacheRead::SpedPast => safe_assert, closure not called
DCacheRead::Lost => safe_assert, closure not called
DCacheRead::NoRef(msg) => payload is None
DCacheRead::Ok((msg, payload)) => payload is Some