### PR TITLE
feat(network): UDP publish/subscribe feed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,6 +664,7 @@ dependencies = [
  "httparse",
  "libc",
  "mio",
+ "rustc-hash",
  "serde",
  "spine-derive",
  "tempfile",

--- a/crates/flux-network/Cargo.toml
+++ b/crates/flux-network/Cargo.toml
@@ -16,6 +16,7 @@ flux-utils.workspace = true
 httparse.workspace = true
 libc.workspace = true
 mio.workspace = true
+rustc-hash.workspace = true
 serde.workspace = true
 tracing.workspace = true
 wincode = { workspace = true, optional = true }

--- a/crates/flux-network/src/lib.rs
+++ b/crates/flux-network/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod http;
 
 pub mod tcp;
+pub mod udp;
 pub use mio::Token;

--- a/crates/flux-network/src/udp/mod.rs
+++ b/crates/flux-network/src/udp/mod.rs
@@ -1,0 +1,6 @@
+mod publisher;
+mod subscriber;
+pub mod wire;
+
+pub use publisher::UdpPublisher;
+pub use subscriber::{UdpMessage, UdpSubscriber, UdpTelemetry};

--- a/crates/flux-network/src/udp/publisher.rs
+++ b/crates/flux-network/src/udp/publisher.rs
@@ -1,0 +1,102 @@
+use std::{
+    io,
+    net::{IpAddr, SocketAddr, UdpSocket},
+};
+
+use flux_timing::Nanos;
+use rustc_hash::FxHashMap;
+use tracing::info;
+
+use super::wire::{DEFAULT_MAX_DATAGRAM_SIZE, SUBSCRIBE, encode_fragments};
+use crate::tcp::set_socket_buf_size;
+
+const SUBSCRIPTION_TTL_NANOS: u64 = 5_000_000_000;
+const CONTROL_BUF_SIZE: usize = 64;
+
+pub struct UdpPublisher {
+    socket: UdpSocket,
+    session_id: u32,
+    next_seq: u64,
+    targets: FxHashMap<SocketAddr, u64>,
+    buf: Vec<u8>,
+}
+
+impl UdpPublisher {
+    pub fn bind(bind: SocketAddr, socket_buf_size: Option<usize>) -> io::Result<Self> {
+        let socket = UdpSocket::bind(bind)?;
+        socket.set_nonblocking(true)?;
+        if let Some(size) = socket_buf_size {
+            set_socket_buf_size(&socket, size);
+        }
+        Ok(Self {
+            socket,
+            // Random, changes per restart vs wrap
+            session_id: (Nanos::now().0 as u32) ^ std::process::id(),
+            next_seq: 0,
+            targets: FxHashMap::default(),
+            buf: Vec::with_capacity(DEFAULT_MAX_DATAGRAM_SIZE),
+        })
+    }
+
+    /// Takes pending subscribes, drops lapsed leases, returns how many were
+    /// added.
+    pub fn poll_subscriptions<F>(&mut self, mut accept: F) -> usize
+    where
+        F: FnMut(IpAddr) -> bool,
+    {
+        let now = Nanos::now().0;
+        let mut buf = [0u8; CONTROL_BUF_SIZE];
+        let mut added = 0;
+        loop {
+            let (n, from) = match self.socket.recv_from(&mut buf) {
+                Ok(v) => v,
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                // Nothing more is waiting: this socket only gets control.
+                Err(_) => break,
+            };
+            if buf[..n] != SUBSCRIBE {
+                continue;
+            }
+            if !accept(from.ip()) {
+                continue;
+            }
+            if self.targets.insert(from, now + SUBSCRIPTION_TTL_NANOS).is_none() {
+                info!(?from, "udp subscriber added");
+                added += 1;
+            }
+        }
+
+        self.targets.retain(|addr, expires| {
+            let live = *expires > now;
+            if !live {
+                info!(?addr, "udp subscription expired");
+            }
+            live
+        });
+        added
+    }
+
+    pub fn publish(&mut self, message: &[u8]) -> Option<u64> {
+        if self.targets.is_empty() {
+            return None;
+        }
+        let seq: u64 = self.next_seq;
+        self.next_seq += 1;
+
+        let Self { socket, targets, buf, .. } = self;
+        encode_fragments(
+            DEFAULT_MAX_DATAGRAM_SIZE,
+            self.session_id,
+            seq,
+            Nanos::now().0,
+            message,
+            buf,
+            |datagram| {
+                for addr in targets.keys() {
+                    let _ = socket.send_to(datagram, addr);
+                }
+            },
+        );
+        Some(seq)
+    }
+}

--- a/crates/flux-network/src/udp/subscriber.rs
+++ b/crates/flux-network/src/udp/subscriber.rs
@@ -1,0 +1,173 @@
+use std::{
+    io,
+    net::{SocketAddr, UdpSocket},
+};
+
+use flux_communication::Timer;
+use flux_timing::Nanos;
+use rustc_hash::FxHashMap;
+
+use super::wire::{
+    DEFAULT_MAX_DATAGRAM_SIZE, Fragment, MAX_DATAGRAM_SIZE, SUBSCRIBE, UDP_HEADER_SIZE,
+    fragment_count,
+};
+use crate::tcp::set_socket_buf_size;
+
+/// mem-guard, prevent unbounded UDP msg partials that never arrive
+const MAX_PARTIALS_PER_SOURCE: usize = 256;
+
+const FRAGMENT_PAYLOAD_SIZE: usize = DEFAULT_MAX_DATAGRAM_SIZE - UDP_HEADER_SIZE;
+
+/// Controls emission of network latency telemetry.
+#[derive(Clone, Copy)]
+pub enum UdpTelemetry {
+    Disabled,
+    Enabled { app_name: &'static str },
+}
+
+/// One publisher's receive state.
+#[derive(Default)]
+struct Source {
+    session_id: u32,
+    /// Oldest is the smallest key: `seq` only grows within a session.
+    partials: FxHashMap<u64, Partial>,
+    latency: Option<Timer>,
+}
+
+struct Partial {
+    buf: Vec<u8>,
+    received: Vec<bool>,
+    remaining: usize,
+}
+
+pub struct UdpMessage<'a> {
+    pub from: SocketAddr,
+    pub session_id: u32,
+    pub seq: u64,
+    /// Publisher clock at framing.
+    pub send_ns: Nanos,
+    pub payload: &'a [u8],
+}
+
+pub struct UdpSubscriber {
+    socket: UdpSocket,
+    telemetry: UdpTelemetry,
+    /// Held for timer labels: the bound port cannot change.
+    local_port: u16,
+    sources: FxHashMap<SocketAddr, Source>,
+    recv_buf: Vec<u8>,
+}
+
+impl UdpSubscriber {
+    pub fn bind(bind: SocketAddr, socket_buf_size: Option<usize>) -> io::Result<Self> {
+        let socket = UdpSocket::bind(bind)?;
+        socket.set_nonblocking(true)?;
+        if let Some(size) = socket_buf_size {
+            set_socket_buf_size(&socket, size);
+        }
+        Ok(Self {
+            local_port: socket.local_addr().map_or(0, |addr| addr.port()),
+            socket,
+            telemetry: UdpTelemetry::Disabled,
+            sources: FxHashMap::default(),
+            recv_buf: vec![0u8; MAX_DATAGRAM_SIZE],
+        })
+    }
+
+    pub fn with_telemetry(mut self, telemetry: UdpTelemetry) -> Self {
+        self.telemetry = telemetry;
+        self
+    }
+
+    /// Sent from the receiving socket, so replies come back here.
+    pub fn dial(&self, publisher: SocketAddr) -> io::Result<()> {
+        self.socket.send_to(&SUBSCRIBE, publisher).map(|_| ())
+    }
+
+    pub fn poll_with<F>(&mut self, mut handler: F) -> usize
+    where
+        F: FnMut(UdpMessage<'_>),
+    {
+        let mut delivered = 0;
+        loop {
+            let (n, from) = match self.socket.recv_from(&mut self.recv_buf) {
+                Ok(v) => v,
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => break,
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                // ICMP surfaces here only on a connected socket; ours is not.
+                Err(_) => break,
+            };
+
+            let Self { sources, recv_buf, telemetry, local_port, .. } = self;
+            let source = sources.entry(from).or_insert_with(|| {
+                let mut source = Source::default();
+                if let UdpTelemetry::Enabled { app_name } = telemetry {
+                    let label = format!("udp_latency_{local_port}-{from}");
+                    source.latency = Some(Timer::new(app_name, label));
+                }
+                source
+            });
+
+            let Some(fragment) = Fragment::decode(&recv_buf[..n], FRAGMENT_PAYLOAD_SIZE) else {
+                continue;
+            };
+            let header = fragment.header;
+            // A new session is a restarted publisher: numbering starts over, so
+            // anything half-assembled from the old one can never complete.
+            if header.session_id != source.session_id {
+                source.session_id = header.session_id;
+                source.partials.clear();
+            }
+
+            let complete;
+            let total = fragment_count(header.len as usize, FRAGMENT_PAYLOAD_SIZE);
+            let payload = if total == 1 {
+                fragment.payload
+            } else {
+                let Some(buf) = source.assemble(&fragment, total) else { continue };
+                complete = buf;
+                &complete[..]
+            };
+            delivered += 1;
+            if let Some(latency) = &mut source.latency {
+                latency.emit_latency_from_nanos(Nanos(header.send_ns), Nanos::now());
+            }
+            handler(UdpMessage {
+                from,
+                session_id: header.session_id,
+                seq: header.seq,
+                send_ns: Nanos(header.send_ns),
+                payload,
+            });
+        }
+        delivered
+    }
+}
+
+impl Source {
+    /// Returns the message on the fragment that completes it.
+    fn assemble(&mut self, fragment: &Fragment<'_>, total: usize) -> Option<Vec<u8>> {
+        let seq = fragment.header.seq;
+        if self.partials.len() >= MAX_PARTIALS_PER_SOURCE && !self.partials.contains_key(&seq) {
+            let oldest = *self.partials.keys().min().unwrap();
+            self.partials.remove(&oldest);
+        }
+        let partial = self.partials.entry(seq).or_insert_with(|| Partial {
+            buf: vec![0u8; fragment.header.len as usize],
+            received: vec![false; total],
+            remaining: total,
+        });
+        if partial.received[fragment.index] {
+            return None; // duplicate fragment
+        }
+        partial.received[fragment.index] = true;
+        partial.remaining -= 1;
+        let offset = fragment.header.offset as usize;
+        partial.buf[offset..offset + fragment.payload.len()].copy_from_slice(fragment.payload);
+
+        if partial.remaining > 0 {
+            return None;
+        }
+        self.partials.remove(&seq).map(|p| p.buf)
+    }
+}

--- a/crates/flux-network/src/udp/wire.rs
+++ b/crates/flux-network/src/udp/wire.rs
@@ -1,0 +1,114 @@
+pub const UDP_MAGIC: [u8; 3] = *b"FLX";
+
+/// Bump on upgrade
+pub const UDP_VERSION: u8 = 1;
+
+/// `magic(3) + version(1) + session_id(4) + seq(8) + len(4) + offset(4) +
+/// send_ns(8)`
+pub const UDP_HEADER_SIZE: usize = 32;
+
+pub const SUBSCRIBE: [u8; 8] = [UDP_MAGIC[0], UDP_MAGIC[1], UDP_MAGIC[2], UDP_VERSION, 1, 0, 0, 0];
+
+/// Fits the 1280-byte IPv6 minimum MTU, so no per-family choice.
+pub const DEFAULT_MAX_DATAGRAM_SIZE: usize = 1200;
+
+pub const MAX_DATAGRAM_SIZE: usize = 65_507;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FragmentHeader {
+    /// Random per process. Changes per restart
+    pub session_id: u32,
+    pub seq: u64,
+    pub len: u32,
+    pub offset: u32,
+    pub send_ns: u64,
+}
+
+impl FragmentHeader {
+    pub fn encode(self, buf: &mut [u8; UDP_HEADER_SIZE]) {
+        buf[..3].copy_from_slice(&UDP_MAGIC);
+        buf[3] = UDP_VERSION;
+        buf[4..8].copy_from_slice(&self.session_id.to_le_bytes());
+        buf[8..16].copy_from_slice(&self.seq.to_le_bytes());
+        buf[16..20].copy_from_slice(&self.len.to_le_bytes());
+        buf[20..24].copy_from_slice(&self.offset.to_le_bytes());
+        buf[24..32].copy_from_slice(&self.send_ns.to_le_bytes());
+    }
+
+    /// `None` if short, foreign, or another version.
+    pub fn decode(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < UDP_HEADER_SIZE || bytes[..3] != UDP_MAGIC || bytes[3] != UDP_VERSION {
+            return None;
+        }
+        Some(Self {
+            session_id: u32::from_le_bytes(bytes[4..8].try_into().unwrap()),
+            seq: u64::from_le_bytes(bytes[8..16].try_into().unwrap()),
+            len: u32::from_le_bytes(bytes[16..20].try_into().unwrap()),
+            offset: u32::from_le_bytes(bytes[20..24].try_into().unwrap()),
+            send_ns: u64::from_le_bytes(bytes[24..32].try_into().unwrap()),
+        })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Fragment<'a> {
+    pub header: FragmentHeader,
+    pub index: usize,
+    pub payload: &'a [u8],
+}
+
+impl<'a> Fragment<'a> {
+    /// `fragment_payload_size` must match the publisher's.
+    pub fn decode(bytes: &'a [u8], fragment_payload_size: usize) -> Option<Self> {
+        let header = FragmentHeader::decode(bytes)?;
+        let payload = &bytes[UDP_HEADER_SIZE..];
+        let (offset, len) = (header.offset as usize, header.len as usize);
+        // catch short datagrams
+        if offset > len ||
+            !offset.is_multiple_of(fragment_payload_size) ||
+            payload.len() != (len - offset).min(fragment_payload_size)
+        {
+            return None;
+        }
+        Some(Self { header, index: offset / fragment_payload_size, payload })
+    }
+}
+
+/// Calls `emit` per datagram, reusing `buf`. An empty message still sends one,
+/// so its sequence number is accounted for.
+pub fn encode_fragments<F>(
+    max_datagram_size: usize,
+    session_id: u32,
+    seq: u64,
+    send_ns: u64,
+    message: &[u8],
+    buf: &mut Vec<u8>,
+    mut emit: F,
+) where
+    F: FnMut(&[u8]),
+{
+    let fragment_payload_size = max_datagram_size - UDP_HEADER_SIZE;
+    let len = message.len() as u32;
+    let mut header = [0u8; UDP_HEADER_SIZE];
+
+    let mut send = |offset: u32, payload: &[u8]| {
+        FragmentHeader { session_id, seq, len, offset, send_ns }.encode(&mut header);
+        buf.clear();
+        buf.extend_from_slice(&header);
+        buf.extend_from_slice(payload);
+        emit(buf);
+    };
+
+    if message.is_empty() {
+        send(0, &[]);
+        return;
+    }
+    for (index, payload) in message.chunks(fragment_payload_size).enumerate() {
+        send((index * fragment_payload_size) as u32, payload);
+    }
+}
+
+/// An empty message is one datagram.
+pub fn fragment_count(len: usize, fragment_payload_size: usize) -> usize {
+    len.div_ceil(fragment_payload_size).max(1)
+}

--- a/crates/flux-network/tests/udp_basic.rs
+++ b/crates/flux-network/tests/udp_basic.rs
@@ -1,0 +1,152 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket};
+
+use flux_network::udp::{UdpPublisher, UdpSubscriber, wire};
+use flux_timing::{Duration, Instant};
+
+fn free_udp_addr() -> SocketAddr {
+    UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap().local_addr().unwrap()
+}
+
+/// A pair, subscribed through the dial the publisher requires.
+fn pair() -> (UdpPublisher, UdpSubscriber, SocketAddr) {
+    let pub_addr = free_udp_addr();
+    let mut publisher = UdpPublisher::bind(pub_addr, None).unwrap();
+    let subscriber = UdpSubscriber::bind((Ipv4Addr::LOCALHOST, 0).into(), None).unwrap();
+    subscriber.dial(pub_addr).unwrap();
+    assert_eq!(publisher.poll_subscriptions(|_| true), 1, "the dial was not honoured");
+    (publisher, subscriber, pub_addr)
+}
+
+/// Models what a real publisher cannot: a chosen session, and a message cut
+/// short at `max_fragments` so a partial is left behind.
+fn raw_send(
+    raw: &UdpSocket,
+    to: SocketAddr,
+    session: u32,
+    seq: u64,
+    msg: &[u8],
+    max_fragments: usize,
+) {
+    let mut buf = Vec::new();
+    let mut sent = 0;
+    wire::encode_fragments(wire::DEFAULT_MAX_DATAGRAM_SIZE, session, seq, 7, msg, &mut buf, |d| {
+        if sent < max_fragments {
+            raw.send_to(d, to).unwrap();
+        }
+        sent += 1;
+    });
+}
+
+/// The deadline only bounds a failure; loopback is effectively synchronous.
+fn collect(subscriber: &mut UdpSubscriber, want: usize) -> Vec<(u64, Vec<u8>, u64)> {
+    let mut got = Vec::new();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while got.len() < want && Instant::now() < deadline {
+        subscriber.poll_with(|m| got.push((m.seq, m.payload.to_vec(), m.send_ns.0)));
+    }
+    got
+}
+
+#[test]
+fn messages_arrive_intact_with_their_send_time() {
+    let (mut publisher, mut subscriber, _) = pair();
+    let before = flux_timing::Nanos::now().0;
+    for i in 0..5u8 {
+        assert_eq!(publisher.publish(&[i; 100]), Some(u64::from(i)));
+    }
+    let got = collect(&mut subscriber, 5);
+    assert_eq!(got.len(), 5);
+    for (i, (seq, payload, send_ns)) in got.iter().enumerate() {
+        assert_eq!(*seq, i as u64);
+        assert_eq!(payload, &vec![i as u8; 100]);
+        assert!(*send_ns >= before, "send_ns must be the publisher's clock, not zero");
+    }
+}
+
+#[test]
+fn large_messages_are_fragmented_and_reassembled() {
+    let (mut publisher, mut subscriber, _) = pair();
+    let big: Vec<u8> = (0..40_000u32).map(|i| (i % 251) as u8).collect();
+    assert!(big.len() > wire::DEFAULT_MAX_DATAGRAM_SIZE, "must exceed one datagram");
+    publisher.publish(&big);
+
+    let got = collect(&mut subscriber, 1);
+    assert_eq!(got.len(), 1);
+    assert_eq!(got[0].1, big, "reassembled bytes must equal the original");
+}
+
+#[test]
+fn foreign_datagrams_are_dropped_without_disturbing_the_feed() {
+    let target = free_udp_addr();
+    let mut sub = UdpSubscriber::bind(target, None).unwrap();
+    let raw = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    raw.send_to(b"this is not a flux datagram", target).unwrap();
+    raw.send_to(&[0u8; wire::UDP_HEADER_SIZE - 1], target).unwrap();
+    // Loopback keeps order, so this landing proves the junk was handled first.
+    raw_send(&raw, target, 99, 0, b"real", usize::MAX);
+
+    let got = collect(&mut sub, 1);
+    assert_eq!(got.len(), 1);
+    assert_eq!(got[0].1, b"real".to_vec(), "junk is dropped, the good message still lands");
+}
+
+#[test]
+fn a_restart_clears_a_half_assembled_message_instead_of_writing_into_it() {
+    let target = free_udp_addr();
+    let mut sub = UdpSubscriber::bind(target, None).unwrap();
+    let raw = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+
+    // Session 1 leaves seq 5 half-assembled: the first of two fragments only.
+    raw_send(&raw, target, 1, 5, &vec![1u8; 2_000], 1);
+    // Session 2 reuses seq 5 for a message the stale buffer cannot hold.
+    let big = vec![2u8; 40_000];
+    raw_send(&raw, target, 2, 5, &big, usize::MAX);
+
+    let got = collect(&mut sub, 1);
+    assert_eq!(got.len(), 1);
+    assert_eq!(got[0].1, big, "the stale partial must be dropped, not written into");
+}
+
+#[test]
+fn a_feed_goes_nowhere_until_it_is_dialed() {
+    let pub_addr = free_udp_addr();
+    let mut publisher = UdpPublisher::bind(pub_addr, None).unwrap();
+    let mut subscriber = UdpSubscriber::bind((Ipv4Addr::LOCALHOST, 0).into(), None).unwrap();
+
+    // No dial, so no target: nothing is sent and no sequence is consumed.
+    assert_eq!(publisher.publish(b"before"), None);
+
+    subscriber.dial(pub_addr).unwrap();
+    publisher.poll_subscriptions(|_| true);
+    assert_eq!(publisher.publish(b"after"), Some(0));
+    let got = collect(&mut subscriber, 1);
+    assert_eq!(got.len(), 1);
+    assert_eq!(got[0].1, b"after".to_vec(), "the first message after a dial is seq 0");
+}
+
+#[test]
+fn a_dial_the_caller_declines_is_ignored() {
+    let pub_addr = free_udp_addr();
+    let mut publisher = UdpPublisher::bind(pub_addr, None).unwrap();
+    let subscriber = UdpSubscriber::bind((Ipv4Addr::LOCALHOST, 0).into(), None).unwrap();
+    subscriber.dial(pub_addr).unwrap();
+
+    // What the RPC does for a source with no TCP connection to the feed.
+    assert_eq!(publisher.poll_subscriptions(|ip| ip != IpAddr::V4(Ipv4Addr::LOCALHOST)), 0);
+    // No targets, so nothing is sent and no sequence is consumed.
+    assert_eq!(publisher.publish(b"denied"), None);
+}
+
+#[test]
+fn a_refreshed_subscription_is_one_subscriber_not_many() {
+    let (mut publisher, mut subscriber, pub_addr) = pair();
+    for _ in 0..5 {
+        subscriber.dial(pub_addr).unwrap();
+        assert_eq!(publisher.poll_subscriptions(|_| true), 0, "a refresh is not a new subscriber");
+    }
+    publisher.publish(b"x");
+    assert_eq!(collect(&mut subscriber, 1).len(), 1);
+    // Duplicates would be queued behind the first, so no deadline is needed.
+    let extra: usize = (0..10).map(|_| subscriber.poll_with(|_| {})).sum();
+    assert_eq!(extra, 0, "delivered once, not five times");
+}


### PR DESCRIPTION
Adds flux_network::udp, a one-to-many UDP feed alongside the existing TCP transport

Flow
 1. Dial. A subscriber sends an 8-byte SUBSCRIBE to the publisher
 2. Publish. publish() splits the message into 1200-byte datagrams and sends each to every target. Returns the sequence number, or None when 0 subscribers.
 3. Receive. poll_with(handler) drains the socket and calls the handler once per whole message, reassembling fragments per publisher.

Wire format:
  32-byte header: magic, version, session id, sequence, length, offset, send time, payload.
  Total 1200 bytes